### PR TITLE
feat: implement atomic checkout flow with seat validation and locking

### DIFF
--- a/reservations/serializers.py
+++ b/reservations/serializers.py
@@ -40,3 +40,28 @@ class TemporaryReservationResponseSerializer(serializers.Serializer):
     status = serializers.CharField()
     expires_at = serializers.DateTimeField()
     seats = TemporaryReservationSeatSerializer(many=True)
+    
+class CheckoutRequestSerializer(serializers.Serializer):
+    session_id = serializers.UUIDField()
+    seat_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        allow_empty=False,
+    )
+
+    def validate_seat_ids(self, value):
+        if len(value) != len(set(value)):
+            raise serializers.ValidationError("Seat IDs must be unique.")
+        return value
+
+
+class CheckoutSeatResponseSerializer(serializers.Serializer):
+    seat_id = serializers.UUIDField()
+    row = serializers.CharField()
+    number = serializers.IntegerField()
+    status = serializers.CharField()
+
+
+class CheckoutResponseSerializer(serializers.Serializer):
+    status = serializers.CharField()
+    session_id = serializers.UUIDField()
+    seats = CheckoutSeatResponseSerializer(many=True)

--- a/reservations/services/__init__.py
+++ b/reservations/services/__init__.py
@@ -1,2 +1,3 @@
 from .reservation_service import TemporaryReservationService
 from .expiration_service import ExpiredSeatReleaseService
+from .checkout_service import CheckoutService

--- a/reservations/services/checkout_service.py
+++ b/reservations/services/checkout_service.py
@@ -1,0 +1,106 @@
+from django.db import transaction
+from django.utils import timezone
+
+from reservations.locks import SeatLockManager
+from reservations.models import SessionSeat, SessionSeatStatus
+
+
+class CheckoutError(Exception):
+    pass
+
+
+class InvalidSeatSelectionError(CheckoutError):
+    pass
+
+
+class ReservationOwnershipError(CheckoutError):
+    pass
+
+
+class ExpiredReservationError(CheckoutError):
+    pass
+
+
+class InvalidSeatStateError(CheckoutError):
+    pass
+
+
+class CheckoutService:
+    INVALID_SELECTION_MESSAGE = (
+        "One or more selected seats do not belong to this session."
+    )
+    OWNERSHIP_MESSAGE = "One or more selected seats are not locked by this user."
+    EXPIRED_MESSAGE = "One or more selected seats have expired reservations."
+    INVALID_STATE_MESSAGE = "One or more selected seats are not available for checkout."
+
+    def __init__(self):
+        self.lock_manager = SeatLockManager()
+
+    @transaction.atomic
+    def execute(self, *, session_id, seat_ids, user):
+        ordered_seat_ids = sorted(set(seat_ids))
+        now = timezone.now()
+
+        session_seats = list(
+            SessionSeat.objects.select_for_update()
+            .select_related("seat", "seat__row")
+            .filter(
+                session_id=session_id,
+                seat_id__in=ordered_seat_ids,
+            )
+            .order_by("seat_id")
+        )
+
+        if len(session_seats) != len(ordered_seat_ids):
+            raise InvalidSeatSelectionError(self.INVALID_SELECTION_MESSAGE)
+
+        for session_seat in session_seats:
+            if session_seat.status != SessionSeatStatus.RESERVED:
+                raise InvalidSeatStateError(self.INVALID_STATE_MESSAGE)
+
+            if session_seat.locked_by_user_id != user.id:
+                raise ReservationOwnershipError(self.OWNERSHIP_MESSAGE)
+
+            if session_seat.lock_expires_at is None or session_seat.lock_expires_at <= now:
+                raise ExpiredReservationError(self.EXPIRED_MESSAGE)
+
+        purchased_seats = []
+
+        for session_seat in session_seats:
+            session_seat.status = SessionSeatStatus.PURCHASED
+            session_seat.locked_by_user = None
+            session_seat.lock_expires_at = None
+            purchased_seats.append(session_seat)
+
+        SessionSeat.objects.bulk_update(
+            purchased_seats,
+            ["status", "locked_by_user", "lock_expires_at"],
+        )
+
+        transaction.on_commit(
+            lambda: self._release_redis_locks(
+                session_id=session_id,
+                session_seats=purchased_seats,
+            )
+        )
+
+        return {
+            "status": "PURCHASED",
+            "session_id": session_id,
+            "seats": [
+                {
+                    "seat_id": str(session_seat.seat_id),
+                    "row": session_seat.seat.row.name,
+                    "number": session_seat.seat.number,
+                    "status": session_seat.status,
+                }
+                for session_seat in purchased_seats
+            ],
+        }
+
+    def _release_redis_locks(self, *, session_id, session_seats):
+        for session_seat in session_seats:
+            self.lock_manager.release(
+                session_id=session_id,
+                seat_id=session_seat.seat_id,
+            )

