### PR TITLE
feat: prepare backend for frontend CORS and token refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DEBUG=True
 SECRET_KEY=change-me
 ALLOWED_HOSTS=127.0.0.1,localhost
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 POSTGRES_DB=cinepolis_natal
 POSTGRES_USER=postgres

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 DEBUG=True
 SECRET_KEY=change-me
 ALLOWED_HOSTS=127.0.0.1,localhost
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 POSTGRES_DB=cinepolis_natal
 POSTGRES_USER=postgres

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,7 @@ The table below maps implemented requirements to concrete endpoints/components.
 | --- | --- | --- |
 | User registration | Register with email, username, password | `POST /api/v1/auth/register/` (`users.views.UserRegistrationView`) |
 | JWT login | Login returns access + refresh tokens | `POST /api/v1/auth/login/` (`users.views.UserLoginView`) |
+| JWT refresh | Refresh token returns a new access token | `POST /api/v1/auth/token/refresh/` (`users.views.UserTokenRefreshView`) |
 | Current user profile | Returns authenticated user identity | `GET /api/v1/auth/me/` and `GET /api/v1/users/me/` |
 | Public catalog | List/create/retrieve/update/delete genres, movies, rooms, sessions | `catalog.views.*` under `/api/v1/catalog/*` |
 | Reservation admin entities | Full CRUD for seat rows and seats; list/create/retrieve/delete for session seats and tickets | `reservations.views.*` under `/api/v1/reservation/*` |
@@ -148,6 +149,7 @@ docker compose exec celery celery -A cinepolis_natal_api inspect ping
 - `SECRET_KEY`: Django secret key.
 - `DEBUG`: `True` or `False`.
 - `ALLOWED_HOSTS`: comma-separated host list.
+- `CORS_ALLOWED_ORIGINS`: comma-separated frontend origins allowed to call the API. Defaults to `http://localhost:3000` for local development; set explicit production origins instead of using wildcards.
 
 ### Database
 
@@ -338,6 +340,16 @@ For `curl`:
 	export ACCESS_TOKEN="<jwt-access-token>"
 	```
 
+### 2a) Refresh JWT access token
+
+```bash
+curl -s -X POST "$BASE_URL/api/v1/auth/token/refresh/" \
+	-H "Content-Type: application/json" \
+	-d '{"refresh":"<jwt-refresh-token>"}'
+```
+
+Expected: `200 OK` with a new `access` token.
+
 ### 3) List movies
 
 ```bash
@@ -428,6 +440,7 @@ Expected: `200 OK` paginated ticket list. Optional filters:
 ### Common error scenarios
 
 - Invalid credentials on login: `401` with `error.code = INVALID_CREDENTIALS`
+- Invalid or expired JWT on protected endpoints or token refresh: `401` with `error.code = NOT_AUTHENTICATED`
 - Validation failure (missing/invalid fields): `400` with `error.code = VALIDATION_FAILED`
 - Invalid checkout ticket type: `400` with `error.code = INVALID_TICKET_TYPE`
 - Invalid checkout payment method: `400` with `error.code = INVALID_PAYMENT_METHOD`
@@ -450,6 +463,7 @@ Expected: `200 OK` paginated ticket list. Optional filters:
 | --- | --- | --- | --- |
 | `POST` | `{{BASE_URL}}/api/v1/auth/register/` | No | `{"email":"dev1@example.com","username":"dev1","password":"StrongPass123!"}` |
 | `POST` | `{{BASE_URL}}/api/v1/auth/login/` | No | `{"email":"dev1@example.com","password":"StrongPass123!"}` |
+| `POST` | `{{BASE_URL}}/api/v1/auth/token/refresh/` | No | `{"refresh":"<jwt-refresh-token>"}` |
 | `GET` | `{{BASE_URL}}/api/v1/auth/me/` | Bearer | none |
 | `GET` | `{{BASE_URL}}/api/v1/users/me/` | Bearer | none |
 | `GET` | `{{BASE_URL}}/api/v1/users/me/tickets/` | Bearer | none |

