### PR TITLE
feat: enrich ticket responses for confirmation and my tickets

### DIFF
--- a/backend/reservations/models.py
+++ b/backend/reservations/models.py
@@ -247,33 +247,42 @@ class Ticket(models.Model):
         return base_price.quantize(Decimal("0.01"))
 
     def clean(self):
+        errors = {}
+
         if self.session_seat_id and self.user_id:
             if self.session_seat.status != SessionSeatStatus.PURCHASED:
-                raise ValidationError(
-                    {
-                        "session_seat": (
-                            "Tickets can only be created for purchased session seats."
-                        )
-                    }
+                errors["session_seat"] = (
+                    "Tickets can only be created for purchased session seats."
                 )
 
             if self.session_seat.locked_by_user is not None:
-                raise ValidationError(
-                    {
-                        "session_seat": (
-                            "Purchased session seats linked to tickets cannot keep a locked user."
-                        )
-                    }
+                errors["session_seat"] = (
+                    "Purchased session seats linked to tickets cannot keep a locked user."
                 )
 
             if self.session_seat.lock_expires_at is not None:
-                raise ValidationError(
-                    {
-                        "session_seat": (
-                            "Purchased session seats linked to tickets cannot keep a lock expiration."
-                        )
-                    }
+                errors["session_seat"] = (
+                    "Purchased session seats linked to tickets cannot keep a lock expiration."
                 )
+
+        if self.session_seat_id and self.ticket_type in TicketType.values:
+            expected_amount = self.calculate_amount(
+                self.session_seat.session.base_price,
+                self.ticket_type,
+            )
+
+            if self.amount_paid is None:
+                errors["amount_paid"] = "Ticket amount paid is required."
+            elif (
+                Decimal(self.amount_paid).quantize(Decimal("0.01"))
+                != expected_amount
+            ):
+                errors["amount_paid"] = (
+                    "Ticket amount paid must match the session price and ticket type."
+                )
+
+        if errors:
+            raise ValidationError(errors)
 
     def save(self, *args, **kwargs):
         if not self.ticket_code:

--- a/backend/reservations/serializers.py
+++ b/backend/reservations/serializers.py
@@ -44,6 +44,11 @@ class SessionSeatSerializer(serializers.ModelSerializer):
 
 
 class TicketSerializer(serializers.ModelSerializer):
+    movie = serializers.SerializerMethodField()
+    session = serializers.SerializerMethodField()
+    room = serializers.SerializerMethodField()
+    seat = serializers.SerializerMethodField()
+
     class Meta:
         model = Ticket
         fields = [
@@ -55,8 +60,44 @@ class TicketSerializer(serializers.ModelSerializer):
             "amount_paid",
             "payment_method",
             "created_at",
+            "movie",
+            "session",
+            "room",
+            "seat",
         ]
         read_only_fields = ["id", "ticket_code", "created_at"]
+
+    def get_movie(self, obj):
+        movie = obj.session_seat.session.movie
+        return {
+            "id": str(movie.id),
+            "title": movie.title,
+            "poster_url": movie.poster_url,
+        }
+
+    def get_session(self, obj):
+        session = obj.session_seat.session
+        return {
+            "id": str(session.id),
+            "start_time": session.start_time,
+            "end_time": session.end_time,
+        }
+
+    def get_room(self, obj):
+        room = obj.session_seat.session.room
+        return {
+            "id": str(room.id),
+            "name": room.name,
+        }
+
+    def get_seat(self, obj):
+        seat = obj.session_seat.seat
+        return {
+            "id": str(seat.id),
+            "row": seat.row.name,
+            "number": seat.number,
+            "identifier": f"{seat.row.name}{seat.number}",
+        }
 
 
 class SessionSeatMapItemSerializer(serializers.ModelSerializer):
@@ -236,6 +277,10 @@ class CheckoutTicketResponseSerializer(serializers.Serializer):
     ticket_type = serializers.CharField()
     amount_paid = serializers.DecimalField(max_digits=8, decimal_places=2)
     payment_method = serializers.CharField()
+    movie = serializers.DictField()
+    session = serializers.DictField()
+    room = serializers.DictField()
+    seat = serializers.DictField()
 
 
 class CheckoutResponseSerializer(serializers.Serializer):

--- a/backend/reservations/services/checkout_service.py
+++ b/backend/reservations/services/checkout_service.py
@@ -55,7 +55,9 @@ class CheckoutService:
 
         session_seats = list(
             SessionSeat.objects.select_for_update()
-            .select_related("seat", "seat__row", "session")
+            .select_related(
+                "seat", "seat__row", "session", "session__movie", "session__room"
+            )
             .filter(id__in=ordered_session_seat_ids)
             .order_by("id")
         )
@@ -154,6 +156,28 @@ class CheckoutService:
                     "ticket_type": ticket.ticket_type,
                     "amount_paid": ticket.amount_paid,
                     "payment_method": ticket.payment_method,
+                    "movie": {
+                        "id": str(ticket.session_seat.session.movie_id),
+                        "title": ticket.session_seat.session.movie.title,
+                    },
+                    "session": {
+                        "id": str(ticket.session_seat.session_id),
+                        "start_time": ticket.session_seat.session.start_time,
+                        "end_time": ticket.session_seat.session.end_time,
+                    },
+                    "room": {
+                        "id": str(ticket.session_seat.session.room_id),
+                        "name": ticket.session_seat.session.room.name,
+                    },
+                    "seat": {
+                        "id": str(ticket.session_seat.seat_id),
+                        "row": ticket.session_seat.seat.row.name,
+                        "number": ticket.session_seat.seat.number,
+                        "identifier": (
+                            f"{ticket.session_seat.seat.row.name}"
+                            f"{ticket.session_seat.seat.number}"
+                        ),
+                    },
                 }
                 for ticket in tickets
             ],

--- a/backend/reservations/views.py
+++ b/backend/reservations/views.py
@@ -107,6 +107,8 @@ class TicketListCreateView(ListCreateAPIView):
         "user",
         "session_seat",
         "session_seat__session",
+        "session_seat__session__movie",
+        "session_seat__session__room",
         "session_seat__seat",
         "session_seat__seat__row",
     ).all()