--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 
-from reservations.views import SessionSeatMapView, TemporarySeatReservationView
+from reservations.views import (
+    CheckoutView,
+    SessionSeatMapView,
+    TemporarySeatReservationView,
+)
 
 urlpatterns = [
     path(
@@ -12,5 +16,10 @@ urlpatterns = [
         "sessions/<uuid:session_id>/reservations/",
         TemporarySeatReservationView.as_view(),
         name="temporary-seat-reservation",
+    ),
+    path(
+        "checkout/",
+        CheckoutView.as_view(),
+        name="checkout",
     ),
 ]

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -13,11 +13,20 @@ from reservations.exceptions import (
 )
 from reservations.models import SessionSeat
 from reservations.serializers import (
+    CheckoutRequestSerializer,
+    CheckoutResponseSerializer,
     SessionSeatMapItemSerializer,
     TemporaryReservationRequestSerializer,
     TemporaryReservationResponseSerializer,
 )
 from reservations.services import TemporaryReservationService
+from reservations.services.checkout_service import (
+    ExpiredReservationError,
+    InvalidSeatStateError,
+    CheckoutService,
+    InvalidSeatSelectionError as CheckoutInvalidSeatSelectionError,
+    ReservationOwnershipError,
+)
 
 
 class SessionSeatMapView(ListAPIView):
@@ -74,3 +83,50 @@ class TemporarySeatReservationView(GenericAPIView):
             response_payload
         )
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+
+class CheckoutView(GenericAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = CheckoutRequestSerializer
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        service = CheckoutService()
+
+        try:
+            checkout_result = service.execute(
+                session_id=serializer.validated_data["session_id"],
+                seat_ids=serializer.validated_data["seat_ids"],
+                user=request.user,
+            )
+        except CheckoutInvalidSeatSelectionError as exc:
+            raise ValidationError(detail={"seat_ids": [str(exc)]}) from exc
+        except ReservationOwnershipError as exc:
+            return Response(
+                {
+                    "error": "RESERVATION_OWNERSHIP_ERROR",
+                    "message": str(exc),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        except ExpiredReservationError as exc:
+            return Response(
+                {
+                    "error": "RESERVATION_EXPIRED",
+                    "message": str(exc),
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        except InvalidSeatStateError as exc:
+            return Response(
+                {
+                    "error": "INVALID_SEAT_STATE",
+                    "message": str(exc),
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        response_serializer = CheckoutResponseSerializer(checkout_result)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/tests/integration/test_checkout_api.py
+++ b/tests/integration/test_checkout_api.py
@@ -1,0 +1,252 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from catalog.models import Movie, Room, Session
+from reservations.models import SessionSeat, SessionSeatStatus, Seat, SeatRow
+
+
+@pytest.mark.django_db
+def test_checkout_should_purchase_reserved_seats_successfully():
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        email="checkout@example.com",
+        username="checkout_user",
+        password="StrongPass123!",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    room = Room.objects.create(name="Checkout Room", capacity=100)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+
+    movie = Movie.objects.create(
+        title="Checkout Movie",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now() + timedelta(hours=1),
+        end_time=timezone.now() + timedelta(hours=3),
+    )
+
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.RESERVED,
+        locked_by_user=user,
+        lock_expires_at=timezone.now() + timedelta(minutes=10),
+    )
+
+    response = client.post(
+        "/api/v1/reservation/checkout/",
+        {
+            "session_id": str(session.id),
+            "seat_ids": [str(seat.id)],
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+
+    session_seat.refresh_from_db()
+    assert session_seat.status == SessionSeatStatus.PURCHASED
+    assert session_seat.locked_by_user is None
+    assert session_seat.lock_expires_at is None
+
+    assert response.data["status"] == "PURCHASED"
+    assert response.data["session_id"] == str(session.id)
+    assert len(response.data["seats"]) == 1
+    assert response.data["seats"][0]["seat_id"] == str(seat.id)
+    assert response.data["seats"][0]["status"] == "PURCHASED"
+    
+@pytest.mark.django_db
+def test_checkout_should_fail_for_expired_reservation():
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        email="expired@example.com",
+        username="expired_checkout_user",
+        password="StrongPass123!",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    room = Room.objects.create(name="Expired Checkout Room", capacity=100)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+
+    movie = Movie.objects.create(
+        title="Expired Checkout Movie",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now() + timedelta(hours=1),
+        end_time=timezone.now() + timedelta(hours=3),
+    )
+
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.RESERVED,
+        locked_by_user=user,
+        lock_expires_at=timezone.now() - timedelta(minutes=1),
+    )
+
+    response = client.post(
+        "/api/v1/reservation/checkout/",
+        {
+            "session_id": str(session.id),
+            "seat_ids": [str(seat.id)],
+        },
+        format="json",
+    )
+
+    assert response.status_code == 409
+    assert response.data["error"] == "RESERVATION_EXPIRED"
+
+    session_seat.refresh_from_db()
+    assert session_seat.status == SessionSeatStatus.RESERVED
+    assert session_seat.locked_by_user == user
+    assert session_seat.lock_expires_at is not None
+    
+@pytest.mark.django_db
+def test_checkout_should_fail_for_different_user():
+    user_model = get_user_model()
+
+    owner = user_model.objects.create_user(
+        email="owner@example.com",
+        username="owner_user",
+        password="StrongPass123!",
+    )
+
+    another_user = user_model.objects.create_user(
+        email="other@example.com",
+        username="other_user",
+        password="StrongPass123!",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=another_user)
+
+    room = Room.objects.create(name="Ownership Room", capacity=100)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+
+    movie = Movie.objects.create(
+        title="Ownership Movie",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now() + timedelta(hours=1),
+        end_time=timezone.now() + timedelta(hours=3),
+    )
+
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.RESERVED,
+        locked_by_user=owner,
+        lock_expires_at=timezone.now() + timedelta(minutes=10),
+    )
+
+    response = client.post(
+        "/api/v1/reservation/checkout/",
+        {
+            "session_id": str(session.id),
+            "seat_ids": [str(seat.id)],
+        },
+        format="json",
+    )
+
+    assert response.status_code == 403
+    assert response.data["error"] == "RESERVATION_OWNERSHIP_ERROR"
+
+    session_seat.refresh_from_db()
+    assert session_seat.status == SessionSeatStatus.RESERVED
+    
+@pytest.mark.django_db
+def test_checkout_should_be_atomic_when_one_seat_is_invalid():
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        email="atomic@example.com",
+        username="atomic_user",
+        password="StrongPass123!",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    room = Room.objects.create(name="Atomic Room", capacity=100)
+    row = SeatRow.objects.create(room=room, name="A")
+
+    seat_valid = Seat.objects.create(row=row, number=1)
+    seat_invalid = Seat.objects.create(row=row, number=2)
+
+    movie = Movie.objects.create(
+        title="Atomic Movie",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now() + timedelta(hours=1),
+        end_time=timezone.now() + timedelta(hours=3),
+    )
+
+    session_seat_valid = SessionSeat.objects.create(
+        session=session,
+        seat=seat_valid,
+        status=SessionSeatStatus.RESERVED,
+        locked_by_user=user,
+        lock_expires_at=timezone.now() + timedelta(minutes=10),
+    )
+
+    session_seat_invalid = SessionSeat.objects.create(
+        session=session,
+        seat=seat_invalid,
+        status=SessionSeatStatus.AVAILABLE,  # <- inválido
+    )
+
+    response = client.post(
+        "/api/v1/reservation/checkout/",
+        {
+            "session_id": str(session.id),
+            "seat_ids": [str(seat_valid.id), str(seat_invalid.id)],
+        },
+        format="json",
+    )
+
+    assert response.status_code == 409
+
+    session_seat_valid.refresh_from_db()
+    session_seat_invalid.refresh_from_db()
+
+    assert session_seat_valid.status == SessionSeatStatus.RESERVED
+    assert session_seat_invalid.status == SessionSeatStatus.AVAILABLE


### PR DESCRIPTION
## Objective

Implement the checkout flow to finalize temporary seat reservations, ensuring atomicity, ownership validation, and strong consistency.

## What was done

* Implemented `CheckoutService` to encapsulate checkout business logic
* Ensured atomic transaction using `transaction.atomic`
* Applied row-level locking with `select_for_update` to prevent race conditions
* Implemented full validation rules:

  * Seat existence and session ownership
  * Seat state must be `RESERVED`
  * Seat must be locked by the requesting user
  * Reservation must not be expired
* Enforced all-or-nothing behavior for multi-seat checkout
* Transitioned seat state:

  * `RESERVED → PURCHASED`
  * Cleared lock metadata (`locked_by_user`, `lock_expires_at`)
* Released Redis locks after successful transaction using `on_commit`
* Implemented API endpoint:

  * `POST /api/v1/reservation/checkout/`
* Added serializers for request and response
* Implemented proper error handling and HTTP mappings:

  * 400 for invalid input
  * 403 for ownership violation
  * 409 for conflicts and expiration
* Added integration tests covering:

  * Successful checkout
  * Expired reservation
  * Ownership violation
  * Atomic rollback behavior
* Ensured no regressions across existing test suite

## How to test

* Run full test suite:

docker compose exec web pytest

* Run checkout tests only:

docker compose exec web pytest tests/integration/test_checkout_api.py -v

## Expected result

* Seats are purchased atomically
* No partial checkout occurs under failure scenarios
* Only the reservation owner can complete checkout
* Expired reservations are rejected
* System remains consistent under concurrent access

Closes #29
