### PR TITLE
feat: add reservation admin CRUD endpoints and safe update flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These capabilities are implemented with emphasis on data consistency, concurrenc
 
 ## Documentation
 
-Detailed implementation-aligned requirements are available in [`cinepolis-natal-api-srs.md`](./software-requirements-specification.md.md).
+Detailed implementation-aligned requirements are available in [`software-requirements-specification.md.md`](./software-requirements-specification.md.md).
 
 ## Tech Stack
 
@@ -40,14 +40,15 @@ The table below maps implemented requirements to concrete endpoints/components.
 | User registration | Register with email, username, password | `POST /api/v1/auth/register/` (`users.views.UserRegistrationView`) |
 | JWT login | Login returns access + refresh tokens | `POST /api/v1/auth/login/` (`users.views.UserLoginView`) |
 | Current user profile | Returns authenticated user identity | `GET /api/v1/auth/me/` and `GET /api/v1/users/me/` |
-| Public catalog | List/create/retrieve/delete genres, movies, rooms, sessions (no update endpoint implemented) | `catalog.views.*` under `/api/v1/catalog/*` |
+| Public catalog | List/create/retrieve/update/delete genres, movies, rooms, sessions | `catalog.views.*` under `/api/v1/catalog/*` |
+| Reservation admin entities | Full CRUD for seat rows and seats; list/create/retrieve/delete for session seats and tickets | `reservations.views.*` under `/api/v1/reservation/*` |
 | Session seat map | Public seat status (`AVAILABLE`, `RESERVED`, `PURCHASED`) | `GET /api/v1/reservation/sessions/{session_id}/seats/` |
 | Temporary reservation | Authenticated seat lock with expiration metadata | `POST /api/v1/reservation/sessions/{session_id}/reservations/` |
 | Checkout | Transactional purchase and ticket creation | `POST /api/v1/reservation/checkout/` + `reservations.services.checkout_service` |
 | My tickets | Authenticated ticket list + `type=upcoming|past` filter | `GET /api/v1/users/me/tickets/` |
 | Standardized errors | Unified error envelope for 4xx/5xx | `cinepolis_natal_api.exception_handler.standardized_exception_handler` |
 | Rate limiting | Global + login + reservation throttles | `cinepolis_natal_api.throttling` + DRF settings |
-| Redis cache | Caching for movies/sessions list endpoints + invalidation | `catalog.views.MovieListCreateView` / `SessionListCreateView` |
+| Redis cache | Caching for movies/sessions list endpoints + invalidation on create/update/delete | `catalog.views.MovieListCreateView` / `SessionListCreateView` |
 | Async jobs | Expiration release + ticket email notification | `reservations.tasks` + Celery worker |
 | Health check | DB/Redis/Celery health status | `GET /health/` |
 | API docs | OpenAPI schema + Swagger UI | `/api/schema/`, `/api/docs/` |
@@ -186,50 +187,78 @@ This is the recommended and validated way to run the project locally, as it prov
 	docker compose exec web pytest -q
 	```
 
+### Run a specific test file
+
+- Docker:
+	```bash
+	docker compose exec web pytest tests/integration/test_catalog_api.py -q
+	docker compose exec web pytest tests/integration/test_reservations_admin_crud_api.py -q
+	```
+
 ### Integration tests
 
 Integration tests are under `tests/integration/` and validate end-to-end API behavior, including authentication, catalog, reservation/checkout concurrency behavior, throttling, error schema, and background task-related flows.
 
 ### CI validation
 
-The CI workflow executes:
+The CI workflow executes these validations inside the CI job environment:
 - `python manage.py check`
 - `python manage.py migrate --noinput`
 - `pytest -q`
 - Docker Compose config validation
 - Docker image build
 
+For local development, prefer only the Docker commands documented in this README.
+
 ## Manual Testing Guide
 
-This guide is executable with `curl`.
+This guide can be executed with Postman or `curl`.
 
 Base URL:
 ```bash
 export BASE_URL="http://localhost:8000"
 ```
 
+### Postman Environment
+
+Suggested Postman environment variables:
+
+- `BASE_URL`: `http://localhost:8000`
+- `ACCESS_TOKEN`: JWT access token returned by login
+- `SESSION_ID`: target session UUID
+- `SEAT_ID`: target seat UUID from the seat map
+- `TICKET_ID`: optional ticket UUID for direct ticket lookup
+
+For authenticated requests in Postman:
+
+- Authorization type: `Bearer Token`
+- Token value: `{{ACCESS_TOKEN}}`
+
 ### Preconditions
 
 - API is running.
 - At least one session exists with seats in `AVAILABLE` status.
-	- The API exposes endpoints for movies/sessions/rooms, but seat rows and seats are model-managed; in local environments you may create base room/seat data via admin or Django shell if needed.
+	- You can manage seat rows, seats, session seats, and tickets directly through `/api/v1/reservation/seat-rows/`, `/api/v1/reservation/seats/`, `/api/v1/reservation/session-seats/`, and `/api/v1/reservation/tickets/`.
+	- If you create a session through the API, session seats are created automatically.
+	- If you create a session directly through Django shell, you must also create the related `SessionSeat` records.
 
 Optional bootstrap via Django shell (minimal base data):
 
 ```bash
-	docker compose exec web pytest -q
+	docker compose exec web python manage.py shell
 ```
 
 ```python
 from django.utils import timezone
 from datetime import timedelta
 from catalog.models import Genre, Movie, Room, Session
-from reservations.models import SeatRow, Seat
+from reservations.models import SeatRow, Seat, SessionSeat
 
 genre = Genre.objects.create(name="Action")
 room = Room.objects.create(name="Room 1", capacity=20)
 row = SeatRow.objects.create(room=room, name="A")
-seat = Seat.objects.create(row=row, number=1)
+seat_1 = Seat.objects.create(row=row, number=1)
+seat_2 = Seat.objects.create(row=row, number=2)
 
 movie = Movie.objects.create(
 	title="Interstellar",
@@ -240,12 +269,19 @@ movie = Movie.objects.create(
 )
 movie.genres.set([genre])
 
-Session.objects.create(
+session = Session.objects.create(
 	movie=movie,
 	room=room,
 	start_time=timezone.now() + timedelta(hours=2),
 	end_time=timezone.now() + timedelta(hours=5),
 )
+
+SessionSeat.objects.create(session=session, seat=seat_1)
+SessionSeat.objects.create(session=session, seat=seat_2)
+
+print("SESSION_ID =", session.id)
+print("SEAT_1_ID =", seat_1.id)
+print("SEAT_2_ID =", seat_2.id)
 ```
 
 ### 1) Register user
