### PR TITLE
feat: implement public session seat map endpoint

### DIFF
--- a/catalog/serializers.py
+++ b/catalog/serializers.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 
+from django.db import transaction
+
 from catalog.models import Genre, Movie, Room, Session
+from reservations.models import SessionSeat, Seat
 
 
 class GenreSerializer(serializers.ModelSerializer):
@@ -97,6 +100,21 @@ class SessionWriteSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    @transaction.atomic
+    def create(self, validated_data):
+        session = Session.objects.create(**validated_data)
+
+        seats = Seat.objects.select_related("row").filter(row__room=session.room)
+
+        session_seats = [
+            SessionSeat(session=session, seat=seat)
+            for seat in seats
+        ]
+
+        SessionSeat.objects.bulk_create(session_seats)
+
+        return session
 
 
 class SessionReadSerializer(serializers.ModelSerializer):

--- a/cinepolis_natal_api/urls.py
+++ b/cinepolis_natal_api/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     path("health/", health_check, name="health-check"),
     path("api/v1/auth/", include("users.urls")),
     path("api/v1/catalog/", include("catalog.urls")),
-    path("api/v1/reservations/", include("reservations.urls")),
+    path("api/v1/catalog/", include("reservations.urls")),
 ]

--- a/reservations/serializers.py
+++ b/reservations/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from reservations.models import SessionSeat
+
+
+class SessionSeatMapItemSerializer(serializers.ModelSerializer):
+    seat_id = serializers.UUIDField(source="seat.id", read_only=True)
+    row = serializers.CharField(source="seat.row.name", read_only=True)
+    number = serializers.IntegerField(source="seat.number", read_only=True)
+
+    class Meta:
+        model = SessionSeat
+        fields = ["seat_id", "row", "number", "status"]

--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -1,3 +1,11 @@
 from django.urls import path
 
-urlpatterns = []
+from reservations.views import SessionSeatMapView
+
+urlpatterns = [
+    path(
+        "sessions/<uuid:session_id>/seats/",
+        SessionSeatMapView.as_view(),
+        name="session-seat-map",
+    ),
+]

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -1,3 +1,21 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import AllowAny
 
-# Create your views here.
+from catalog.models import Session
+from reservations.models import SessionSeat
+from reservations.serializers import SessionSeatMapItemSerializer
+
+
+class SessionSeatMapView(ListAPIView):
+    serializer_class = SessionSeatMapItemSerializer
+    permission_classes = [AllowAny]
+
+    def get_queryset(self):
+        session = get_object_or_404(Session, id=self.kwargs["session_id"])
+
+        return (
+            SessionSeat.objects.select_related("seat", "seat__row")
+            .filter(session=session)
+            .order_by("seat__row__name", "seat__number")
+        )

