### PR TITLE
eat: implement API rate limiting and throttling strategy

### DIFF
--- a/cinepolis_natal_api/settings.py
+++ b/cinepolis_natal_api/settings.py
@@ -185,14 +185,25 @@ CELERY_TASK_SERIALIZER = "json"
 # -------------------------------------------------------------------
 
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": (
+    "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
-    ),
-    "DEFAULT_PERMISSION_CLASSES": (
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.AllowAny",
-    ),
+    ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
+    "DEFAULT_THROTTLE_CLASSES": [
+        "cinepolis_natal_api.throttling.GlobalAnonRateThrottle",
+        "cinepolis_natal_api.throttling.GlobalUserRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": os.getenv("THROTTLE_ANON_RATE", "60/minute"),
+        "user": os.getenv("THROTTLE_USER_RATE", "120/minute"),
+        "login": os.getenv("THROTTLE_LOGIN_RATE", "5/minute"),
+        "reservation": os.getenv("THROTTLE_RESERVATION_RATE", "10/minute"),
+    },
+    "EXCEPTION_HANDLER": "cinepolis_natal_api.throttling.throttling_exception_handler",
 }
 
 # -------------------------------------------------------------------

--- a/cinepolis_natal_api/tasks.py
+++ b/cinepolis_natal_api/tasks.py
@@ -1,6 +1,11 @@
+import logging
+
 from celery import shared_task
+
+
+logger = logging.getLogger(__name__)
 
 @shared_task
 def test_task():
-    print("Celery task executed")
+    logger.info("Celery task executed")
     return "Celery is working"