@@ -270,10 +306,20 @@ LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/v1/auth/login/" \
 	-d '{"email":"dev1@example.com","password":"StrongPass123!"}')
 
 echo "$LOGIN_RESPONSE"
-export ACCESS_TOKEN=$(echo "$LOGIN_RESPONSE" | python -c "import sys, json; print(json.load(sys.stdin)['access'])")
 ```
 
 Expected: `200 OK` with `access` and `refresh`.
+
+For Postman:
+
+- Copy the `access` value into the `ACCESS_TOKEN` environment variable.
+
+For `curl`:
+
+- Copy the `access` token from `LOGIN_RESPONSE` and export it manually:
+	```bash
+	export ACCESS_TOKEN="<jwt-access-token>"
+	```
 
 ### 3) List movies
 
@@ -324,7 +370,9 @@ curl -s -X POST "$BASE_URL/api/v1/reservation/checkout/" \
 	-d "{\"session_id\":\"$SESSION_ID\",\"seat_ids\":[\"$SEAT_ID\"]}"
 ```
 
-Expected: `200 OK` with `status: PURCHASED`, purchased seats, and generated ticket metadata.
+Expected: `200 OK` with `status: PURCHASED`, `session_id`, and purchased seats summary.
+
+The ticket records are created internally and can be verified via `GET /api/v1/users/me/tickets/`.
 
 ### 8) List user tickets
 
@@ -344,49 +392,91 @@ Expected: `200 OK` paginated ticket list. Optional filters:
 - Seat already reserved/purchased: `409` with `error.code = SEAT_ALREADY_RESERVED`
 - Rate limiting exceeded: `429` with `error.code = THROTTLED`
 
-## API Usage (Quick Curl Reference)
+## Postman Routes Reference
 
-### Register
+### Support routes
 
-```bash
-curl -X POST "$BASE_URL/api/v1/auth/register/" -H "Content-Type: application/json" -d '{"email":"dev2@example.com","username":"dev2","password":"StrongPass123!"}'
-```
+| Method | Route | Auth | Notes |
+| --- | --- | --- | --- |
+| `GET` | `{{BASE_URL}}/health/` | No | Health check for DB, Redis, and Celery |
+| `GET` | `{{BASE_URL}}/api/schema/` | No | OpenAPI schema |
+| `GET` | `{{BASE_URL}}/api/docs/` | No | Swagger UI |
 
-### Login
+### Auth and user routes
 
-```bash
-curl -X POST "$BASE_URL/api/v1/auth/login/" -H "Content-Type: application/json" -d '{"email":"dev2@example.com","password":"StrongPass123!"}'
-```
+| Method | Route | Auth | Body example |
+| --- | --- | --- | --- |
+| `POST` | `{{BASE_URL}}/api/v1/auth/register/` | No | `{"email":"dev1@example.com","username":"dev1","password":"StrongPass123!"}` |
+| `POST` | `{{BASE_URL}}/api/v1/auth/login/` | No | `{"email":"dev1@example.com","password":"StrongPass123!"}` |
+| `GET` | `{{BASE_URL}}/api/v1/auth/me/` | Bearer | none |
+| `GET` | `{{BASE_URL}}/api/v1/users/me/` | Bearer | none |
+| `GET` | `{{BASE_URL}}/api/v1/users/me/tickets/` | Bearer | none |
+| `GET` | `{{BASE_URL}}/api/v1/users/me/tickets/?type=upcoming` | Bearer | none |
+| `GET` | `{{BASE_URL}}/api/v1/users/me/tickets/?type=past` | Bearer | none |
 
-### List movies
+### Catalog routes
 