--- a/tests/integration/test_session_creation_seats.py
+++ b/tests/integration/test_session_creation_seats.py
@@ -1,0 +1,52 @@
+import pytest
+from rest_framework.test import APIClient
+
+from catalog.models import Movie, Room, Session
+from reservations.models import Seat, SeatRow, SessionSeat
+
+
+@pytest.mark.django_db
+def test_creating_session_auto_generates_session_seats():
+    client = APIClient()
+
+    room = Room.objects.create(name="Room 1", capacity=100)
+    row_a = SeatRow.objects.create(room=room, name="A")
+    row_b = SeatRow.objects.create(room=room, name="B")
+
+    seat_a1 = Seat.objects.create(row=row_a, number=1)
+    seat_a2 = Seat.objects.create(row=row_a, number=2)
+    seat_b1 = Seat.objects.create(row=row_b, number=1)
+
+    movie = Movie.objects.create(
+        title="Movie 1",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    response = client.post(
+        "/api/v1/catalog/sessions/",
+        {
+            "movie": str(movie.id),
+            "room": str(room.id),
+            "start_time": "2026-03-22T18:00:00Z",
+            "end_time": "2026-03-22T20:00:00Z",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+
+    session = Session.objects.get(id=response.data["id"])
+
+    session_seats = SessionSeat.objects.filter(session=session).order_by(
+        "seat__row__name", "seat__number"
+    )
+
+    assert session_seats.count() == 3
+    assert list(session_seats.values_list("seat_id", flat=True)) == [
+        seat_a1.id,
+        seat_a2.id,
+        seat_b1.id,
+    ]

--- a/tests/integration/test_session_seat_map_api.py
+++ b/tests/integration/test_session_seat_map_api.py
@@ -1,0 +1,106 @@
+import pytest
+from rest_framework.test import APIClient
+
+from catalog.models import Movie, Room, Session
+from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus
+from users.models import User
+from django.utils import timezone
+
+
+@pytest.mark.django_db
+def test_session_seat_map_returns_full_seat_map():
+    client = APIClient()
+
+    room = Room.objects.create(name="Room 1", capacity=100)
+    row_a = SeatRow.objects.create(room=room, name="A")
+    row_b = SeatRow.objects.create(room=room, name="B")
+
+    seat_a1 = Seat.objects.create(row=row_a, number=1)
+    seat_a2 = Seat.objects.create(row=row_a, number=2)
+    seat_b1 = Seat.objects.create(row=row_b, number=1)
+
+    movie = Movie.objects.create(
+        title="Movie 1",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now(),
+        end_time=timezone.now() + timezone.timedelta(hours=2),
+    )
+
+    SessionSeat.objects.bulk_create(
+        [
+            SessionSeat(session=session, seat=seat_a1, status=SessionSeatStatus.AVAILABLE),
+            SessionSeat(session=session, seat=seat_a2, status=SessionSeatStatus.RESERVED, locked_by_user=User.objects.create_user(email="u1@example.com", username="u1", password="StrongPass123"), lock_expires_at=timezone.now() + timezone.timedelta(minutes=10)),
+            SessionSeat(session=session, seat=seat_b1, status=SessionSeatStatus.PURCHASED),
+        ]
+    )
+
+    response = client.get(f"/api/v1/catalog/sessions/{session.id}/seats/")
+
+    assert response.status_code == 200
+    assert response.data == [
+        {
+            "seat_id": str(seat_a1.id),
+            "row": "A",
+            "number": 1,
+            "status": "AVAILABLE",
+        },
+        {
+            "seat_id": str(seat_a2.id),
+            "row": "A",
+            "number": 2,
+            "status": "RESERVED",
+        },
+        {
+            "seat_id": str(seat_b1.id),
+            "row": "B",
+            "number": 1,
+            "status": "PURCHASED",
+        },
+    ]
+
+
+@pytest.mark.django_db
+def test_session_seat_map_is_publicly_accessible():
+    client = APIClient()
+
+    room = Room.objects.create(name="Room 1", capacity=100)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+
+    movie = Movie.objects.create(
+        title="Movie 1",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now(),
+        end_time=timezone.now() + timezone.timedelta(hours=2),
+    )
+
+    SessionSeat.objects.create(session=session, seat=seat)
+
+    response = client.get(f"/api/v1/catalog/sessions/{session.id}/seats/")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_session_seat_map_returns_404_for_unknown_session():
+    client = APIClient()
+
+    response = client.get("/api/v1/catalog/sessions/00000000-0000-0000-0000-000000000000/seats/")
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Objective

Implement a public endpoint that exposes the seat map for a given session, returning each seat with its current state (AVAILABLE, RESERVED, PURCHASED), as required by the system specification.

This endpoint is essential for allowing users to visualize real-time seat availability before initiating the reservation flow.

## What was done

- Implemented public endpoint:
  - `GET /api/v1/catalog/sessions/{session_id}/seats/`

- Designed a dedicated read-only serializer for seat map responses

- Returned seat data including:
  - seat identifier
  - row
  - number
  - current status

- Ensured response is scoped correctly to the requested session

- Implemented automatic creation of `SessionSeat` records when a new `Session` is created

- Ensured newly created session seats are initialized with the correct default state

- Optimized queryset using `select_related` to avoid N+1 query issues

- Ensured endpoint is publicly accessible without authentication

- Added integration tests covering:
  - successful seat map retrieval
  - correct seat state representation
  - automatic session seat creation
  - session not found (404)

- Manually validated the endpoint with real data through API requests

## How to test

- Start the environment:

```docker compose up -d```

- Apply migrations if needed:

```docker compose exec web python manage.py migrate```

- Run seat map tests:

```docker compose exec web pytest tests/integration/test_session_seat_map_api.py -v```

- Run session seat creation tests:

```docker compose exec web pytest tests/integration/test_session_creation_seats.py -v```

- Run the full test suite:

```docker compose exec web pytest```

## Expected result

- The endpoint returns the full seat map for a valid session

- Each seat includes its correct current state

- The endpoint is accessible without authentication

- Non-existent sessions return 404 Not Found

- SessionSeat records are automatically created when a session is created

- No N+1 query issues are introduced during seat map retrieval

- The response shape is stable and suitable for frontend/mobile consumption

Closes #26 