@@ -120,6 +122,8 @@ class TicketDetailView(RetrieveDestroyAPIView):
         "user",
         "session_seat",
         "session_seat__session",
+        "session_seat__session__movie",
+        "session_seat__session__room",
         "session_seat__seat",
         "session_seat__seat__row",
     ).all()

--- a/backend/tests/integration/test_checkout_api.py
+++ b/backend/tests/integration/test_checkout_api.py
@@ -132,6 +132,23 @@ def test_checkout_should_purchase_single_reserved_seat_with_ticket_type(
     assert response.data["tickets"][0]["ticket_type"] == ticket_type
     assert response.data["tickets"][0]["amount_paid"] == expected_amount
     assert response.data["tickets"][0]["payment_method"] == "pix"
+    assert response.data["tickets"][0]["movie"] == {
+        "id": str(context["session"].movie_id),
+        "title": context["session"].movie.title,
+    }
+    assert response.data["tickets"][0]["session"]["id"] == str(context["session"].id)
+    assert response.data["tickets"][0]["session"]["start_time"] is not None
+    assert response.data["tickets"][0]["session"]["end_time"] is not None
+    assert response.data["tickets"][0]["room"] == {
+        "id": str(context["session"].room_id),
+        "name": context["session"].room.name,
+    }
+    assert response.data["tickets"][0]["seat"] == {
+        "id": str(context["seats"][0].id),
+        "row": context["seats"][0].row.name,
+        "number": context["seats"][0].number,
+        "identifier": "A1",
+    }
 
     session_seat = context["session_seats"][0]
     session_seat.refresh_from_db()

--- a/backend/tests/integration/test_reservations_admin_crud_api.py
+++ b/backend/tests/integration/test_reservations_admin_crud_api.py
@@ -21,7 +21,6 @@ from reservations.views import (
 )
 from users.models import User
 
-
 REST_FRAMEWORK_OVERRIDE = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
@@ -245,11 +244,20 @@ def test_ticket_create_list_retrieve_delete_endpoints(api_client, room, session)
     assert create_response.status_code == status.HTTP_201_CREATED
     ticket_id = create_response.data["id"]
     assert create_response.data["ticket_code"]
+    assert create_response.data["ticket_type"] == "inteira"
+    assert create_response.data["amount_paid"] == "30.00"
+    assert create_response.data["payment_method"] == "pix"
+    assert create_response.data["movie"]["id"] == str(session.movie_id)
+    assert create_response.data["session"]["id"] == str(session.id)
+    assert create_response.data["room"]["id"] == str(room.id)
+    assert create_response.data["seat"]["identifier"] == "A1"
 
     retrieve_response = api_client.get(f"/api/v1/reservation/tickets/{ticket_id}/")
 
     assert retrieve_response.status_code == status.HTTP_200_OK
     assert retrieve_response.data["id"] == ticket_id
+    assert retrieve_response.data["ticket_type"] == "inteira"
+    assert retrieve_response.data["amount_paid"] == "30.00"
 
     list_response = api_client.get("/api/v1/reservation/tickets/")
 

--- a/backend/tests/integration/test_ticket_model.py
+++ b/backend/tests/integration/test_ticket_model.py
@@ -1,6 +1,8 @@
-import pytest
 from decimal import Decimal
+
+import pytest
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from catalog.models import Movie, Room, Session
@@ -58,10 +60,13 @@ def test_should_create_ticket_for_purchased_seat():
     assert ticket.id is not None
     assert ticket.ticket_code is not None
     assert ticket.session_seat == session_seat
+    assert ticket.ticket_type == "inteira"
+    assert ticket.amount_paid == Decimal("30.00")
+    assert ticket.payment_method == "pix"
 
 
 @pytest.mark.django_db
-def test_should_preserve_explicit_zero_amount_ticket():
+def test_should_not_allow_explicit_zero_amount_when_price_is_not_zero():
     user = get_user_model().objects.create_user(
         email="comp@test.com",
         username="comp_ticket",
@@ -94,16 +99,16 @@ def test_should_preserve_explicit_zero_amount_ticket():
         status=SessionSeatStatus.PURCHASED,
     )
 
-    ticket = Ticket.objects.create(
-        user=user,
-        session_seat=session_seat,
-        ticket_type="inteira",
-        amount_paid="0.00",
-        payment_method="pix",
-    )
+    with pytest.raises(ValidationError) as exc_info:
+        Ticket.objects.create(
+            user=user,
+            session_seat=session_seat,
+            ticket_type="inteira",
+            amount_paid="0.00",
+            payment_method="pix",
+        )
 
-    ticket.refresh_from_db()
-    assert ticket.amount_paid == Decimal("0.00")
+    assert "amount_paid" in exc_info.value.message_dict
 
 
 @pytest.mark.django_db
@@ -148,6 +153,52 @@ def test_should_not_allow_ticket_for_non_purchased_seat():
             amount_paid="30.00",
             payment_method="pix",
         )