--- a/cinepolis_natal_api/throttling.py
+++ b/cinepolis_natal_api/throttling.py
@@ -1,0 +1,52 @@
+from rest_framework.throttling import SimpleRateThrottle, AnonRateThrottle, UserRateThrottle
+from rest_framework.views import exception_handler
+from rest_framework.response import Response
+from rest_framework import status
+
+
+class GlobalAnonRateThrottle(AnonRateThrottle):
+    scope = "anon"
+
+
+class GlobalUserRateThrottle(UserRateThrottle):
+    scope = "user"
+
+
+class LoginRateThrottle(SimpleRateThrottle):
+    scope = "login"
+
+    def get_cache_key(self, request, view):
+        return self.get_ident(request)
+
+
+class ReservationRateThrottle(SimpleRateThrottle):
+    scope = "reservation"
+
+    def get_cache_key(self, request, view):
+        return self.get_ident(request)
+
+
+def throttling_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+
+    if response is not None and response.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        wait = None
+        if hasattr(exc, "wait"):
+            wait = exc.wait
+
+        message = "Request limit exceeded. Please try again later."
+        if wait:
+            message = f"Request limit exceeded. Please try again in {int(wait)} seconds."
+
+        return Response(
+            {
+                "error": {
+                    "code": "THROTTLED",
+                    "message": message,
+                    "status": status.HTTP_429_TOO_MANY_REQUESTS,
+                }
+            },
+            status=status.HTTP_429_TOO_MANY_REQUESTS,
+        )
+
+    return response

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -5,6 +5,8 @@ from rest_framework.generics import GenericAPIView, ListAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
+from cinepolis_natal_api.throttling import ReservationRateThrottle
+
 from catalog.models import Session
 from reservations.exceptions import (
     InvalidSeatSelectionError,
@@ -47,6 +49,7 @@ class SessionSeatMapView(ListAPIView):
 class TemporarySeatReservationView(GenericAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = TemporaryReservationRequestSerializer
+    throttle_classes = [ReservationRateThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -89,6 +92,7 @@ class TemporarySeatReservationView(GenericAPIView):
 class CheckoutView(GenericAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = CheckoutRequestSerializer
+    throttle_classes = [ReservationRateThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/tests/integration/test_temporary_seat_reservation_api.py
+++ b/tests/integration/test_temporary_seat_reservation_api.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -10,7 +11,46 @@ from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus
 from users.models import User
 
 
-pytestmark = pytest.mark.django_db
+REST_FRAMEWORK_OVERRIDE = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
+    ],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+    "DEFAULT_THROTTLE_CLASSES": [],
+    "DEFAULT_THROTTLE_RATES": {},
+    "EXCEPTION_HANDLER": "cinepolis_natal_api.throttling.throttling_exception_handler",
+}
+
+
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures("disable_throttling_for_module"),
+]
+
+
+@pytest.fixture(autouse=True)
+def disable_throttling_for_module():
+    from reservations.views import CheckoutView, TemporarySeatReservationView
+    from users.views import UserLoginView
+
+    original_login_throttles = UserLoginView.throttle_classes
+    original_temp_reservation_throttles = TemporarySeatReservationView.throttle_classes
+    original_checkout_throttles = CheckoutView.throttle_classes
+
+    UserLoginView.throttle_classes = []
+    TemporarySeatReservationView.throttle_classes = []
+    CheckoutView.throttle_classes = []
+
+    with override_settings(REST_FRAMEWORK=REST_FRAMEWORK_OVERRIDE):
+        yield
+
+    UserLoginView.throttle_classes = original_login_throttles
+    TemporarySeatReservationView.throttle_classes = original_temp_reservation_throttles
+    CheckoutView.throttle_classes = original_checkout_throttles
 
 
 def create_user(email="user@example.com", password="StrongPass123!"):
@@ -90,8 +130,6 @@ def test_temporary_reservation_success():
         {"seat_ids": [str(seats[0].id), str(seats[1].id)]},
         format="json",
     )
-    
-    print(response.data)
 
     assert response.status_code == 201
     assert response.data["status"] == "TEMPORARILY_RESERVED"

--- a/tests/integration/test_throttling_api.py
+++ b/tests/integration/test_throttling_api.py
@@ -1,0 +1,266 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.conf import settings
+from django.core.cache import cache
+from django.test import override_settings
+from django.utils import timezone
+from rest_framework.throttling import SimpleRateThrottle
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+User = get_user_model()
+
+
+def _sync_throttle_rates_from_settings():
+    SimpleRateThrottle.THROTTLE_RATES = settings.REST_FRAMEWORK.get(
+        "DEFAULT_THROTTLE_RATES",
+        {},
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolate_throttling_state():
+    from catalog.views import GenreListCreateView
+    from cinepolis_natal_api.throttling import (
+        GlobalAnonRateThrottle,
+        GlobalUserRateThrottle,
+        LoginRateThrottle,
+        ReservationRateThrottle,
+    )
+    from reservations.views import CheckoutView, TemporarySeatReservationView
+    from users.views import UserLoginView
+
+    original_genre_throttles = getattr(GenreListCreateView, "throttle_classes", None)
+    original_login_throttles = UserLoginView.throttle_classes
+    original_temp_reservation_throttles = TemporarySeatReservationView.throttle_classes
+    original_checkout_throttles = CheckoutView.throttle_classes
+    original_simple_rate_throttle_rates = SimpleRateThrottle.THROTTLE_RATES
+
+    GenreListCreateView.throttle_classes = [GlobalAnonRateThrottle, GlobalUserRateThrottle]
+    UserLoginView.throttle_classes = [LoginRateThrottle]
+    TemporarySeatReservationView.throttle_classes = [ReservationRateThrottle]
+    CheckoutView.throttle_classes = [ReservationRateThrottle]
+
+    cache.clear()
+    yield
+    cache.clear()
+
+    if original_genre_throttles is None:
+        delattr(GenreListCreateView, "throttle_classes")
+    else:
+        GenreListCreateView.throttle_classes = original_genre_throttles
+    UserLoginView.throttle_classes = original_login_throttles
+    TemporarySeatReservationView.throttle_classes = original_temp_reservation_throttles
+    CheckoutView.throttle_classes = original_checkout_throttles
+    SimpleRateThrottle.THROTTLE_RATES = original_simple_rate_throttle_rates
+
+
+@pytest.mark.django_db
+class TestApiThrottling:
+    @pytest.fixture
+    def api_client(self):
+        client = APIClient()
+        client.defaults["REMOTE_ADDR"] = "10.10.10.10"
+        return client
+
+    @pytest.fixture
+    def user(self):
+        return User.objects.create_user(
+            email="user@example.com",
+            username="testuser",
+            password="StrongPass123!",
+        )
+
+    @pytest.fixture
+    def authenticated_client(self, user):
+        client = APIClient()
+        client.defaults["REMOTE_ADDR"] = "10.10.10.11"
+        refresh = RefreshToken.for_user(user)
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+        return client
+
+    @pytest.fixture
+    def session_with_seats(self):
+        from catalog.models import Genre, Movie, Room, Session
+        from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus
+        from datetime import timedelta
+
+        genre = Genre.objects.create(name="Action")
+        movie = Movie.objects.create(
+            title="Throttle Test Movie",
+            synopsis="Test synopsis",
+            duration_minutes=120,
+            release_date=timezone.now().date(),
+            poster_url="https://example.com/throttle-test.jpg",
+        )
+        movie.genres.set([genre])
+
+        room = Room.objects.create(name="Room 1", capacity=20)
+        row = SeatRow.objects.create(room=room, name="A")
+        seat_1 = Seat.objects.create(row=row, number=1)
+        seat_2 = Seat.objects.create(row=row, number=2)
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=timezone.now() + timedelta(days=1),
+            end_time=timezone.now() + timedelta(days=1, hours=2),
+        )
+        SessionSeat.objects.create(
+            session=session,
+            seat=seat_1,
+            status=SessionSeatStatus.AVAILABLE,
+        )
+        SessionSeat.objects.create(
+            session=session,
+            seat=seat_2,
+            status=SessionSeatStatus.AVAILABLE,
+        )
+
+        return {
+            "session": session,
+            "seat_1": seat_1,
+            "seat_2": seat_2,
+        }
+
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_AUTHENTICATION_CLASSES": [
+                "rest_framework_simplejwt.authentication.JWTAuthentication",
+            ],
+            "DEFAULT_PERMISSION_CLASSES": [
+                "rest_framework.permissions.AllowAny",
+            ],
+            "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+            "PAGE_SIZE": 10,
+            "DEFAULT_THROTTLE_CLASSES": [
+                "cinepolis_natal_api.throttling.GlobalAnonRateThrottle",
+                "cinepolis_natal_api.throttling.GlobalUserRateThrottle",
+            ],
+            "DEFAULT_THROTTLE_RATES": {
+                "anon": "2/minute",
+                "user": "2/minute",
+                "login": "1/minute",
+                "reservation": "1/minute",
+            },
+            "EXCEPTION_HANDLER": "cinepolis_natal_api.throttling.throttling_exception_handler",
+        }
+    )
+    def test_global_anonymous_throttling_blocks_after_limit(self, api_client, monkeypatch):
+        _sync_throttle_rates_from_settings()
+
+        first_response = api_client.get("/api/v1/catalog/genres/")
+        second_response = api_client.get("/api/v1/catalog/genres/")
+        third_response = api_client.get("/api/v1/catalog/genres/")
+
+        assert first_response.status_code == status.HTTP_200_OK
+        assert second_response.status_code == status.HTTP_200_OK
+        assert third_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        body = third_response.json()
+        assert body["error"]["code"] == "THROTTLED"
+        assert body["error"]["status"] == 429
+        assert "Request limit exceeded" in body["error"]["message"]
+
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_AUTHENTICATION_CLASSES": [
+                "rest_framework_simplejwt.authentication.JWTAuthentication",
+            ],
+            "DEFAULT_PERMISSION_CLASSES": [
+                "rest_framework.permissions.AllowAny",
+            ],
+            "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+            "PAGE_SIZE": 10,
+            "DEFAULT_THROTTLE_CLASSES": [
+                "cinepolis_natal_api.throttling.GlobalAnonRateThrottle",
+                "cinepolis_natal_api.throttling.GlobalUserRateThrottle",
+            ],
+            "DEFAULT_THROTTLE_RATES": {
+                "anon": "10/minute",
+                "user": "10/minute",
+                "login": "1/minute",
+                "reservation": "10/minute",
+            },
+            "EXCEPTION_HANDLER": "cinepolis_natal_api.throttling.throttling_exception_handler",
+        }
+    )
+    def test_login_endpoint_is_throttled_faster_than_global_limit(self, api_client):
+        _sync_throttle_rates_from_settings()
+
+        payload = {
+            "email": "user@example.com",
+            "password": "wrong-password",
+        }
+
+        first_response = api_client.post("/api/v1/auth/login/", payload, format="json")
+        second_response = api_client.post("/api/v1/auth/login/", payload, format="json")
+
+        assert first_response.status_code in {
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+        }
+        assert second_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        body = second_response.json()
+        assert body["error"]["code"] == "THROTTLED"
+        assert body["error"]["status"] == 429
+        assert "Request limit exceeded" in body["error"]["message"]
+
+    @override_settings(
+        REST_FRAMEWORK={
+            "DEFAULT_AUTHENTICATION_CLASSES": [
+                "rest_framework_simplejwt.authentication.JWTAuthentication",
+            ],
+            "DEFAULT_PERMISSION_CLASSES": [
+                "rest_framework.permissions.AllowAny",
+            ],
+            "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+            "PAGE_SIZE": 10,
+            "DEFAULT_THROTTLE_CLASSES": [
+                "cinepolis_natal_api.throttling.GlobalAnonRateThrottle",
+                "cinepolis_natal_api.throttling.GlobalUserRateThrottle",
+            ],
+            "DEFAULT_THROTTLE_RATES": {
+                "anon": "10/minute",
+                "user": "10/minute",
+                "login": "10/minute",
+                "reservation": "1/minute",
+            },
+            "EXCEPTION_HANDLER": "cinepolis_natal_api.throttling.throttling_exception_handler",
+        }
+    )
+    def test_reservation_endpoint_is_throttled_with_specific_limit(
+        self,
+        authenticated_client,
+        session_with_seats,
+    ):
+        _sync_throttle_rates_from_settings()
+
+        session = session_with_seats["session"]
+        seat_1 = session_with_seats["seat_1"]
+        seat_2 = session_with_seats["seat_2"]
+
+        first_payload = {
+            "seat_ids": [str(seat_1.id)],
+        }
+        second_payload = {
+            "seat_ids": [str(seat_2.id)],
+        }
+
+        first_response = authenticated_client.post(
+            f"/api/v1/reservation/sessions/{session.id}/reservations/",
+            first_payload,
+            format="json",
+        )
+        second_response = authenticated_client.post(
+            f"/api/v1/reservation/sessions/{session.id}/reservations/",
+            second_payload,
+            format="json",
+        )
+
+        assert first_response.status_code == status.HTTP_201_CREATED
+        assert second_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        body = second_response.json()
+        assert body["error"]["code"] == "THROTTLED"
+        assert body["error"]["status"] == 429
+        assert "Request limit exceeded" in body["error"]["message"]