--- a/backend/cinepolis_natal_api/exception_handler.py
+++ b/backend/cinepolis_natal_api/exception_handler.py
@@ -62,7 +62,12 @@ def _map_error_code(exc, response_status):
         return "VALIDATION_FAILED"
 
     if isinstance(exc, AuthenticationFailed):
-        return "INVALID_CREDENTIALS"
+        detail_message = _extract_detail_message(
+            _to_primitive(getattr(exc, "detail", None))
+        )
+        if detail_message in {"Invalid credentials.", "User account is disabled."}:
+            return "INVALID_CREDENTIALS"
+        return "NOT_AUTHENTICATED"
 
     if isinstance(exc, NotAuthenticated):
         return "NOT_AUTHENTICATED"

--- a/backend/cinepolis_natal_api/settings.py
+++ b/backend/cinepolis_natal_api/settings.py
@@ -37,6 +37,7 @@ DJANGO_APPS = [
 
 THIRD_PARTY_APPS = [
     "django.contrib.postgres",
+    "corsheaders",
     "rest_framework",
     "drf_spectacular",
 ]
@@ -54,6 +55,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 # -------------------------------------------------------------------
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "cinepolis_natal_api.middleware.CorrelationIdMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -70,6 +72,16 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "cinepolis_natal_api.urls"
 WSGI_APPLICATION = "cinepolis_natal_api.wsgi.application"
+
+# -------------------------------------------------------------------
+# CORS
+# -------------------------------------------------------------------
+
+CORS_ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if origin.strip()
+]
 
 # -------------------------------------------------------------------
 # Templates

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -265,6 +265,22 @@ argon2 = ["argon2-cffi (>=23.1.0)"]
 bcrypt = ["bcrypt (>=4.1.1)"]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.9.0"
+description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449"},
+    {file = "django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8"},
+]
+
+[package.dependencies]
+asgiref = ">=3.6"
+django = ">=4.2"
+
+[[package]]
 name = "django-redis"
 version = "6.0.0"
 description = "Full featured redis cache backend for Django."
@@ -1130,4 +1146,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "c7daeec8bb444e021c78dcf8663ae87a2ffb83d3364d5e6bd6a741c9a4b36f46"
+content-hash = "bec0b9ddec9200cd396b9e14884d6feb5fb51dcb7891dfa4d1ee0a00595a69b4"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "django-redis (>=6.0.0,<7.0.0)",
     "celery (>=5.6.2,<6.0.0)",
     "djangorestframework-simplejwt (>=5.5.1,<6.0.0)",
-    "drf-spectacular (>=0.29.0,<0.30.0)"
+    "drf-spectacular (>=0.29.0,<0.30.0)",
+    "django-cors-headers (>=4.9.0,<5.0.0)"
 ]
 
 

--- a/backend/tests/integration/test_cors_api.py
+++ b/backend/tests/integration/test_cors_api.py
@@ -1,0 +1,25 @@
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+
+def _preflight_from(origin):
+    client = APIClient()
+    return client.options(
+        "/api/v1/auth/login/",
+        HTTP_ORIGIN=origin,
+        HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
+    )
+
+
+@override_settings(CORS_ALLOWED_ORIGINS=["http://localhost:3000"])
+def test_cors_allows_configured_frontend_origin():
+    response = _preflight_from("http://localhost:3000")
+
+    assert response["access-control-allow-origin"] == "http://localhost:3000"
+
+
+@override_settings(CORS_ALLOWED_ORIGINS=["https://app.example.com"])
+def test_cors_rejects_origins_not_configured():
+    response = _preflight_from("http://localhost:3000")
+
+    assert "access-control-allow-origin" not in response