+
+
+@pytest.mark.django_db
+def test_should_not_allow_ticket_with_invalid_amount_paid():
+    user = get_user_model().objects.create_user(
+        email="invalid-amount@test.com",
+        username="invalid_amount_ticket",
+        password="123456",
+    )
+
+    room = Room.objects.create(name="Invalid Amount Room", capacity=100)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+
+    movie = Movie.objects.create(
+        title="Invalid Amount Movie",
+        synopsis="...",
+        duration_minutes=120,
+        release_date="2026-01-01",
+        poster_url="http://test.com",
+    )
+
+    session = Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=timezone.now(),
+        end_time=timezone.now(),
+        base_price="30.00",
+    )
+
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.PURCHASED,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        Ticket.objects.create(
+            user=user,
+            session_seat=session_seat,
+            ticket_type="meia",
+            amount_paid="30.00",
+            payment_method="pix",
+        )
+
+    assert "amount_paid" in exc_info.value.message_dict
 
 
 @pytest.mark.django_db

--- a/backend/tests/integration/test_user_tickets_api.py
+++ b/backend/tests/integration/test_user_tickets_api.py
@@ -54,12 +54,12 @@ def test_should_return_only_authenticated_user_tickets():
         status=SessionSeatStatus.PURCHASED,
     )
 