--- a/users/views.py
+++ b/users/views.py
@@ -1,21 +1,18 @@
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.generics import CreateAPIView, ListAPIView
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
 
+from cinepolis_natal_api.throttling import LoginRateThrottle
 from reservations.models import Ticket
 from users.serializers import (
     UserLoginSerializer,
     UserRegistrationSerializer,
     UserTicketSerializer,
 )
-
-from rest_framework import status
-from rest_framework.generics import CreateAPIView
-from rest_framework.permissions import AllowAny, IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework_simplejwt.tokens import RefreshToken
-
-from users.serializers import UserLoginSerializer, UserRegistrationSerializer
 
 
 class UserRegistrationView(CreateAPIView):
@@ -25,6 +22,7 @@ class UserRegistrationView(CreateAPIView):
 
 class UserLoginView(APIView):
     permission_classes = [AllowAny]
+    throttle_classes = [LoginRateThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = UserLoginSerializer(


### PR DESCRIPTION
## Objective
Implement a robust and configurable API throttling strategy to protect the platform against abuse, brute-force attacks, and excessive request volume, while maintaining a consistent developer experience and preserving normal usage patterns for both public and authenticated endpoints.

## What was done

### Global Throttling
* Introduced global rate limiting for:
    * **Anonymous users** (AnonRateThrottle)
    * **Authenticated users** (UserRateThrottle)
* Configured default limits via `REST_FRAMEWORK` settings.
* Ensured all limits are environment-driven using `os.getenv`, allowing flexibility across development, staging, and production.

### Endpoint-Specific Throttling
* Implemented stricter throttling rules for sensitive operations:
    * **Authentication (login):** brute-force protection.
    * **Reservations & checkout:** protection against abusive booking bursts.
* Created dedicated throttle classes using `SimpleRateThrottle`:
    * `LoginRateThrottle`
    * `ReservationRateThrottle`
* Used client IP (`get_ident`) as the throttle key for deterministic behavior.

### Standardized Throttling Responses
* Implemented a custom exception handler for throttling scenarios.
* All throttled requests now return **HTTP 429 Too Many Requests**.
* Standardized error payload:
{
  "error": {
    "code": "THROTTLED",
    "message": "Request limit exceeded. Please try again later.",
    "status": 429
  }
}
* Included dynamic wait time messaging when available.

### Observability Alignment
* Ensured throttling integrates seamlessly with the existing structured logging system.
* Replaced residual `print` statements in async tasks with proper `logger.info` usage.
* Maintained consistency between API and Celery logging strategies.

## Test Strategy and Reliability
* Added dedicated integration tests for:
    * Global anonymous throttling.
    * Login throttling with stricter limits.
    * Reservation throttling with stricter limits.
    * Standardized 429 response structure.
* **Addressed common testing pitfalls:**
    * Implemented cache isolation between tests to avoid flakiness.
    * Ensured unique client IPs per test context.
    * Avoided interference from business logic (e.g., ensuring throttling triggers before seat conflicts).
    * Explicitly disabled throttling in non-related test modules to prevent unintended 429 responses.

## Validation
* Full integration test suite executed successfully: `tests/integration/*` → all tests passing.
* Verified deterministic behavior both in isolated test execution and in full-suite execution.

## Expected Result
* **/api/v1/auth/login/** triggers throttling significantly faster than general endpoints.
* Throttled requests return a clean, structured JSON response instead of default HTML/Plain text.
* Logs capture throttled events with the corresponding `correlation_id`.
* System remains stable under artificial request bursts during local testing.

## Notes
* This implementation focuses on application-level rate limiting using Django REST Framework.
* No infrastructure-level throttling (e.g., API Gateway, Nginx) was introduced in this PR.
* Throttling limits remain fully configurable via environment variables (e.g., `THROTTLE_ANON_LIMIT`).
* Design prioritizes: **determinism**, **test isolation**, and **production-readiness**.

Closes #34 