--- a/backend/tests/integration/test_current_user.py
+++ b/backend/tests/integration/test_current_user.py
@@ -24,6 +24,7 @@ class TestCurrentUserView:
         response = api_client.get("/api/v1/auth/me/")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data["error"]["code"] == "NOT_AUTHENTICATED"
 
     def test_current_user_returns_authenticated_user(self, api_client, user):
         refresh = RefreshToken.for_user(user)
@@ -45,3 +46,4 @@ class TestCurrentUserView:
         response = api_client.get("/api/v1/auth/me/")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data["error"]["code"] == "NOT_AUTHENTICATED"

--- a/backend/tests/integration/test_user_login.py
+++ b/backend/tests/integration/test_user_login.py
@@ -1,3 +1,5 @@
+from itertools import count
+
 import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -5,11 +7,16 @@ from rest_framework.test import APIClient
 from users.models import User
 
 
+_ip_counter = count(1)
+
+
 @pytest.mark.django_db
 class TestUserLoginView:
     @pytest.fixture
     def api_client(self):
-        return APIClient()
+        client = APIClient()
+        client.defaults["REMOTE_ADDR"] = f"10.20.30.{next(_ip_counter)}"
+        return client
 
     @pytest.fixture
     def user(self):
@@ -34,6 +41,49 @@ class TestUserLoginView:
         assert "refresh" in response.data
         assert response.data["access"]
         assert response.data["refresh"]