-    Ticket.objects.create(
+    ticket = Ticket.objects.create(
         user=user1,
         session_seat=session_seat,
-        ticket_type="inteira",
-        amount_paid="30.00",
-        payment_method="pix",
+        ticket_type="meia",
+        amount_paid="15.00",
+        payment_method="cartao_credito",
     )
 
     # Ticket de outro usuário (não deve aparecer)
@@ -80,6 +80,31 @@ def test_should_return_only_authenticated_user_tickets():
 
     assert response.status_code == 200
     assert response.data["count"] == 1
+
+    ticket_payload = response.data["results"][0]
+    assert ticket_payload["ticket_id"] == str(ticket.id)
+    assert ticket_payload["ticket_code"] == ticket.ticket_code
+    assert ticket_payload["ticket_type"] == "meia"
+    assert ticket_payload["amount_paid"] == "15.00"
+    assert ticket_payload["payment_method"] == "cartao_credito"
+    assert ticket_payload["session"]["id"] == str(session.id)
+    assert ticket_payload["session"]["start_time"] is not None
+    assert ticket_payload["session"]["end_time"] is not None
+    assert ticket_payload["room"] == {
+        "id": str(room.id),
+        "name": room.name,
+    }
+    assert ticket_payload["movie"] == {
+        "id": str(movie.id),
+        "title": movie.title,
+        "poster_url": movie.poster_url,
+    }
+    assert ticket_payload["seat"] == {
+        "id": str(seat.id),
+        "row": row.name,
+        "number": seat.number,
+        "identifier": "A1",
+    }
 
 
 @pytest.mark.django_db
@@ -154,6 +179,11 @@ def test_should_return_only_upcoming_tickets():
 
     assert response.status_code == 200
     assert response.data["count"] == 1
+    ticket_payload = response.data["results"][0]
+    assert ticket_payload["session"]["id"] == str(future_session.id)
+    assert ticket_payload["room"]["name"] == room.name
+    assert ticket_payload["movie"]["poster_url"] == movie.poster_url
+    assert ticket_payload["seat"]["identifier"] == "A1"
 
 
 @pytest.mark.django_db
@@ -204,6 +234,11 @@ def test_should_return_only_past_tickets():
 
     assert response.status_code == 200
     assert response.data["count"] == 1
+    ticket_payload = response.data["results"][0]
+    assert ticket_payload["session"]["id"] == str(past_session.id)
+    assert ticket_payload["room"]["name"] == room.name
+    assert ticket_payload["movie"]["title"] == movie.title
+    assert ticket_payload["seat"]["identifier"] == "A1"
 
 
 @pytest.mark.django_db

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -68,6 +68,11 @@ class UserTicketSessionSerializer(serializers.Serializer):
     end_time = serializers.DateTimeField()
 
 
+class UserTicketRoomSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    name = serializers.CharField()
+
+
 class UserTicketMovieSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     title = serializers.CharField()
@@ -78,6 +83,7 @@ class UserTicketSeatSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     row = serializers.CharField()
     number = serializers.IntegerField()
+    identifier = serializers.CharField()
 
 
 class UserTicketSerializer(serializers.ModelSerializer):
@@ -86,6 +92,7 @@ class UserTicketSerializer(serializers.ModelSerializer):
     created_at = serializers.DateTimeField()
 
     session = serializers.SerializerMethodField()
+    room = serializers.SerializerMethodField()
     movie = serializers.SerializerMethodField()
     seat = serializers.SerializerMethodField()
 
@@ -99,6 +106,7 @@ class UserTicketSerializer(serializers.ModelSerializer):
             "payment_method",
             "created_at",
             "session",
+            "room",
             "movie",
             "seat",
         )