-```bash
-curl "$BASE_URL/api/v1/catalog/movies/"
-```
+| Method | Route | Auth | Body example |
+| --- | --- | --- | --- |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/genres/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/genres/` | No | `{"name":"Sci-Fi"}` |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | No | `{"name":"Science Fiction"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/movies/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/movies/` | No | `{"title":"Interstellar","genres":["{genre_id}"],"synopsis":"Space exploration.","duration_minutes":169,"release_date":"2014-11-07","poster_url":"https://example.com/interstellar.jpg"}` |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | No | `{"title":"Interstellar Remastered"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/rooms/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/rooms/` | No | `{"name":"Room 2","capacity":80}` |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | No | `{"name":"Room Prime","capacity":100}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/sessions/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/sessions/` | No | `{"movie":"{movie_id}","room":"{room_id}","start_time":"2026-03-23T18:00:00Z","end_time":"2026-03-23T20:55:00Z"}` |
+| `GET` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | No | `{"end_time":"2026-03-23T21:10:00Z"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | No | none |
 
-### List sessions
+Notes:
 
-```bash
-curl "$BASE_URL/api/v1/catalog/sessions/"
-```
+- Updating a `Genre` is useful when it is already linked to multiple movies.
+- Updating a `Session` is supported, but changing its `room` after creation is rejected to avoid inconsistency with existing `SessionSeat` records.
+- Creating a `Session` through the API creates its `SessionSeat` records automatically from the seats already registered for that room.
 
-### Reserve seats
+### Reservation routes
 
-```bash
-curl -X POST "$BASE_URL/api/v1/reservation/sessions/$SESSION_ID/reservations/" -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d "{\"seat_ids\":[\"$SEAT_ID\"]}"
-```
+| Method | Route | Auth | Body example |
+| --- | --- | --- | --- |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seat-rows/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/seat-rows/` | No | `{"room":"{room_id}","name":"A"}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | No | `{"name":"B"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seats/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/seats/` | No | `{"row":"{seat_row_id}","number":1}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | No | `{"number":2}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/session-seats/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/session-seats/` | No | `{"session":"{session_id}","seat":"{seat_id}","status":"AVAILABLE","locked_by_user":null,"lock_expires_at":null}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/session-seats/{session_seat_id}/` | No | none |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/session-seats/{session_seat_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/tickets/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/tickets/` | No | `{"user":"{user_id}","session_seat":"{session_seat_id}"}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/tickets/{ticket_id}/` | No | none |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/tickets/{ticket_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/seats/` | No | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/reservations/` | Bearer | `{"seat_ids":["{{SEAT_ID}}"]}` |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/checkout/` | Bearer | `{"session_id":"{{SESSION_ID}}","seat_ids":["{{SEAT_ID}}"]}` |
 
-### Checkout
+Notes:
 
-```bash
-curl -X POST "$BASE_URL/api/v1/reservation/checkout/" -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d "{\"session_id\":\"$SESSION_ID\",\"seat_ids\":[\"$SEAT_ID\"]}"
-```
-
-### My tickets
-
-```bash
-curl "$BASE_URL/api/v1/users/me/tickets/" -H "Authorization: Bearer $ACCESS_TOKEN"
-```
+- `SeatRow` and `Seat` support full CRUD because they are structural resources.
+- `SessionSeat` and `Ticket` intentionally do not expose `PATCH` endpoints.
+- `SessionSeat` state transitions should happen through reservation and checkout flows, not arbitrary updates.
+- `Ticket` creation is allowed for admin/testing scenarios, but application purchase flow should use checkout.
 
 ## Error Handling
 
@@ -416,7 +506,7 @@ GitHub Actions workflow (`.github/workflows/main.yml`) includes two jobs:
 
 1. **Validate Django API**
 	 - provisions PostgreSQL + Redis services
-	 - installs dependencies with Poetry
+	 - installs dependencies in the CI environment
 	 - runs `manage.py check`, migrations, and full tests
 
 2. **Validate Docker build**

--- a/catalog/serializers.py
+++ b/catalog/serializers.py
@@ -101,6 +101,24 @@ class SessionWriteSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        if (
+            self.instance is not None
+            and "room" in attrs
+            and attrs["room"] != self.instance.room
+        ):
+            raise serializers.ValidationError(
+                {
+                    "room": (
+                        "Updating the room of an existing session is not supported."
+                    )
+                }
+            )
+
+        return attrs
+
     @transaction.atomic
     def create(self, validated_data):
         session = Session.objects.create(**validated_data)

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django_redis import get_redis_connection
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
-from rest_framework.generics import ListCreateAPIView, RetrieveDestroyAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.permissions import AllowAny
 
 from catalog.models import Genre, Movie, Room, Session
@@ -26,6 +26,12 @@ def invalidate_session_list_cache():
     for key in redis.scan_iter("*catalog:sessions:*"):
         redis.delete(key)
 
+
+def invalidate_movie_and_session_list_cache():
+    invalidate_movie_list_cache()
+    invalidate_session_list_cache()
+
+
 @extend_schema(tags=["Catalog"], summary="List or create genres")
 class GenreListCreateView(ListCreateAPIView):
     queryset = Genre.objects.all()
@@ -33,11 +39,20 @@ class GenreListCreateView(ListCreateAPIView):
     permission_classes = [AllowAny]
 
 
-@extend_schema(tags=["Catalog"], summary="Get or delete genre")
-class GenreDetailView(RetrieveDestroyAPIView):
+@extend_schema(tags=["Catalog"], summary="Get, update or delete genre")
+class GenreDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Genre.objects.all()
     serializer_class = GenreSerializer
     permission_classes = [AllowAny]
+
+    def perform_update(self, serializer):
+        serializer.save()
+        invalidate_movie_and_session_list_cache()
+
+    def destroy(self, request, *args, **kwargs):
+        response = super().destroy(request, *args, **kwargs)
+        invalidate_movie_and_session_list_cache()
+        return response
 
 
 @extend_schema(tags=["Catalog"], summary="List or create movies")
@@ -68,8 +83,8 @@ class MovieListCreateView(ListCreateAPIView):
         return response
 
 
-@extend_schema(tags=["Catalog"], summary="Get or delete movie")
-class MovieDetailView(RetrieveDestroyAPIView):
+@extend_schema(tags=["Catalog"], summary="Get, update or delete movie")
+class MovieDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Movie.objects.prefetch_related("genres").all()
     permission_classes = [AllowAny]
 
@@ -78,9 +93,13 @@ class MovieDetailView(RetrieveDestroyAPIView):
             return MovieReadSerializer
         return MovieWriteSerializer
 
+    def perform_update(self, serializer):
+        serializer.save()
+        invalidate_movie_and_session_list_cache()
+
     def destroy(self, request, *args, **kwargs):
         response = super().destroy(request, *args, **kwargs)
-        invalidate_movie_list_cache()
+        invalidate_movie_and_session_list_cache()
         return response
 
 
@@ -91,11 +110,20 @@ class RoomListCreateView(ListCreateAPIView):
     permission_classes = [AllowAny]
 
 
-@extend_schema(tags=["Catalog"], summary="Get or delete room")
-class RoomDetailView(RetrieveDestroyAPIView):
+@extend_schema(tags=["Catalog"], summary="Get, update or delete room")
+class RoomDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
     permission_classes = [AllowAny]
+
+    def perform_update(self, serializer):
+        serializer.save()
+        invalidate_session_list_cache()
+
+    def destroy(self, request, *args, **kwargs):
+        response = super().destroy(request, *args, **kwargs)
+        invalidate_session_list_cache()
+        return response
 
 
 @extend_schema(tags=["Catalog"], summary="List or create sessions")
@@ -128,8 +156,8 @@ class SessionListCreateView(ListCreateAPIView):
         return response
 
 
-@extend_schema(tags=["Catalog"], summary="Get or delete session")
-class SessionDetailView(RetrieveDestroyAPIView):
+@extend_schema(tags=["Catalog"], summary="Get, update or delete session")
+class SessionDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Session.objects.select_related("movie", "room").prefetch_related(
         "movie__genres"
     ).all()
@@ -139,6 +167,10 @@ class SessionDetailView(RetrieveDestroyAPIView):
         if self.request.method == "GET":
             return SessionReadSerializer
         return SessionWriteSerializer
+
+    def perform_update(self, serializer):
+        serializer.save()
+        invalidate_session_list_cache()
 
     def destroy(self, request, *args, **kwargs):
         response = super().destroy(request, *args, **kwargs)

--- a/postman/Cinepolis-Natal-API.postman_collection.json
+++ b/postman/Cinepolis-Natal-API.postman_collection.json
@@ -1,0 +1,1317 @@
+{
+  "info": {
+    "_postman_id": "d0a34dd8-8e26-4d33-b9fd-cinepolis-natal-api",
+    "name": "Cinepolis Natal API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Colecao para validar manualmente os fluxos principais da Cinepolis Natal API."
+  },
+  "item": [
+    {
+      "name": "00 - Support",
+      "item": [
+        {
+          "name": "Health Check",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/health/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "health",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Swagger UI",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/docs/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "docs",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "01 - Auth",
+      "item": [
+        {
+          "name": "Register User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"manual@example.com\",\n  \"username\": \"manual\",\n  \"password\": \"StrongPass123!\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/auth/register/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "register",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.access) pm.collectionVariables.set('ACCESS_TOKEN', data.access);",
+                  "if (data.refresh) pm.collectionVariables.set('REFRESH_TOKEN', data.refresh);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"manual@example.com\",\n  \"password\": \"StrongPass123!\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/auth/login/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Auth Me",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{ACCESS_TOKEN}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/auth/me/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "me",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Users Me",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{ACCESS_TOKEN}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/users/me/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "02 - Catalog",
+      "item": [
+        {
+          "name": "Create Genre",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('GENRE_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Sci-Fi Manual\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/genres/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "genres",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Genre",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Science Fiction Manual\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/genres/{{GENRE_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "genres",
+                "{{GENRE_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Movie",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('MOVIE_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Interstellar Manual\",\n  \"genres\": [\"{{GENRE_ID}}\"],\n  \"synopsis\": \"Space exploration.\",\n  \"duration_minutes\": 169,\n  \"release_date\": \"2014-11-07\",\n  \"poster_url\": \"https://example.com/interstellar.jpg\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/movies/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "movies",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Movie",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Interstellar Manual Updated\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/movies/{{MOVIE_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "movies",
+                "{{MOVIE_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Room",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('ROOM_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Room Manual\",\n  \"capacity\": 20\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/rooms/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "rooms",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Extra Room (For Invalid Session Room Change)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('OTHER_ROOM_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Room Manual Extra\",\n  \"capacity\": 30\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/rooms/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "rooms",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Room",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Room Manual Prime\",\n  \"capacity\": 25\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/rooms/{{ROOM_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "rooms",
+                "{{ROOM_ID}}",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "03 - Reservation Structure",
+      "item": [
+        {
+          "name": "Create Seat Row",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('SEAT_ROW_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"room\": \"{{ROOM_ID}}\",\n  \"name\": \"A\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/seat-rows/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "seat-rows",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Seat Row",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"B\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/seat-rows/{{SEAT_ROW_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "seat-rows",
+                "{{SEAT_ROW_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Seat",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('SEAT_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"row\": \"{{SEAT_ROW_ID}}\",\n  \"number\": 1\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/seats/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "seats",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Seat",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"number\": 2\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/seats/{{SEAT_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "seats",
+                "{{SEAT_ID}}",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "04 - Session Flow",
+      "item": [
+        {
+          "name": "Create Session",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "if (data.id) pm.collectionVariables.set('SESSION_ID', data.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"movie\": \"{{MOVIE_ID}}\",\n  \"room\": \"{{ROOM_ID}}\",\n  \"start_time\": \"2026-04-01T18:00:00Z\",\n  \"end_time\": \"2026-04-01T20:30:00Z\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/sessions/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "sessions",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Session",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/sessions/{{SESSION_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "sessions",
+                "{{SESSION_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Session End Time",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"end_time\": \"2026-04-01T20:45:00Z\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/sessions/{{SESSION_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "sessions",
+                "{{SESSION_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Session Room (Should Fail)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"room\": \"{{OTHER_ROOM_ID}}\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/sessions/{{SESSION_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "sessions",
+                "{{SESSION_ID}}",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "05 - Reservation and Checkout",
+      "item": [
+        {
+          "name": "Get Seat Map",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/seats/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "sessions",
+                "{{SESSION_ID}}",
+                "seats",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Session Seats and Capture SESSION_SEAT_ID",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "const results = Array.isArray(data.results) ? data.results : [];",
+                  "const match = results.find(item => item.session === pm.collectionVariables.get('SESSION_ID') && item.seat === pm.collectionVariables.get('SEAT_ID'));",
+                  "if (match && match.id) pm.collectionVariables.set('SESSION_SEAT_ID', match.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/session-seats/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "session-seats",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Session Seat",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/session-seats/{{SESSION_SEAT_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "session-seats",
+                "{{SESSION_SEAT_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Patch Session Seat (Should Fail)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"PURCHASED\"\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/session-seats/{{SESSION_SEAT_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "session-seats",
+                "{{SESSION_SEAT_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Temporary Reservation",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{ACCESS_TOKEN}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"seat_ids\": [\"{{SEAT_ID}}\"]\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/reservations/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "sessions",
+                "{{SESSION_ID}}",
+                "reservations",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Temporary Reservation Again (Should Conflict)",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{ACCESS_TOKEN}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"seat_ids\": [\"{{SEAT_ID}}\"]\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/reservations/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "sessions",
+                "{{SESSION_ID}}",
+                "reservations",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Checkout",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{ACCESS_TOKEN}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"session_id\": \"{{SESSION_ID}}\",\n  \"seat_ids\": [\"{{SEAT_ID}}\"]\n}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/checkout/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "checkout",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "06 - Tickets",
+      "item": [
+        {
+          "name": "List My Tickets",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{ACCESS_TOKEN}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/users/me/tickets/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "users",
+                "me",
+                "tickets",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Tickets (Admin) and Capture TICKET_ID",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const data = pm.response.json();",
+                  "const results = Array.isArray(data.results) ? data.results : [];",
+                  "const match = results.find(item => item.session_seat === pm.collectionVariables.get('SESSION_SEAT_ID'));",
+                  "if (match && match.id) pm.collectionVariables.set('TICKET_ID', match.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/tickets/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "tickets",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Ticket",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/tickets/{{TICKET_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "tickets",
+                "{{TICKET_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Patch Ticket (Should Fail)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/tickets/{{TICKET_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "tickets",
+                "{{TICKET_ID}}",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "07 - Cleanup",
+      "item": [
+        {
+          "name": "Delete Ticket",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/tickets/{{TICKET_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "tickets",
+                "{{TICKET_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Session Seat",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/session-seats/{{SESSION_SEAT_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "session-seats",
+                "{{SESSION_SEAT_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Session",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/sessions/{{SESSION_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "sessions",
+                "{{SESSION_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Seat",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/seats/{{SEAT_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "seats",
+                "{{SEAT_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Seat Row",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/reservation/seat-rows/{{SEAT_ROW_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reservation",
+                "seat-rows",
+                "{{SEAT_ROW_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Movie",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/movies/{{MOVIE_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "movies",
+                "{{MOVIE_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Genre",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/genres/{{GENRE_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "genres",
+                "{{GENRE_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Room",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/rooms/{{ROOM_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "rooms",
+                "{{ROOM_ID}}",
+                ""
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Extra Room",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/api/v1/catalog/rooms/{{OTHER_ROOM_ID}}/",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "catalog",
+                "rooms",
+                "{{OTHER_ROOM_ID}}",
+                ""
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {
+      "key": "BASE_URL",
+      "value": "http://localhost:8000"
+    },
+    {
+      "key": "ACCESS_TOKEN",
+      "value": ""
+    },
+    {
+      "key": "REFRESH_TOKEN",
+      "value": ""
+    },
+    {
+      "key": "GENRE_ID",
+      "value": ""
+    },
+    {
+      "key": "MOVIE_ID",
+      "value": ""
+    },
+    {
+      "key": "ROOM_ID",
+      "value": ""
+    },
+    {
+      "key": "OTHER_ROOM_ID",
+      "value": ""
+    },
+    {
+      "key": "SEAT_ROW_ID",
+      "value": ""
+    },
+    {
+      "key": "SEAT_ID",
+      "value": ""
+    },
+    {
+      "key": "SESSION_ID",
+      "value": ""
+    },
+    {
+      "key": "SESSION_SEAT_ID",
+      "value": ""
+    },
+    {
+      "key": "TICKET_ID",
+      "value": ""
+    }
+  ]
+}

--- a/postman/Cinepolis-Natal-Local.postman_environment.json
+++ b/postman/Cinepolis-Natal-Local.postman_environment.json
@@ -1,0 +1,66 @@
+{
+  "id": "18fe0bbb-8a47-41a3-91f1-cinepolis-local-env",
+  "name": "Cinepolis Natal Local",
+  "values": [
+    {
+      "key": "BASE_URL",
+      "value": "http://localhost:8000",
+      "enabled": true
+    },
+    {
+      "key": "ACCESS_TOKEN",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "REFRESH_TOKEN",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "GENRE_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "MOVIE_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "ROOM_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "OTHER_ROOM_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "SEAT_ROW_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "SEAT_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "SESSION_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "SESSION_SEAT_ID",
+      "value": "",
+      "enabled": true
+    },
+    {
+      "key": "TICKET_ID",
+      "value": "",
+      "enabled": true
+    }
+  ]
+}

--- a/reservations/serializers.py
+++ b/reservations/serializers.py
@@ -1,6 +1,41 @@
 from rest_framework import serializers
 
-from reservations.models import SessionSeat
+from reservations.models import Seat, SeatRow, SessionSeat, Ticket
+
+
+class SeatRowSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SeatRow
+        fields = ["id", "room", "name"]
+        read_only_fields = ["id"]
+
+
+class SeatSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Seat
+        fields = ["id", "row", "number"]
+        read_only_fields = ["id"]
+
+
+class SessionSeatSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SessionSeat
+        fields = [
+            "id",
+            "session",
+            "seat",
+            "status",
+            "locked_by_user",
+            "lock_expires_at",
+        ]
+        read_only_fields = ["id"]
+
+
+class TicketSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Ticket
+        fields = ["id", "user", "session_seat", "ticket_code", "created_at"]
+        read_only_fields = ["id", "ticket_code", "created_at"]
 
 
 class SessionSeatMapItemSerializer(serializers.ModelSerializer):

--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -2,11 +2,35 @@ from django.urls import path
 
 from reservations.views import (
     CheckoutView,
+    SeatDetailView,
+    SeatListCreateView,
+    SeatRowDetailView,
+    SeatRowListCreateView,
+    SessionSeatDetailView,
+    SessionSeatListCreateView,
     SessionSeatMapView,
+    TicketDetailView,
+    TicketListCreateView,
     TemporarySeatReservationView,
 )
 
 urlpatterns = [
+    path("seat-rows/", SeatRowListCreateView.as_view(), name="seat-row-list-create"),
+    path("seat-rows/<uuid:pk>/", SeatRowDetailView.as_view(), name="seat-row-detail"),
+    path("seats/", SeatListCreateView.as_view(), name="seat-list-create"),
+    path("seats/<uuid:pk>/", SeatDetailView.as_view(), name="seat-detail"),
+    path(
+        "session-seats/",
+        SessionSeatListCreateView.as_view(),
+        name="session-seat-list-create",
+    ),
+    path(
+        "session-seats/<uuid:pk>/",
+        SessionSeatDetailView.as_view(),
+        name="session-seat-detail",
+    ),
+    path("tickets/", TicketListCreateView.as_view(), name="ticket-list-create"),
+    path("tickets/<uuid:pk>/", TicketDetailView.as_view(), name="ticket-detail"),
     path("sessions/<uuid:session_id>/seats/", SessionSeatMapView.as_view(), name="session-seat-map"),
     path("sessions/<uuid:session_id>/reservations/", TemporarySeatReservationView.as_view(), name="temporary-seat-reservation"),
     path("checkout/", CheckoutView.as_view(), name="checkout"),

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -2,7 +2,13 @@ from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
-from rest_framework.generics import GenericAPIView, ListAPIView
+from rest_framework.generics import (
+    GenericAPIView,
+    ListAPIView,
+    ListCreateAPIView,
+    RetrieveUpdateDestroyAPIView,
+    RetrieveDestroyAPIView,
+)
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
@@ -15,11 +21,15 @@ from reservations.exceptions import (
     SeatUnavailableError,
     SessionNotFoundError,
 )
-from reservations.models import SessionSeat
+from reservations.models import Seat, SeatRow, SessionSeat, Ticket
 from reservations.serializers import (
     CheckoutRequestSerializer,
     CheckoutResponseSerializer,
+    SeatRowSerializer,
+    SeatSerializer,
+    SessionSeatSerializer,
     SessionSeatMapItemSerializer,
+    TicketSerializer,
     TemporaryReservationRequestSerializer,
     TemporaryReservationResponseSerializer,
 )
@@ -31,6 +41,78 @@ from reservations.services.checkout_service import (
     InvalidSeatSelectionError as CheckoutInvalidSeatSelectionError,
     ReservationOwnershipError,
 )
+
+
+@extend_schema(tags=["Reservations"], summary="List or create seat rows")
+class SeatRowListCreateView(ListCreateAPIView):
+    queryset = SeatRow.objects.select_related("room").all()
+    serializer_class = SeatRowSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="Get, update or delete seat row")
+class SeatRowDetailView(RetrieveUpdateDestroyAPIView):
+    queryset = SeatRow.objects.select_related("room").all()
+    serializer_class = SeatRowSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="List or create seats")
+class SeatListCreateView(ListCreateAPIView):
+    queryset = Seat.objects.select_related("row", "row__room").all()
+    serializer_class = SeatSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="Get, update or delete seat")
+class SeatDetailView(RetrieveUpdateDestroyAPIView):
+    queryset = Seat.objects.select_related("row", "row__room").all()
+    serializer_class = SeatSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="List or create session seats")
+class SessionSeatListCreateView(ListCreateAPIView):
+    queryset = SessionSeat.objects.select_related(
+        "session", "seat", "seat__row", "seat__row__room", "locked_by_user"
+    ).all()
+    serializer_class = SessionSeatSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="Get or delete session seat")
+class SessionSeatDetailView(RetrieveDestroyAPIView):
+    queryset = SessionSeat.objects.select_related(
+        "session", "seat", "seat__row", "seat__row__room", "locked_by_user"
+    ).all()
+    serializer_class = SessionSeatSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="List or create tickets")
+class TicketListCreateView(ListCreateAPIView):
+    queryset = Ticket.objects.select_related(
+        "user",
+        "session_seat",
+        "session_seat__session",
+        "session_seat__seat",
+        "session_seat__seat__row",
+    ).all()
+    serializer_class = TicketSerializer
+    permission_classes = [AllowAny]
+
+
+@extend_schema(tags=["Reservations"], summary="Get or delete ticket")
+class TicketDetailView(RetrieveDestroyAPIView):
+    queryset = Ticket.objects.select_related(
+        "user",
+        "session_seat",
+        "session_seat__session",
+        "session_seat__seat",
+        "session_seat__seat__row",
+    ).all()
+    serializer_class = TicketSerializer
+    permission_classes = [AllowAny]
 
 
 @extend_schema_view(

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -159,6 +159,76 @@ class TestCatalogApi:
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Genre.objects.filter(id=genre.id).exists()
+
+    def test_update_genre_returns_200(self, api_client, genre, movie):
+        response = api_client.patch(
+            f"/api/v1/catalog/genres/{genre.id}/",
+            {"name": "Drama Updated"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["name"] == "Drama Updated"
+        genre.refresh_from_db()
+        assert genre.name == "Drama Updated"
+        movie.refresh_from_db()
+        assert movie.genres.filter(name="Drama Updated").exists()
+
+    def test_update_movie_returns_200(self, api_client, movie):
+        response = api_client.patch(
+            f"/api/v1/catalog/movies/{movie.id}/",
+            {"title": "The Godfather Remastered"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        movie.refresh_from_db()
+        assert movie.title == "The Godfather Remastered"
+
+    def test_update_room_returns_200(self, api_client, room):
+        response = api_client.patch(
+            f"/api/v1/catalog/rooms/{room.id}/",
+            {"name": "Room Prime", "capacity": 90},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["name"] == "Room Prime"
+        assert response.data["capacity"] == 90
+        room.refresh_from_db()
+        assert room.name == "Room Prime"
+        assert room.capacity == 90
+
+    def test_update_session_returns_200(self, api_client, session):
+        new_end_time = (session.end_time + timedelta(minutes=30)).isoformat().replace(
+            "+00:00",
+            "Z",
+        )
+
+        response = api_client.patch(
+            f"/api/v1/catalog/sessions/{session.id}/",
+            {"end_time": new_end_time},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        session.refresh_from_db()
+        assert session.end_time == timezone.datetime.fromisoformat(
+            new_end_time.replace("Z", "+00:00")
+        )
+
+    def test_update_session_should_reject_room_change(self, api_client, session):
+        other_room = Room.objects.create(name="Room 2", capacity=80)
+
+        response = api_client.patch(
+            f"/api/v1/catalog/sessions/{session.id}/",
+            {"room": str(other_room.id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["error"]["code"] == "VALIDATION_FAILED"
+        assert "room" in response.data["error"]["details"]
         
     def test_list_movies_should_use_cache_on_second_request(self, api_client, movie):
         cache.clear()
@@ -264,6 +334,76 @@ class TestCatalogApi:
         assert second_response.status_code == status.HTTP_200_OK
         assert second_response.data["count"] == initial_count - 1
 
+    def test_genre_update_should_invalidate_movie_and_session_list_caches(
+        self,
+        api_client,
+        genre,
+        session,
+    ):
+        cache.clear()
+
+        first_movie_response = api_client.get("/api/v1/catalog/movies/")
+        first_session_response = api_client.get("/api/v1/catalog/sessions/")
+
+        assert first_movie_response.status_code == status.HTTP_200_OK
+        assert first_session_response.status_code == status.HTTP_200_OK
+        assert first_movie_response.data["results"][0]["genres"][0]["name"] == "Crime"
+
+        update_response = api_client.patch(
+            f"/api/v1/catalog/genres/{genre.id}/",
+            {"name": "Drama Updated"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+
+        second_movie_response = api_client.get("/api/v1/catalog/movies/")
+        second_session_response = api_client.get("/api/v1/catalog/sessions/")
+
+        assert second_movie_response.status_code == status.HTTP_200_OK
+        assert second_session_response.status_code == status.HTTP_200_OK
+        movie_genre_names = [
+            item["name"]
+            for item in second_movie_response.data["results"][0]["genres"]
+        ]
+        session_genre_names = [
+            item["name"]
+            for item in second_session_response.data["results"][0]["movie"]["genres"]
+        ]
+        assert "Drama Updated" in movie_genre_names
+        assert "Drama Updated" in session_genre_names
+
+    def test_movie_update_should_invalidate_movie_and_session_list_caches(
+        self,
+        api_client,
+        movie,
+        session,
+    ):
+        cache.clear()
+
+        first_movie_response = api_client.get("/api/v1/catalog/movies/")
+        first_session_response = api_client.get("/api/v1/catalog/sessions/")
+
+        assert first_movie_response.status_code == status.HTTP_200_OK
+        assert first_session_response.status_code == status.HTTP_200_OK
+
+        update_response = api_client.patch(
+            f"/api/v1/catalog/movies/{movie.id}/",
+            {"title": "The Godfather Updated"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+
+        second_movie_response = api_client.get("/api/v1/catalog/movies/")
+        second_session_response = api_client.get("/api/v1/catalog/sessions/")
+
+        assert second_movie_response.status_code == status.HTTP_200_OK
+        assert second_session_response.status_code == status.HTTP_200_OK
+        assert second_movie_response.data["results"][0]["title"] == "The Godfather Updated"
+        assert (
+            second_session_response.data["results"][0]["movie"]["title"]
+            == "The Godfather Updated"
+        )
+
     def test_session_list_cache_should_be_invalidated_after_session_deletion(
         self,
         api_client,
@@ -283,3 +423,52 @@ class TestCatalogApi:
         second_response = api_client.get("/api/v1/catalog/sessions/")
         assert second_response.status_code == status.HTTP_200_OK
         assert second_response.data["count"] == initial_count - 1
+
+    def test_room_update_should_invalidate_session_list_cache(
+        self,
+        api_client,
+        room,
+        session,
+    ):
+        cache.clear()
+
+        first_response = api_client.get("/api/v1/catalog/sessions/")
+        assert first_response.status_code == status.HTTP_200_OK
+        assert first_response.data["results"][0]["room"]["name"] == "Room 1"
+
+        update_response = api_client.patch(
+            f"/api/v1/catalog/rooms/{room.id}/",
+            {"name": "Room Prime", "capacity": 70},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+
+        second_response = api_client.get("/api/v1/catalog/sessions/")
+        assert second_response.status_code == status.HTTP_200_OK
+        assert second_response.data["results"][0]["room"]["name"] == "Room Prime"
+
+    def test_session_update_should_invalidate_session_list_cache(
+        self,
+        api_client,
+        session,
+    ):
+        cache.clear()
+
+        first_response = api_client.get("/api/v1/catalog/sessions/")
+        assert first_response.status_code == status.HTTP_200_OK
+
+        new_end_time = (session.end_time + timedelta(minutes=30)).isoformat().replace(
+            "+00:00",
+            "Z",
+        )
+
+        update_response = api_client.patch(
+            f"/api/v1/catalog/sessions/{session.id}/",
+            {"end_time": new_end_time},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+
+        second_response = api_client.get("/api/v1/catalog/sessions/")
+        assert second_response.status_code == status.HTTP_200_OK
+        assert second_response.data["results"][0]["end_time"] == new_end_time

--- a/tests/integration/test_reservations_admin_crud_api.py
+++ b/tests/integration/test_reservations_admin_crud_api.py
@@ -1,0 +1,269 @@
+import pytest
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.test import override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from catalog.models import Movie, Room, Session
+from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus
+from reservations.views import (
+    SeatDetailView,
+    SeatListCreateView,
+    SeatRowDetailView,
+    SeatRowListCreateView,
+    SessionSeatDetailView,
+    SessionSeatListCreateView,
+    TicketDetailView,
+    TicketListCreateView,
+)
+from users.models import User
+
+
+REST_FRAMEWORK_OVERRIDE = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
+    ],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+    "DEFAULT_THROTTLE_CLASSES": [],
+    "DEFAULT_THROTTLE_RATES": {},
+    "EXCEPTION_HANDLER": "cinepolis_natal_api.exception_handler.standardized_exception_handler",
+}
+
+
+@pytest.fixture(autouse=True)
+def disable_throttling_for_module():
+    original_seat_row_list_throttles = SeatRowListCreateView.throttle_classes
+    original_seat_row_detail_throttles = SeatRowDetailView.throttle_classes
+    original_seat_list_throttles = SeatListCreateView.throttle_classes
+    original_seat_detail_throttles = SeatDetailView.throttle_classes
+    original_session_seat_list_throttles = SessionSeatListCreateView.throttle_classes
+    original_session_seat_detail_throttles = SessionSeatDetailView.throttle_classes
+    original_ticket_list_throttles = TicketListCreateView.throttle_classes
+    original_ticket_detail_throttles = TicketDetailView.throttle_classes
+
+    SeatRowListCreateView.throttle_classes = []
+    SeatRowDetailView.throttle_classes = []
+    SeatListCreateView.throttle_classes = []
+    SeatDetailView.throttle_classes = []
+    SessionSeatListCreateView.throttle_classes = []
+    SessionSeatDetailView.throttle_classes = []
+    TicketListCreateView.throttle_classes = []
+    TicketDetailView.throttle_classes = []
+
+    cache.clear()
+    with override_settings(REST_FRAMEWORK=REST_FRAMEWORK_OVERRIDE):
+        yield
+    cache.clear()
+
+    SeatRowListCreateView.throttle_classes = original_seat_row_list_throttles
+    SeatRowDetailView.throttle_classes = original_seat_row_detail_throttles
+    SeatListCreateView.throttle_classes = original_seat_list_throttles
+    SeatDetailView.throttle_classes = original_seat_detail_throttles
+    SessionSeatListCreateView.throttle_classes = original_session_seat_list_throttles
+    SessionSeatDetailView.throttle_classes = original_session_seat_detail_throttles
+    TicketListCreateView.throttle_classes = original_ticket_list_throttles
+    TicketDetailView.throttle_classes = original_ticket_detail_throttles
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def room():
+    return Room.objects.create(name="Room CRUD", capacity=50)
+
+
+@pytest.fixture
+def movie():
+    return Movie.objects.create(
+        title="Movie CRUD",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-29",
+        poster_url="https://example.com/movie-crud.jpg",
+    )
+
+
+@pytest.fixture
+def session(movie, room):
+    now = timezone.now()
+    return Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=now + timedelta(hours=1),
+        end_time=now + timedelta(hours=3),
+    )
+
+
+@pytest.mark.django_db
+def test_seat_row_create_retrieve_delete_endpoints(api_client, room):
+    create_response = api_client.post(
+        "/api/v1/reservation/seat-rows/",
+        {"room": str(room.id), "name": "a"},
+        format="json",
+    )
+
+    assert create_response.status_code == status.HTTP_201_CREATED
+    seat_row_id = create_response.data["id"]
+    assert create_response.data["name"] == "A"
+
+    retrieve_response = api_client.get(
+        f"/api/v1/reservation/seat-rows/{seat_row_id}/",
+    )
+
+    assert retrieve_response.status_code == status.HTTP_200_OK
+    assert retrieve_response.data["name"] == "A"
+
+    patch_response = api_client.patch(
+        f"/api/v1/reservation/seat-rows/{seat_row_id}/",
+        {"name": "b"},
+        format="json",
+    )
+
+    assert patch_response.status_code == status.HTTP_200_OK
+    assert patch_response.data["name"] == "B"
+
+    delete_response = api_client.delete(
+        f"/api/v1/reservation/seat-rows/{seat_row_id}/"
+    )
+
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_seat_create_retrieve_delete_endpoints(api_client, room):
+    seat_row = SeatRow.objects.create(room=room, name="A")
+
+    create_response = api_client.post(
+        "/api/v1/reservation/seats/",
+        {"row": str(seat_row.id), "number": 1},
+        format="json",
+    )
+
+    assert create_response.status_code == status.HTTP_201_CREATED
+    seat_id = create_response.data["id"]
+
+    retrieve_response = api_client.get(
+        f"/api/v1/reservation/seats/{seat_id}/",
+    )
+
+    assert retrieve_response.status_code == status.HTTP_200_OK
+    assert retrieve_response.data["number"] == 1
+
+    patch_response = api_client.patch(
+        f"/api/v1/reservation/seats/{seat_id}/",
+        {"number": 2},
+        format="json",
+    )
+
+    assert patch_response.status_code == status.HTTP_200_OK
+    assert patch_response.data["number"] == 2
+
+    delete_response = api_client.delete(f"/api/v1/reservation/seats/{seat_id}/")
+
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_session_seat_create_retrieve_delete_endpoints(api_client, room, session):
+    seat_row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=seat_row, number=1)
+
+    create_response = api_client.post(
+        "/api/v1/reservation/session-seats/",
+        {
+            "session": str(session.id),
+            "seat": str(seat.id),
+            "status": SessionSeatStatus.AVAILABLE,
+            "locked_by_user": None,
+            "lock_expires_at": None,
+        },
+        format="json",
+    )
+
+    assert create_response.status_code == status.HTTP_201_CREATED
+    session_seat_id = create_response.data["id"]
+
+    retrieve_response = api_client.get(
+        f"/api/v1/reservation/session-seats/{session_seat_id}/",
+    )
+
+    assert retrieve_response.status_code == status.HTTP_200_OK
+    assert retrieve_response.data["status"] == SessionSeatStatus.AVAILABLE
+
+    patch_response = api_client.patch(
+        f"/api/v1/reservation/session-seats/{session_seat_id}/",
+        {"status": SessionSeatStatus.PURCHASED},
+        format="json",
+    )
+
+    assert patch_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    delete_response = api_client.delete(
+        f"/api/v1/reservation/session-seats/{session_seat_id}/"
+    )
+
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_ticket_create_list_retrieve_delete_endpoints(api_client, room, session):
+    user = User.objects.create_user(
+        email="ticket-crud@example.com",
+        username="ticketcrud",
+        password="StrongPass123",
+    )
+    seat_row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=seat_row, number=1)
+
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.PURCHASED,
+    )
+
+    create_response = api_client.post(
+        "/api/v1/reservation/tickets/",
+        {
+            "user": str(user.id),
+            "session_seat": str(session_seat.id),
+        },
+        format="json",
+    )
+
+    assert create_response.status_code == status.HTTP_201_CREATED
+    ticket_id = create_response.data["id"]
+    assert create_response.data["ticket_code"]
+
+    retrieve_response = api_client.get(f"/api/v1/reservation/tickets/{ticket_id}/")
+
+    assert retrieve_response.status_code == status.HTTP_200_OK
+    assert retrieve_response.data["id"] == ticket_id
+
+    list_response = api_client.get("/api/v1/reservation/tickets/")
+
+    assert list_response.status_code == status.HTTP_200_OK
+    assert list_response.data["count"] == 1
+
+    patch_response = api_client.patch(
+        f"/api/v1/reservation/tickets/{ticket_id}/",
+        {"user": str(user.id)},
+        format="json",
+    )
+
+    assert patch_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    delete_response = api_client.delete(
+        f"/api/v1/reservation/tickets/{ticket_id}/"
+    )
+
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT


### PR DESCRIPTION
## Objective

Expand the administrative CRUD surface of the API in a way that is operationally useful, while preserving business consistency for transactional resources. This change also improves the manual testing experience by updating the README and adding ready-to-import Postman assets.

## What was done

### 1. Reservation admin CRUD endpoints

Implemented administrative endpoints for reservation-related resources under `/api/v1/reservation/`:

- Added CRUD for `SeatRow`.
- Added CRUD for `Seat`.
- Added list/create/retrieve/delete for `SessionSeat`.
- Added list/create/retrieve/delete for `Ticket`.

This keeps structural resources editable while avoiding unsafe generic updates for transactional resources.

### 2. Reservation serializers and views

Added the missing serializers and views required for these resources:

- `SeatRowSerializer`
- `SeatSerializer`
- `SessionSeatSerializer`
- `TicketSerializer`

Also registered the corresponding routes in `reservations/urls.py`.

### 3. Safe update policy for structural resources

Expanded update support in the catalog for resources where editing is operationally useful:

- `Genre`
- `Movie`
- `Room`
- `Session`

This supports real-world correction flows, such as renaming a genre already linked to many movies, without forcing destructive deletion/recreation.

### 4. Session safety guard

Added validation to prevent changing the `room` of an existing `Session`.

This avoids an inconsistent state where a session already has generated `SessionSeat` records for one room and is later moved to another room through a generic PATCH.

### 5. Cache invalidation on update/delete

Adjusted catalog cache invalidation so cached movie/session lists stay correct after updates and deletes affecting nested data:

- genre updates invalidate movie/session list cache
- movie updates invalidate movie/session list cache
- room updates invalidate session list cache
- session updates invalidate session list cache

### 6. Integration test coverage

Added and updated integration coverage for the new behavior:

- Added reservation admin CRUD integration tests.
- Added catalog update tests.
- Added cache invalidation tests for update flows.
- Added validation coverage for rejecting session room changes.
- Kept `SessionSeat` and `Ticket` without PATCH coverage intentionally, asserting `405 Method Not Allowed`.

### 7. Documentation and manual testing improvements

Updated `README.md` to reflect the actual current API contract:

- catalog now documents update support
- reservation admin resources are described with the correct CRUD granularity
- manual testing guide was corrected
- Docker-only local commands were preserved
- Postman-oriented manual testing guidance was added

### 8. Postman assets

Added importable Postman files under `postman/`:

- `Cinepolis-Natal-API.postman_collection.json`
- `Cinepolis-Natal-Local.postman_environment.json`

These assets include:

- request ordering by flow
- token capture
- automatic capture of created IDs
- manual validation of success and adverse scenarios

## How to test

### Automated validation

Run the full test suite with Docker:

```bash
docker compose exec web pytest -q
```
### Optional targeted runs:

```bash
docker compose exec web pytest -q
```

### Manual validation

1. Start the stack:

```
docker compose up --build
```

2. Import into Postman:

- `postman/Cinepolis-Natal-API.postman_collection.json`
- `postman/Cinepolis-Natal-Local.postman_environment.json`

3. Run the collection in this order:

- `00 - Support`
- `01 - Auth`
- `02 - Catalog`
- `03 - Reservation Structure`
- `04 - Session Flow`
- `05 - Reservation and Checkout`
- `06 - Tickets`
- `07 - Cleanup`

4. Validate the main expected behaviors:

- `Genre`, `Movie`, `Room`, and `Session` accept PATCH where appropriate.
- `Session` rejects room changes with `400`.
- `SeatRow` and `Seat` support full CRUD.
- `SessionSeat` and `Ticket` reject PATCH with `405`.
- temporary reservation works
- repeated reservation conflicts
- checkout purchases the seat
- ticket appears in `GET /api/v1/users/me/tickets/`

## Expected Result

- Reservation admin resources become manageable through dedicated endpoints.
- Structural resources can be safely corrected without destructive recreation.
- Transactional resources remain protected from unsafe generic updates.
- Catalog caches remain consistent after update/delete operations.
- Manual testing becomes reproducible through README instructions and Postman assets.
- Full Docker-based test suite passes successfully.

## Notes

- `SessionSeat` and `Ticket` intentionally do not expose generic update endpoints.
- Local documentation avoids Poetry-based execution paths and keeps Docker as the supported local workflow.
- The branch history was rewritten to keep the final commits coherent and focused.