+
+    def test_token_refresh_returns_new_access_token(self, api_client, user):
+        login_response = api_client.post(
+            "/api/v1/auth/login/",
+            {
+                "email": "orlando@gmail.com",
+                "password": "Soueu123*A",
+            },
+            format="json",
+        )
+
+        refresh_response = api_client.post(
+            "/api/v1/auth/token/refresh/",
+            {"refresh": login_response.data["refresh"]},
+            format="json",
+        )
+
+        assert refresh_response.status_code == status.HTTP_200_OK
+        assert "access" in refresh_response.data
+        assert "refresh" not in refresh_response.data
+
+        api_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {refresh_response.data['access']}"
+        )
+        current_user_response = api_client.get("/api/v1/auth/me/")
+
+        assert current_user_response.status_code == status.HTTP_200_OK
+        assert current_user_response.data["id"] == str(user.id)
+
+    def test_token_refresh_returns_standard_error_with_invalid_refresh(
+        self,
+        api_client,
+    ):
+        response = api_client.post(
+            "/api/v1/auth/token/refresh/",
+            {"refresh": "invalid-refresh-token"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data["error"]["code"] == "NOT_AUTHENTICATED"
+        assert response.data["error"]["status"] == 401
+        assert isinstance(response.data["error"]["details"], dict)
 
     def test_login_returns_401_with_invalid_password(self, api_client, user):
         response = api_client.post(

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,10 +1,21 @@
 from django.urls import path
 
-from users.views import CurrentUserView, UserLoginView, UserRegistrationView, MyTicketsView
+from users.views import (
+    CurrentUserView,
+    MyTicketsView,
+    UserLoginView,
+    UserRegistrationView,
+    UserTokenRefreshView,
+)
 
 urlpatterns = [
     path("register/", UserRegistrationView.as_view(), name="user-register"),
     path("login/", UserLoginView.as_view(), name="user-login"),
+    path(
+        "token/refresh/",
+        UserTokenRefreshView.as_view(),
+        name="token-refresh",
+    ),
     path("me/", CurrentUserView.as_view(), name="user-current"),
     path("me/tickets/", MyTicketsView.as_view(), name="user-my-tickets"),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -11,7 +11,9 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework.views import APIView
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenRefreshView
 
 from cinepolis_natal_api.throttling import LoginRateThrottle
 from reservations.models import Ticket
@@ -25,6 +27,10 @@ from users.serializers import (
 class UserLoginResponseSerializer(serializers.Serializer):
     access = serializers.CharField()
     refresh = serializers.CharField()
+
+
+class TokenRefreshResponseSerializer(serializers.Serializer):
+    access = serializers.CharField()
 
 
 class CurrentUserResponseSerializer(serializers.Serializer):
@@ -85,6 +91,22 @@ class UserLoginView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+@extend_schema_view(
+    post=extend_schema(
+        tags=["Auth"],
+        summary="Refresh access token",
+        description="Issue a new JWT access token from a valid refresh token.",
+        request=TokenRefreshSerializer,
+        responses={
+            200: TokenRefreshResponseSerializer,
+            401: OpenApiResponse(description="Invalid or expired refresh token."),
+        },
+    )
+)
+class UserTokenRefreshView(TokenRefreshView):
+    permission_classes = [AllowAny]
 
 
 @extend_schema_view(

--- a/product-requirements-document.md
+++ b/product-requirements-document.md
@@ -367,22 +367,60 @@ The frontend shall provide registration and login forms. On successful login, JW
 
 ## 9. API Contract and Error Standard
 
-### 9.1 Base Endpoints
+### 9.1 API Endpoints
 
-```
-GET  /health/
-GET  /api/schema/
-GET  /api/docs/
-POST /api/v1/auth/register/
-POST /api/v1/auth/login/
-GET  /api/v1/auth/me/
-GET  /api/v1/users/me/
-GET  /api/v1/users/me/tickets/
-GET/POST/DELETE /api/v1/catalog/...
-GET  /api/v1/reservation/sessions/{session_id}/seats/
-POST /api/v1/reservation/sessions/{session_id}/reservations/
-POST /api/v1/reservation/checkout/
-```
+Support and documentation:
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/health/` | Health check for database, Redis, and Celery connectivity |
+| `GET` | `/api/schema/` | OpenAPI schema |
+| `GET` | `/api/docs/` | Swagger UI |
+
+Authentication and user endpoints:
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/v1/auth/register/` | Register a user |
+| `POST` | `/api/v1/auth/login/` | Authenticate and issue access and refresh tokens |
+| `POST` | `/api/v1/auth/token/refresh/` | Refresh an access token from a valid refresh token |
+| `GET` | `/api/v1/auth/me/` | Return current authenticated user profile |
+| `GET` | `/api/v1/users/me/` | Return current authenticated user profile |
+| `GET` | `/api/v1/users/me/tickets/` | Return authenticated user's tickets |
+
+Catalog endpoints:
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET`, `POST` | `/api/v1/catalog/genres/` | List or create genres |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/api/v1/catalog/genres/{genre_id}/` | Retrieve, update, or delete a genre |
+| `GET`, `POST` | `/api/v1/catalog/movies/` | List or create movies |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/api/v1/catalog/movies/{movie_id}/` | Retrieve, update, or delete a movie |
+| `GET`, `POST` | `/api/v1/catalog/rooms/` | List or create rooms |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/api/v1/catalog/rooms/{room_id}/` | Retrieve, update, or delete a room |
+| `GET`, `POST` | `/api/v1/catalog/sessions/` | List or create sessions |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/api/v1/catalog/sessions/{session_id}/` | Retrieve, update, or delete a session |
+
+Reservation endpoints:
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET`, `POST` | `/api/v1/reservation/seat-rows/` | List or create seat rows |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/api/v1/reservation/seat-rows/{seat_row_id}/` | Retrieve, update, or delete a seat row |
+| `GET`, `POST` | `/api/v1/reservation/seats/` | List or create seats |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/api/v1/reservation/seats/{seat_id}/` | Retrieve, update, or delete a seat |
+| `GET`, `POST` | `/api/v1/reservation/session-seats/` | List or create session seats |
+| `GET`, `DELETE` | `/api/v1/reservation/session-seats/{session_seat_id}/` | Retrieve or delete a session seat |
+| `GET`, `POST` | `/api/v1/reservation/tickets/` | List or create tickets |
+| `GET`, `DELETE` | `/api/v1/reservation/tickets/{ticket_id}/` | Retrieve or delete a ticket |
+| `GET` | `/api/v1/reservation/sessions/{session_id}/seats/` | Return the seat map for a session |
+| `POST`, `DELETE` | `/api/v1/reservation/sessions/{session_id}/reservations/` | Create or release temporary reservations |
+| `POST` | `/api/v1/reservation/checkout/` | Finalize checkout for temporarily reserved seats |
+
+The backend currently includes `users.urls` under both `/api/v1/auth/` and
+`/api/v1/users/`. The canonical frontend-facing routes are the ones listed above;
+the duplicated user-route aliases are implementation compatibility paths and
+should not be preferred by new clients.
 
 ### 9.2 Catalog Query Parameters (amended)
 


### PR DESCRIPTION
## Objective
Prepare the backend to be consumed directly by the Next.js frontend running on a different local origin, while completing the JWT refresh flow and keeping the API contract aligned with the formal requirements document.

## What was done

### CORS Support
* Added `django-cors-headers` as the official CORS solution.
* Registered `corsheaders` and `corsheaders.middleware.CorsMiddleware` in Django settings.
* Added environment-driven `CORS_ALLOWED_ORIGINS` configuration.
* Included `http://localhost:3000` as the local development default origin.
* Kept production behavior safely restrictable through an explicit origin allowlist.

### Token Refresh Endpoint
* Added SimpleJWT refresh support at **POST /api/v1/auth/token/refresh/**.
* Documented the endpoint in OpenAPI/Swagger with request and response schemas.
* Ensured valid refresh tokens return a new access token using the expected response shape:
    * `{"access": "new-access-token"}`.

### Auth Error Behavior
* Ensured invalid or expired JWTs return the standardized `NOT_AUTHENTICATED` error envelope.
* Preserved `INVALID_CREDENTIALS` for failed login attempts.
* Confirmed protected endpoints continue returning `NOT_AUTHENTICATED` when authentication is missing or invalid.

### Documentation and Environment
* Added `CORS_ALLOWED_ORIGINS` to both `.env.example` files:
    * Root `.env.example`.
    * `backend/.env.example`.
* Updated backend README/API docs with:
    * CORS environment configuration.
    * Refresh token endpoint usage.
    * Standard auth error behavior.
    * Route reference updates.
* Updated the PRD API contract to list all canonical API endpoints explicitly.
* Added a PRD note clarifying duplicated `users.urls` aliases and the preferred frontend-facing routes.

### Tests
* Added token refresh success coverage.
* Added invalid refresh token error coverage.
* Added CORS allowed-origin and rejected-origin coverage.
* Isolated login tests from rate-limit cross-test interference.

## Validation
* **Docker Build:** Executed `docker compose build backend` successfully.
* **Django Check:** Executed `docker compose run --rm backend python manage.py check` successfully.
* **Focused Tests:** Executed `docker compose run --rm backend pytest tests/integration/test_user_login.py tests/integration/test_current_user.py tests/integration/test_cors_api.py -q` successfully.
    * Result: `12 passed`.
* **Full Test Suite:** Executed `docker compose run --rm backend pytest -q` successfully.
    * Result: `157 passed`.
* **Schema Validation:** Executed `docker compose run --rm backend python manage.py spectacular --validate --file /tmp/schema.yml` successfully.
    * Result: `0 errors`.
* **Manual CORS Verification:** Confirmed `http://localhost:3000` receives `access-control-allow-origin: http://localhost:3000` from the backend container.

## Expected Result
* Browser requests from **http://localhost:3000** can call the local backend without CORS failures.
* Allowed CORS origins are environment-configurable and safely restrictable in production.
* **POST /api/v1/auth/token/refresh/** returns a new access token for a valid refresh token.
* Invalid refresh tokens and invalid Bearer tokens use the standardized `NOT_AUTHENTICATED` envelope.
* Protected endpoint authentication behavior remains unchanged.
* The PRD, README, OpenAPI schema, and tests reflect the implemented API contract.

closes #66 