@@ -110,6 +118,14 @@ class UserTicketSerializer(serializers.ModelSerializer):
             "id": str(session.id),
             "start_time": session.start_time,
             "end_time": session.end_time,
+        }
+
+    @extend_schema_field(UserTicketRoomSerializer)
+    def get_room(self, obj):
+        room = obj.session_seat.session.room
+        return {
+            "id": str(room.id),
+            "name": room.name,
         }
 
     @extend_schema_field(UserTicketMovieSerializer)
@@ -128,4 +144,5 @@ class UserTicketSerializer(serializers.ModelSerializer):
             "id": str(seat.id),
             "row": seat.row.name,
             "number": seat.number,
+            "identifier": f"{seat.row.name}{seat.number}",
         }

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,5 +1,10 @@
 from django.utils import timezone
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import status
 from rest_framework.generics import CreateAPIView, ListAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -130,6 +135,7 @@ class MyTicketsView(ListAPIView):
             Ticket.objects.filter(user=self.request.user)
             .select_related(
                 "session_seat__session__movie",
+                "session_seat__session__room",
                 "session_seat__seat__row",
             )
             .order_by("-created_at")


### PR DESCRIPTION
## Objective

Return complete ticket data required by the Order Confirmation and My Tickets frontend pages after checkout and in authenticated ticket listings.

## What was done

### 1. Checkout ticket response enrichment

Expanded the checkout response so generated tickets now include the data needed to render confirmation cards immediately:

- ticket id and ticket code
- ticket type
- amount paid
- payment method
- movie id and title
- session id, start time, and end time
- room id and name
- seat id, row, number, and identifier

The checkout response continues to include the computed order-level total amount.

### 2. My Tickets response enrichment

Updated GET /api/v1/users/me/tickets/ so each ticket card includes:

- ticket_type
- amount_paid
- payment_method
- room data
- session date/time
- movie title and poster
- seat row, number, and identifier

The endpoint remains authenticated, paginated, and owned by the current user.

### 3. Upcoming and past filtering preserved

Kept the existing type=upcoming|past filtering behavior while expanding the serializer payload returned by the endpoint.

### 4. Direct ticket serializers

Expanded direct Ticket serializer output used by admin/debug reservation endpoints so enriched ticket details are exposed consistently there as well.

### 5. Ticket model validation

Strengthened Ticket validation so tickets must:

- belong to a purchased session seat
- have no stale seat lock metadata
- store amount_paid matching the session base price and ticket_type rules

### 6. Integration test coverage

Added and updated integration coverage for the enriched behavior:

- checkout response ticket payload
- My Tickets response payload
- upcoming/past filters with enriched serializer output
- ticket model defaults and amount validation
- direct ticket endpoint enriched payload compatibility

## How to test

### Automated validation

Run the full test suite with Docker:

```bash
docker compose run --rm backend pytest -q
```

### Optional targeted runs

```bash
docker compose run --rm backend pytest tests/integration/test_checkout_api.py tests/integration/test_user_tickets_api.py tests/integration/test_ticket_model.py tests/integration/test_reservations_admin_crud_api.py -q
```

### Manual validation

1. Start the stack:

```bash
docker compose up --build
```

2. Complete the authenticated reservation and checkout flow.

3. Validate the checkout response includes:

- status PURCHASED
- computed total_amount
- generated tickets
- movie, session, room, and seat data per ticket

4. Validate GET /api/v1/users/me/tickets/ includes:

- ticket pricing and payment fields
- movie title and poster
- session date/time
- room data
- seat identifier

5. Validate filters still work:

- GET /api/v1/users/me/tickets/?type=upcoming
- GET /api/v1/users/me/tickets/?type=past

## Expected Result

- Ticket responses contain the frontend data needed by confirmation and My Tickets pages.
- Checkout returns generated tickets and computed total amount.
- My Tickets remains authenticated, paginated, and filterable.
- Direct ticket endpoints remain compatible while exposing the enriched fields.
- Ticket integrity and pricing validation remain enforced.
- Full Docker-based test suite passes successfully.

closes #65 