### PR TITLE
chore: add catalog routing and basic endpoints for manual testing

### DIFF
--- a/catalog/serializers.py
+++ b/catalog/serializers.py
@@ -1,0 +1,116 @@
+from rest_framework import serializers
+
+from catalog.models import Genre, Movie, Room, Session
+
+
+class GenreSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Genre
+        fields = ["id", "name", "created_at", "updated_at"]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class GenreSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Genre
+        fields = ["id", "name"]
+
+
+class RoomSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Room
+        fields = ["id", "name", "capacity", "created_at", "updated_at"]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class RoomSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Room
+        fields = ["id", "name", "capacity"]
+
+
+class MovieWriteSerializer(serializers.ModelSerializer):
+    genres = serializers.PrimaryKeyRelatedField(
+        many=True,
+        queryset=Genre.objects.all(),
+    )
+
+    class Meta:
+        model = Movie
+        fields = [
+            "id",
+            "title",
+            "genres",
+            "synopsis",
+            "duration_minutes",
+            "release_date",
+            "poster_url",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class MovieReadSerializer(serializers.ModelSerializer):
+    genres = GenreSummarySerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Movie
+        fields = [
+            "id",
+            "title",
+            "genres",
+            "synopsis",
+            "duration_minutes",
+            "release_date",
+            "poster_url",
+            "created_at",
+            "updated_at",
+        ]
+
+
+class MovieSummarySerializer(serializers.ModelSerializer):
+    genres = GenreSummarySerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Movie
+        fields = [
+            "id",
+            "title",
+            "genres",
+            "duration_minutes",
+            "release_date",
+            "poster_url",
+        ]
+
+
+class SessionWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Session
+        fields = [
+            "id",
+            "movie",
+            "room",
+            "start_time",
+            "end_time",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class SessionReadSerializer(serializers.ModelSerializer):
+    movie = MovieSummarySerializer(read_only=True)
+    room = RoomSummarySerializer(read_only=True)
+
+    class Meta:
+        model = Session
+        fields = [
+            "id",
+            "movie",
+            "room",
+            "start_time",
+            "end_time",
+            "created_at",
+            "updated_at",
+        ]

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -1,0 +1,23 @@
+from django.urls import path
+
+from catalog.views import (
+    GenreDetailView,
+    GenreListCreateView,
+    MovieDetailView,
+    MovieListCreateView,
+    RoomDetailView,
+    RoomListCreateView,
+    SessionDetailView,
+    SessionListCreateView,
+)
+
+urlpatterns = [
+    path("genres/", GenreListCreateView.as_view(), name="genre-list-create"),
+    path("genres/<uuid:pk>/", GenreDetailView.as_view(), name="genre-detail"),
+    path("movies/", MovieListCreateView.as_view(), name="movie-list-create"),
+    path("movies/<uuid:pk>/", MovieDetailView.as_view(), name="movie-detail"),
+    path("rooms/", RoomListCreateView.as_view(), name="room-list-create"),
+    path("rooms/<uuid:pk>/", RoomDetailView.as_view(), name="room-detail"),
+    path("sessions/", SessionListCreateView.as_view(), name="session-list-create"),
+    path("sessions/<uuid:pk>/", SessionDetailView.as_view(), name="session-detail"),
+]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -1,3 +1,80 @@
-from django.shortcuts import render
+from rest_framework.generics import ListCreateAPIView, RetrieveDestroyAPIView
+from rest_framework.permissions import AllowAny
 
-# Create your views here.
+from catalog.models import Genre, Movie, Room, Session
+from catalog.serializers import (
+    GenreSerializer,
+    MovieReadSerializer,
+    MovieWriteSerializer,
+    RoomSerializer,
+    SessionReadSerializer,
+    SessionWriteSerializer,
+)
+
+
+class GenreListCreateView(ListCreateAPIView):
+    queryset = Genre.objects.all()
+    serializer_class = GenreSerializer
+    permission_classes = [AllowAny]
+
+
+class GenreDetailView(RetrieveDestroyAPIView):
+    queryset = Genre.objects.all()
+    serializer_class = GenreSerializer
+    permission_classes = [AllowAny]
+
+
+class MovieListCreateView(ListCreateAPIView):
+    queryset = Movie.objects.prefetch_related("genres").all()
+    permission_classes = [AllowAny]
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return MovieReadSerializer
+        return MovieWriteSerializer
+
+
+class MovieDetailView(RetrieveDestroyAPIView):
+    queryset = Movie.objects.prefetch_related("genres").all()
+    permission_classes = [AllowAny]
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return MovieReadSerializer
+        return MovieWriteSerializer
+
+
+class RoomListCreateView(ListCreateAPIView):
+    queryset = Room.objects.all()
+    serializer_class = RoomSerializer
+    permission_classes = [AllowAny]
+
+
+class RoomDetailView(RetrieveDestroyAPIView):
+    queryset = Room.objects.all()
+    serializer_class = RoomSerializer
+    permission_classes = [AllowAny]
+
+
+class SessionListCreateView(ListCreateAPIView):
+    queryset = Session.objects.select_related("movie", "room").prefetch_related(
+        "movie__genres"
+    ).all()
+    permission_classes = [AllowAny]
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return SessionReadSerializer
+        return SessionWriteSerializer
+
+
+class SessionDetailView(RetrieveDestroyAPIView):
+    queryset = Session.objects.select_related("movie", "room").prefetch_related(
+        "movie__genres"
+    ).all()
+    permission_classes = [AllowAny]
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return SessionReadSerializer
+        return SessionWriteSerializer

--- a/cinepolis_natal_api/urls.py
+++ b/cinepolis_natal_api/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("health/", health_check, name="health-check"),
     path("api/v1/auth/", include("users.urls")),
+    path("api/v1/catalog/", include("catalog.urls")),
 ]

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -1,0 +1,146 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from catalog.models import Genre, Movie, Room, Session
+
+
+@pytest.mark.django_db
+class TestCatalogApi:
+    @pytest.fixture
+    def api_client(self):
+        return APIClient()
+
+    @pytest.fixture
+    def genre(self):
+        return Genre.objects.create(name="Drama")
+
+    @pytest.fixture
+    def second_genre(self):
+        return Genre.objects.create(name="Crime")
+
+    @pytest.fixture
+    def movie(self, genre, second_genre):
+        movie = Movie.objects.create(
+            title="The Godfather",
+            synopsis="Crime family drama.",
+            duration_minutes=175,
+            release_date="1972-07-07",
+            poster_url="https://example.com/godfather.jpg",
+        )
+        movie.genres.set([genre, second_genre])
+        return movie
+
+    @pytest.fixture
+    def room(self):
+        return Room.objects.create(
+            name="Room 1",
+            capacity=70,
+        )
+
+    @pytest.fixture
+    def session(self, movie, room):
+        return Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time="2026-03-22T18:00:00Z",
+            end_time="2026-03-22T20:55:00Z",
+        )
+
+    def test_list_genres_returns_200(self, api_client, genre):
+        response = api_client.get("/api/v1/catalog/genres/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["name"] == genre.name
+
+    def test_create_genre_returns_201(self, api_client):
+        response = api_client.post(
+            "/api/v1/catalog/genres/",
+            {"name": "Sci-Fi"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["name"] == "Sci-Fi"
+        assert Genre.objects.filter(name="Sci-Fi").exists()
+
+    def test_list_movies_returns_200_with_nested_genres(self, api_client, movie):
+        response = api_client.get("/api/v1/catalog/movies/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["title"] == movie.title
+        assert len(response.data[0]["genres"]) == 2
+        assert "name" in response.data[0]["genres"][0]
+
+    def test_create_movie_returns_201(self, api_client, genre, second_genre):
+        response = api_client.post(
+            "/api/v1/catalog/movies/",
+            {
+                "title": "Interstellar",
+                "genres": [str(genre.id), str(second_genre.id)],
+                "synopsis": "Space exploration.",
+                "duration_minutes": 169,
+                "release_date": "2014-11-07",
+                "poster_url": "https://example.com/interstellar.jpg",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Movie.objects.filter(title="Interstellar").exists()
+
+    def test_list_rooms_returns_200(self, api_client, room):
+        response = api_client.get("/api/v1/catalog/rooms/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["name"] == room.name
+
+    def test_create_room_returns_201(self, api_client):
+        response = api_client.post(
+            "/api/v1/catalog/rooms/",
+            {
+                "name": "Room 2",
+                "capacity": 80,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["name"] == "Room 2"
+        assert Room.objects.filter(name="Room 2").exists()
+
+    def test_list_sessions_returns_200_with_nested_movie_and_room(
+        self,
+        api_client,
+        session,
+    ):
+        response = api_client.get("/api/v1/catalog/sessions/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["movie"]["title"] == session.movie.title
+        assert response.data[0]["room"]["name"] == session.room.name
+
+    def test_create_session_returns_201(self, api_client, movie, room):
+        response = api_client.post(
+            "/api/v1/catalog/sessions/",
+            {
+                "movie": str(movie.id),
+                "room": str(room.id),
+                "start_time": "2026-03-23T18:00:00Z",
+                "end_time": "2026-03-23T20:55:00Z",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Session.objects.count() == 1
+
+    def test_delete_genre_returns_204(self, api_client, genre):
+        response = api_client.delete(f"/api/v1/catalog/genres/{genre.id}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Genre.objects.filter(id=genre.id).exists()


### PR DESCRIPTION
## Objective

Add initial catalog routing and basic API endpoints to support manual testing of catalog resources without relying on the Django admin.

## What was done

- Created `catalog/urls.py`
- Registered catalog routes under `/api/v1/catalog/` in the main project URL configuration
- Added serializers for catalog resources:
  - `GenreSerializer`
  - `RoomSerializer`
  - `MovieWriteSerializer`
  - `MovieReadSerializer`
  - `MovieSummarySerializer`
  - `SessionWriteSerializer`
  - `SessionReadSerializer`
- Implemented basic catalog API views for manual testing:
  - genre list/create and detail/delete
  - movie list/create and detail/delete
  - room list/create and detail/delete
  - session list/create and detail/delete
- Improved read responses with richer nested representations for movie genres, session movie data, and room data
- Kept the endpoints publicly accessible to simplify local manual testing during development
- Added integration tests covering:
  - listing catalog resources
  - creating genres, movies, rooms, and sessions
  - deleting a genre
  - nested read responses for movies and sessions

## How to test

- Start the environment:
  `docker compose up -d`

- Apply migrations if needed:
  `docker compose exec web python manage.py migrate`

- Run the catalog API tests:
  `docker compose exec web pytest tests/integration/test_catalog_api.py`

- Run the full test suite:
  `docker compose exec web pytest`

- Example manual test endpoints:
  - `GET /api/v1/catalog/genres/`
  - `POST /api/v1/catalog/genres/`
  - `GET /api/v1/catalog/movies/`
  - `POST /api/v1/catalog/movies/`
  - `GET /api/v1/catalog/rooms/`
  - `POST /api/v1/catalog/rooms/`
  - `GET /api/v1/catalog/sessions/`
  - `POST /api/v1/catalog/sessions/`

## Expected result

- Catalog routes are available under `/api/v1/catalog/`
- Catalog resources can be created, listed, retrieved, and deleted through HTTP endpoints
- Movie read responses include nested genre data
- Session read responses include summarized movie and room data
- Manual testing of catalog resources is possible without using the Django admin
- Existing test coverage remains passing

Close #23 