### PR TITLE
fix: secure admin API permissions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,8 +40,8 @@ The table below maps implemented requirements to concrete endpoints/components.
 | User registration | Register with email, username, password | `POST /api/v1/auth/register/` (`users.views.UserRegistrationView`) |
 | JWT login | Login returns access + refresh tokens | `POST /api/v1/auth/login/` (`users.views.UserLoginView`) |
 | Current user profile | Returns authenticated user identity | `GET /api/v1/auth/me/` and `GET /api/v1/users/me/` |
-| Public catalog | List/create/retrieve/update/delete genres, movies, rooms, sessions | `catalog.views.*` under `/api/v1/catalog/*` |
-| Reservation admin entities | Full CRUD for seat rows and seats; list/create/retrieve/delete for session seats and tickets | `reservations.views.*` under `/api/v1/reservation/*` |
+| Public catalog | Public list/retrieve for genres, movies, rooms, sessions; admin-only catalog mutations | `catalog.views.*` under `/api/v1/catalog/*` |
+| Reservation admin entities | Admin-only full CRUD for seat rows and seats; admin-only list/create/retrieve/delete for session seats; admin-only list/retrieve/delete for tickets | `reservations.views.*` under `/api/v1/reservation/*` |
 | Session seat map | Public seat status (`AVAILABLE`, `RESERVED`, `PURCHASED`) | `GET /api/v1/reservation/sessions/{session_id}/seats/` |
 | Temporary reservation | Authenticated seat lock with expiration metadata | `POST /api/v1/reservation/sessions/{session_id}/reservations/` |
 | Checkout | Transactional purchase and ticket creation | `POST /api/v1/reservation/checkout/` + `reservations.services.checkout_service` |
@@ -461,25 +461,25 @@ Expected: `200 OK` paginated ticket list. Optional filters:
 | Method | Route | Auth | Body example |
 | --- | --- | --- | --- |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/genres/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/catalog/genres/` | No | `{"name":"Sci-Fi"}` |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/genres/` | Admin | `{"name":"Sci-Fi"}` |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | No | none |
-| `PATCH` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | No | `{"name":"Science Fiction"}` |
-| `DELETE` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | Admin | `{"name":"Science Fiction"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/genres/{genre_id}/` | Admin | none |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/movies/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/catalog/movies/` | No | `{"title":"Interstellar","genres":["{genre_id}"],"synopsis":"Space exploration.","duration_minutes":169,"release_date":"2014-11-07","poster_url":"https://example.com/interstellar.jpg"}` |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/movies/` | Admin | `{"title":"Interstellar","genres":["{genre_id}"],"synopsis":"Space exploration.","duration_minutes":169,"release_date":"2014-11-07","poster_url":"https://example.com/interstellar.jpg"}` |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | No | none |
-| `PATCH` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | No | `{"title":"Interstellar Remastered"}` |
-| `DELETE` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | Admin | `{"title":"Interstellar Remastered"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/movies/{movie_id}/` | Admin | none |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/rooms/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/catalog/rooms/` | No | `{"name":"Room 2","capacity":80}` |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/rooms/` | Admin | `{"name":"Room 2","capacity":80}` |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | No | none |
-| `PATCH` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | No | `{"name":"Room Prime","capacity":100}` |
-| `DELETE` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | Admin | `{"name":"Room Prime","capacity":100}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/rooms/{room_id}/` | Admin | none |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/sessions/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/catalog/sessions/` | No | `{"movie":"{movie_id}","room":"{room_id}","start_time":"2026-03-23T18:00:00Z","end_time":"2026-03-23T20:55:00Z","base_price":"30.00"}` |
+| `POST` | `{{BASE_URL}}/api/v1/catalog/sessions/` | Admin | `{"movie":"{movie_id}","room":"{room_id}","start_time":"2026-03-23T18:00:00Z","end_time":"2026-03-23T20:55:00Z","base_price":"30.00"}` |
 | `GET` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | No | none |
-| `PATCH` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | No | `{"end_time":"2026-03-23T21:10:00Z"}` |
-| `DELETE` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | No | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | Admin | `{"end_time":"2026-03-23T21:10:00Z"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/catalog/sessions/{session_id}/` | Admin | none |
 
 Notes:
 
@@ -491,24 +491,23 @@ Notes:
 
 | Method | Route | Auth | Body example |
 | --- | --- | --- | --- |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/seat-rows/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/reservation/seat-rows/` | No | `{"room":"{room_id}","name":"A"}` |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | No | none |
-| `PATCH` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | No | `{"name":"B"}` |
-| `DELETE` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | No | none |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/seats/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/reservation/seats/` | No | `{"row":"{seat_row_id}","number":1}` |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | No | none |
-| `PATCH` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | No | `{"number":2}` |
-| `DELETE` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | No | none |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/session-seats/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/reservation/session-seats/` | No | `{"session":"{session_id}","seat":"{seat_id}","status":"AVAILABLE","locked_by_user":null,"lock_expires_at":null}` |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/session-seats/{session_seat_id}/` | No | none |
-| `DELETE` | `{{BASE_URL}}/api/v1/reservation/session-seats/{session_seat_id}/` | No | none |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/tickets/` | No | none |
-| `POST` | `{{BASE_URL}}/api/v1/reservation/tickets/` | No | `{"user":"{user_id}","session_seat":"{session_seat_id}","ticket_type":"inteira","amount_paid":"30.00","payment_method":"pix"}` |
-| `GET` | `{{BASE_URL}}/api/v1/reservation/tickets/{ticket_id}/` | No | none |
-| `DELETE` | `{{BASE_URL}}/api/v1/reservation/tickets/{ticket_id}/` | No | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seat-rows/` | Admin | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/seat-rows/` | Admin | `{"room":"{room_id}","name":"A"}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | Admin | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | Admin | `{"name":"B"}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/seat-rows/{seat_row_id}/` | Admin | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seats/` | Admin | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/seats/` | Admin | `{"row":"{seat_row_id}","number":1}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | Admin | none |
+| `PATCH` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | Admin | `{"number":2}` |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/seats/{seat_id}/` | Admin | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/session-seats/` | Admin | none |
+| `POST` | `{{BASE_URL}}/api/v1/reservation/session-seats/` | Admin | `{"session":"{session_id}","seat":"{seat_id}"}` |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/session-seats/{session_seat_id}/` | Admin | none |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/session-seats/{session_seat_id}/` | Admin | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/tickets/` | Admin | none |
+| `GET` | `{{BASE_URL}}/api/v1/reservation/tickets/{ticket_id}/` | Admin | none |
+| `DELETE` | `{{BASE_URL}}/api/v1/reservation/tickets/{ticket_id}/` | Admin | none |
 | `GET` | `{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/seats/` | No | none |
 | `POST` | `{{BASE_URL}}/api/v1/reservation/sessions/{{SESSION_ID}}/reservations/` | Bearer | `{"seat_ids":["{{SEAT_ID}}"]}` |
 | `POST` | `{{BASE_URL}}/api/v1/reservation/checkout/` | Bearer | `{"seats":[{"session_seat_id":"{{SESSION_SEAT_ID}}","ticket_type":"inteira"}],"payment_method":"pix"}` |
@@ -518,7 +517,7 @@ Notes:
 - `SeatRow` and `Seat` support full CRUD because they are structural resources.
 - `SessionSeat` and `Ticket` intentionally do not expose `PATCH` endpoints.
 - `SessionSeat` state transitions should happen through reservation and checkout flows, not arbitrary updates.
-- `Ticket` creation is allowed for admin/testing scenarios when the `SessionSeat` is already `PURCHASED`, but application purchase flow should use checkout.
+- `Ticket` records are created by checkout; the direct ticket API is read/delete only for admins.
 
 ## Error Handling
 

--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -8,8 +8,8 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
-from rest_framework.permissions import AllowAny
 
+from cinepolis_natal_api.permissions import IsAdminUserOrReadOnly
 from catalog.models import Genre, Movie, MovieStatus, Room, Session
 from catalog.serializers import (
     GenreSerializer,
@@ -42,14 +42,14 @@ def invalidate_movie_and_session_list_cache():
 class GenreListCreateView(ListCreateAPIView):
     queryset = Genre.objects.all()
     serializer_class = GenreSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
 
 
 @extend_schema(tags=["Catalog"], summary="Get, update or delete genre")
 class GenreDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Genre.objects.all()
     serializer_class = GenreSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
 
     def perform_update(self, serializer):
         serializer.save()
@@ -64,7 +64,7 @@ class GenreDetailView(RetrieveUpdateDestroyAPIView):
 @extend_schema(tags=["Catalog"], summary="List or create movies")
 class MovieListCreateView(ListCreateAPIView):
     queryset = Movie.objects.prefetch_related("genres").all()
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
     CACHE_TTL_SECONDS = 300
     IS_FEATURED_FILTER_VALUES = {
         "true": True,
@@ -148,7 +148,7 @@ class MovieListCreateView(ListCreateAPIView):
 @extend_schema(tags=["Catalog"], summary="Get, update or delete movie")
 class MovieDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Movie.objects.prefetch_related("genres").all()
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
 
     def get_serializer_class(self):
         if self.request.method == "GET":
@@ -169,14 +169,14 @@ class MovieDetailView(RetrieveUpdateDestroyAPIView):
 class RoomListCreateView(ListCreateAPIView):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
 
 
 @extend_schema(tags=["Catalog"], summary="Get, update or delete room")
 class RoomDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Room.objects.all()
     serializer_class = RoomSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
 
     def perform_update(self, serializer):
         serializer.save()
@@ -195,7 +195,7 @@ class SessionListCreateView(ListCreateAPIView):
         .prefetch_related("movie__genres")
         .all()
     )
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
     CACHE_TTL_SECONDS = 300
 
     def _get_validated_filters(self):
@@ -303,7 +303,7 @@ class SessionDetailView(RetrieveUpdateDestroyAPIView):
         .prefetch_related("movie__genres")
         .all()
     )
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUserOrReadOnly]
 
     def get_serializer_class(self):
         if self.request.method == "GET":

--- a/backend/cinepolis_natal_api/permissions.py
+++ b/backend/cinepolis_natal_api/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsAdminUserOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return True
+
+        return bool(request.user and request.user.is_staff)

--- a/backend/cinepolis_natal_api/settings.py
+++ b/backend/cinepolis_natal_api/settings.py
@@ -216,7 +216,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+        "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,

--- a/backend/reservations/serializers.py
+++ b/backend/reservations/serializers.py
@@ -40,7 +40,7 @@ class SessionSeatSerializer(serializers.ModelSerializer):
             "locked_by_user",
             "lock_expires_at",
         ]
-        read_only_fields = ["id"]
+        read_only_fields = ["id", "status", "locked_by_user", "lock_expires_at"]
 
 
 class TicketSerializer(serializers.ModelSerializer):

--- a/backend/reservations/views.py
+++ b/backend/reservations/views.py
@@ -9,7 +9,7 @@ from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
     RetrieveDestroyAPIView,
 )
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 from cinepolis_natal_api.throttling import ReservationRateThrottle
@@ -59,28 +59,28 @@ from reservations.services.release_service import (
 class SeatRowListCreateView(ListCreateAPIView):
     queryset = SeatRow.objects.select_related("room").all()
     serializer_class = SeatRowSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema(tags=["Reservations"], summary="Get, update or delete seat row")
 class SeatRowDetailView(RetrieveUpdateDestroyAPIView):
     queryset = SeatRow.objects.select_related("room").all()
     serializer_class = SeatRowSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema(tags=["Reservations"], summary="List or create seats")
 class SeatListCreateView(ListCreateAPIView):
     queryset = Seat.objects.select_related("row", "row__room").all()
     serializer_class = SeatSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema(tags=["Reservations"], summary="Get, update or delete seat")
 class SeatDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Seat.objects.select_related("row", "row__room").all()
     serializer_class = SeatSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema(tags=["Reservations"], summary="List or create session seats")
@@ -89,7 +89,7 @@ class SessionSeatListCreateView(ListCreateAPIView):
         "session", "seat", "seat__row", "seat__row__room", "locked_by_user"
     ).all()
     serializer_class = SessionSeatSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema(tags=["Reservations"], summary="Get or delete session seat")
@@ -98,11 +98,11 @@ class SessionSeatDetailView(RetrieveDestroyAPIView):
         "session", "seat", "seat__row", "seat__row__room", "locked_by_user"
     ).all()
     serializer_class = SessionSeatSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
-@extend_schema(tags=["Reservations"], summary="List or create tickets")
-class TicketListCreateView(ListCreateAPIView):
+@extend_schema(tags=["Reservations"], summary="List tickets")
+class TicketListCreateView(ListAPIView):
     queryset = Ticket.objects.select_related(
         "user",
         "session_seat",
@@ -111,7 +111,7 @@ class TicketListCreateView(ListCreateAPIView):
         "session_seat__seat__row",
     ).all()
     serializer_class = TicketSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema(tags=["Reservations"], summary="Get or delete ticket")
@@ -124,7 +124,7 @@ class TicketDetailView(RetrieveDestroyAPIView):
         "session_seat__seat__row",
     ).all()
     serializer_class = TicketSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [IsAdminUser]
 
 
 @extend_schema_view(

--- a/backend/tests/integration/test_catalog_api.py
+++ b/backend/tests/integration/test_catalog_api.py
@@ -1,6 +1,7 @@
 import pytest
 from decimal import Decimal
 from datetime import datetime, timedelta
+from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -9,6 +10,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from catalog.models import Genre, Movie, MovieStatus, Room, Session
+from users.models import User
 
 
 @pytest.mark.django_db
@@ -20,8 +22,37 @@ class TestCatalogApi:
         cache.clear()
 
     @pytest.fixture
-    def api_client(self):
+    def admin_user(self):
+        return User.objects.create_user(
+            email="catalog-admin@example.com",
+            username="catalog_admin",
+            password="StrongPass123",
+            is_staff=True,
+        )
+
+    @pytest.fixture
+    def api_client(self, admin_user):
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        return client
+
+    @pytest.fixture
+    def anonymous_api_client(self):
         return APIClient()
+
+    @pytest.fixture
+    def regular_user(self):
+        return User.objects.create_user(
+            email="catalog-user@example.com",
+            username="catalog_user",
+            password="StrongPass123",
+        )
+
+    @pytest.fixture
+    def regular_api_client(self, regular_user):
+        client = APIClient()
+        client.force_authenticate(user=regular_user)
+        return client
 
     @pytest.fixture
     def genre(self):
@@ -80,6 +111,12 @@ class TestCatalogApi:
         movie.genres.set([genre])
         return movie
 
+    def test_global_default_permission_is_not_allow_any(self):
+        default_permissions = settings.REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"]
+
+        assert "rest_framework.permissions.IsAuthenticated" in default_permissions
+        assert "rest_framework.permissions.AllowAny" not in default_permissions
+
     def test_list_genres_returns_200(self, api_client, genre):
         response = api_client.get("/api/v1/catalog/genres/")
 
@@ -87,6 +124,151 @@ class TestCatalogApi:
         assert response.data["count"] == 1
         assert len(response.data["results"]) == 1
         assert response.data["results"][0]["name"] == genre.name
+
+    def test_catalog_read_endpoints_remain_public(
+        self,
+        anonymous_api_client,
+        genre,
+        movie,
+        room,
+        session,
+    ):
+        endpoints = [
+            "/api/v1/catalog/genres/",
+            f"/api/v1/catalog/genres/{genre.id}/",
+            "/api/v1/catalog/movies/",
+            f"/api/v1/catalog/movies/{movie.id}/",
+            "/api/v1/catalog/rooms/",
+            f"/api/v1/catalog/rooms/{room.id}/",
+            "/api/v1/catalog/sessions/",
+            f"/api/v1/catalog/sessions/{session.id}/",
+        ]
+
+        for endpoint in endpoints:
+            response = anonymous_api_client.get(endpoint)
+            assert response.status_code == status.HTTP_200_OK
+
+    def test_anonymous_users_cannot_mutate_catalog_resources(
+        self,
+        anonymous_api_client,
+        genre,
+        movie,
+        room,
+        session,
+    ):
+        forbidden_requests = [
+            (
+                anonymous_api_client.post,
+                "/api/v1/catalog/genres/",
+                {"name": "Sci-Fi"},
+            ),
+            (
+                anonymous_api_client.patch,
+                f"/api/v1/catalog/genres/{genre.id}/",
+                {"name": "Updated"},
+            ),
+            (
+                anonymous_api_client.delete,
+                f"/api/v1/catalog/genres/{genre.id}/",
+                None,
+            ),
+            (
+                anonymous_api_client.post,
+                "/api/v1/catalog/movies/",
+                {
+                    "title": "Interstellar",
+                    "genres": [str(genre.id)],
+                    "synopsis": "Space exploration.",
+                    "duration_minutes": 169,
+                    "release_date": "2014-11-07",
+                    "poster_url": "https://example.com/interstellar.jpg",
+                },
+            ),
+            (
+                anonymous_api_client.patch,
+                f"/api/v1/catalog/movies/{movie.id}/",
+                {"title": "Updated"},
+            ),
+            (
+                anonymous_api_client.delete,
+                f"/api/v1/catalog/movies/{movie.id}/",
+                None,
+            ),
+            (
+                anonymous_api_client.post,
+                "/api/v1/catalog/rooms/",
+                {"name": "Room 2", "capacity": 80},
+            ),
+            (
+                anonymous_api_client.patch,
+                f"/api/v1/catalog/rooms/{room.id}/",
+                {"name": "Updated"},
+            ),
+            (
+                anonymous_api_client.delete,
+                f"/api/v1/catalog/rooms/{room.id}/",
+                None,
+            ),
+            (
+                anonymous_api_client.post,
+                "/api/v1/catalog/sessions/",
+                {
+                    "movie": str(movie.id),
+                    "room": str(room.id),
+                    "start_time": "2026-03-23T18:00:00Z",
+                    "end_time": "2026-03-23T20:55:00Z",
+                    "base_price": "42.50",
+                },
+            ),
+            (
+                anonymous_api_client.patch,
+                f"/api/v1/catalog/sessions/{session.id}/",
+                {"base_price": "36.75"},
+            ),
+            (
+                anonymous_api_client.delete,
+                f"/api/v1/catalog/sessions/{session.id}/",
+                None,
+            ),
+        ]
+
+        for method, endpoint, payload in forbidden_requests:
+            if payload is None:
+                response = method(endpoint)
+            else:
+                response = method(endpoint, payload, format="json")
+
+            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_regular_users_cannot_mutate_catalog_resources(
+        self,
+        regular_api_client,
+        genre,
+        movie,
+        room,
+        session,
+    ):
+        requests = [
+            regular_api_client.post(
+                "/api/v1/catalog/genres/",
+                {"name": "Sci-Fi"},
+                format="json",
+            ),
+            regular_api_client.patch(
+                f"/api/v1/catalog/movies/{movie.id}/",
+                {"title": "Updated"},
+                format="json",
+            ),
+            regular_api_client.delete(f"/api/v1/catalog/rooms/{room.id}/"),
+            regular_api_client.patch(
+                f"/api/v1/catalog/sessions/{session.id}/",
+                {"base_price": "36.75"},
+                format="json",
+            ),
+        ]
+
+        for response in requests:
+            assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_create_genre_returns_201(self, api_client):
         response = api_client.post(

--- a/backend/tests/integration/test_reservations_admin_crud_api.py
+++ b/backend/tests/integration/test_reservations_admin_crud_api.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from catalog.models import Movie, Room, Session
-from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus
+from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus, Ticket
 from reservations.views import (
     SeatDetailView,
     SeatListCreateView,
@@ -27,7 +27,7 @@ REST_FRAMEWORK_OVERRIDE = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+        "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
@@ -73,8 +73,41 @@ def disable_throttling_for_module():
 
 
 @pytest.fixture
-def api_client():
+def admin_user():
+    return User.objects.create_user(
+        email="reservation-admin@example.com",
+        username="reservation_admin",
+        password="StrongPass123",
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def regular_user():
+    return User.objects.create_user(
+        email="reservation-user@example.com",
+        username="reservation_user",
+        password="StrongPass123",
+    )
+
+
+@pytest.fixture
+def api_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def anonymous_api_client():
     return APIClient()
+
+
+@pytest.fixture
+def regular_api_client(regular_user):
+    client = APIClient()
+    client.force_authenticate(user=regular_user)
+    return client
 
 
 @pytest.fixture
@@ -182,7 +215,7 @@ def test_session_seat_create_retrieve_delete_endpoints(api_client, room, session
         {
             "session": str(session.id),
             "seat": str(seat.id),
-            "status": SessionSeatStatus.AVAILABLE,
+            "status": SessionSeatStatus.PURCHASED,
             "locked_by_user": None,
             "lock_expires_at": None,
         },
@@ -191,6 +224,7 @@ def test_session_seat_create_retrieve_delete_endpoints(api_client, room, session
 
     assert create_response.status_code == status.HTTP_201_CREATED
     session_seat_id = create_response.data["id"]
+    assert create_response.data["status"] == SessionSeatStatus.AVAILABLE
 
     retrieve_response = api_client.get(
         f"/api/v1/reservation/session-seats/{session_seat_id}/",
@@ -215,7 +249,7 @@ def test_session_seat_create_retrieve_delete_endpoints(api_client, room, session
 
 
 @pytest.mark.django_db
-def test_ticket_create_list_retrieve_delete_endpoints(api_client, room, session):
+def test_ticket_list_retrieve_delete_endpoints(api_client, room, session):
     user = User.objects.create_user(
         email="ticket-crud@example.com",
         username="ticketcrud",
@@ -230,7 +264,61 @@ def test_ticket_create_list_retrieve_delete_endpoints(api_client, room, session)
         status=SessionSeatStatus.PURCHASED,
     )
 
-    create_response = api_client.post(
+    ticket = Ticket.objects.create(
+        user=user,
+        session_seat=session_seat,
+        ticket_type="inteira",
+        amount_paid="30.00",
+        payment_method="pix",
+    )
+
+    retrieve_response = api_client.get(f"/api/v1/reservation/tickets/{ticket.id}/")
+
+    assert retrieve_response.status_code == status.HTTP_200_OK
+    assert retrieve_response.data["id"] == str(ticket.id)
+    assert retrieve_response.data["ticket_code"]
+    assert retrieve_response.data["ticket_type"] == "inteira"
+    assert retrieve_response.data["amount_paid"] == "30.00"
+    assert retrieve_response.data["payment_method"] == "pix"
+
+    list_response = api_client.get("/api/v1/reservation/tickets/")
+
+    assert list_response.status_code == status.HTTP_200_OK
+    assert list_response.data["count"] == 1
+
+    patch_response = api_client.patch(
+        f"/api/v1/reservation/tickets/{ticket.id}/",
+        {"user": str(user.id)},
+        format="json",
+    )
+
+    assert patch_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    delete_response = api_client.delete(f"/api/v1/reservation/tickets/{ticket.id}/")
+
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_ticket_creation_endpoint_is_not_available_for_admins(
+    api_client,
+    room,
+    session,
+):
+    user = User.objects.create_user(
+        email="ticket-create-admin@example.com",
+        username="ticket_create_admin",
+        password="StrongPass123",
+    )
+    seat_row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=seat_row, number=1)
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.PURCHASED,
+    )
+
+    response = api_client.post(
         "/api/v1/reservation/tickets/",
         {
             "user": str(user.id),
@@ -242,28 +330,126 @@ def test_ticket_create_list_retrieve_delete_endpoints(api_client, room, session)
         format="json",
     )
 
-    assert create_response.status_code == status.HTTP_201_CREATED
-    ticket_id = create_response.data["id"]
-    assert create_response.data["ticket_code"]
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+    assert Ticket.objects.count() == 0
 
-    retrieve_response = api_client.get(f"/api/v1/reservation/tickets/{ticket_id}/")
 
-    assert retrieve_response.status_code == status.HTTP_200_OK
-    assert retrieve_response.data["id"] == ticket_id
+@pytest.mark.django_db
+def test_non_admin_users_cannot_mutate_reservation_admin_resources(
+    regular_api_client,
+    regular_user,
+    room,
+    session,
+):
+    seat_row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=seat_row, number=1)
+    session_seat = SessionSeat.objects.create(session=session, seat=seat)
 
-    list_response = api_client.get("/api/v1/reservation/tickets/")
+    responses = [
+        regular_api_client.post(
+            "/api/v1/reservation/seat-rows/",
+            {"room": str(room.id), "name": "B"},
+            format="json",
+        ),
+        regular_api_client.patch(
+            f"/api/v1/reservation/seat-rows/{seat_row.id}/",
+            {"name": "C"},
+            format="json",
+        ),
+        regular_api_client.delete(f"/api/v1/reservation/seats/{seat.id}/"),
+        regular_api_client.post(
+            "/api/v1/reservation/session-seats/",
+            {
+                "session": str(session.id),
+                "seat": str(seat.id),
+                "status": SessionSeatStatus.PURCHASED,
+            },
+            format="json",
+        ),
+        regular_api_client.patch(
+            f"/api/v1/reservation/session-seats/{session_seat.id}/",
+            {"status": SessionSeatStatus.PURCHASED},
+            format="json",
+        ),
+        regular_api_client.post(
+            "/api/v1/reservation/tickets/",
+            {
+                "user": str(regular_user.id),
+                "session_seat": str(session_seat.id),
+                "ticket_type": "inteira",
+                "amount_paid": "30.00",
+                "payment_method": "pix",
+            },
+            format="json",
+        ),
+    ]
 
-    assert list_response.status_code == status.HTTP_200_OK
-    assert list_response.data["count"] == 1
+    for response in responses:
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    patch_response = api_client.patch(
-        f"/api/v1/reservation/tickets/{ticket_id}/",
-        {"user": str(user.id)},
-        format="json",
-    )
+    session_seat.refresh_from_db()
+    assert session_seat.status == SessionSeatStatus.AVAILABLE
+    assert Ticket.objects.count() == 0
 
-    assert patch_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
-    delete_response = api_client.delete(f"/api/v1/reservation/tickets/{ticket_id}/")
+@pytest.mark.django_db
+def test_anonymous_users_cannot_mutate_reservation_admin_resources(
+    anonymous_api_client,
+    room,
+    session,
+):
+    seat_row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=seat_row, number=1)
+    session_seat = SessionSeat.objects.create(session=session, seat=seat)
 
-    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+    responses = [
+        anonymous_api_client.post(
+            "/api/v1/reservation/seat-rows/",
+            {"room": str(room.id), "name": "B"},
+            format="json",
+        ),
+        anonymous_api_client.patch(
+            f"/api/v1/reservation/seat-rows/{seat_row.id}/",
+            {"name": "C"},
+            format="json",
+        ),
+        anonymous_api_client.delete(f"/api/v1/reservation/seats/{seat.id}/"),
+        anonymous_api_client.post(
+            "/api/v1/reservation/session-seats/",
+            {
+                "session": str(session.id),
+                "seat": str(seat.id),
+                "status": SessionSeatStatus.PURCHASED,
+            },
+            format="json",
+        ),
+        anonymous_api_client.patch(
+            f"/api/v1/reservation/session-seats/{session_seat.id}/",
+            {"status": SessionSeatStatus.PURCHASED},
+            format="json",
+        ),
+        anonymous_api_client.post(
+            "/api/v1/reservation/tickets/",
+            {
+                "user": str(
+                    User.objects.create_user(
+                        email="anon-ticket-user@example.com",
+                        username="anon_ticket_user",
+                        password="StrongPass123",
+                    ).id
+                ),
+                "session_seat": str(session_seat.id),
+                "ticket_type": "inteira",
+                "amount_paid": "30.00",
+                "payment_method": "pix",
+            },
+            format="json",
+        ),
+    ]
+
+    for response in responses:
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    session_seat.refresh_from_db()
+    assert session_seat.status == SessionSeatStatus.AVAILABLE
+    assert Ticket.objects.count() == 0

--- a/backend/tests/integration/test_session_creation_seats.py
+++ b/backend/tests/integration/test_session_creation_seats.py
@@ -4,14 +4,14 @@ from rest_framework.test import APIClient
 
 from catalog.models import Movie, Room, Session
 from reservations.models import Seat, SeatRow, SessionSeat
-
+from users.models import User
 
 REST_FRAMEWORK_OVERRIDE = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+        "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
@@ -37,6 +37,13 @@ def disable_throttling_for_module():
 @pytest.mark.django_db
 def test_creating_session_auto_generates_session_seats():
     client = APIClient()
+    admin_user = User.objects.create_user(
+        email="session-admin@example.com",
+        username="session_admin",
+        password="StrongPass123",
+        is_staff=True,
+    )
+    client.force_authenticate(user=admin_user)
 
     room = Room.objects.create(name="Room 1", capacity=100)
     row_a = SeatRow.objects.create(room=room, name="A")

--- a/product-requirements-document.md
+++ b/product-requirements-document.md
@@ -123,7 +123,7 @@ The system shall expose an authenticated endpoint to retrieve the current user p
 
 ### FR-04 Catalog Endpoints
 
-The system shall provide endpoints for genres, movies, rooms, and sessions with list/create/retrieve/delete operations. In the current implementation, all catalog operations are public (`AllowAny`), including create and delete. Update operations are not implemented.
+The system shall provide endpoints for genres, movies, rooms, and sessions with public list/retrieve operations and admin-only create/update/delete operations.
 
 ### FR-04a Movie Status and Featured Flag
 
@@ -500,9 +500,9 @@ The seat map is a grid derived from the `SessionSeat` list returned by `GET /api
 ## 11. Security and Access Control
 
 - JWT Bearer authentication is the default API auth mechanism.
-- Catalog and health endpoints are public.
-- Catalog mutation operations (`POST` and `DELETE` on catalog resources) are also public in the current implementation and should be exposed only in controlled deployment contexts.
-- Reservation, checkout, current-user, and ticket endpoints require authentication.
+- Catalog read and health endpoints are public.
+- Catalog mutation operations require admin permissions.
+- Reservation admin resources require admin permissions; user-facing reservation, checkout, current-user, and my-ticket endpoints require authentication.
 - Login and reservation endpoints have dedicated throttle scopes.
 - The checkout service validates computed totals server-side; the frontend-submitted total is never blindly trusted.
 - Frontend routes requiring authentication redirect unauthenticated users to `/login`, preserving the originally requested path for post-login redirect.


### PR DESCRIPTION
## Objective

Restrict public write access across catalog and reservation administrative endpoints, replace permissive permission defaults, and prevent direct client mutation of sensitive reservation and ticket state.

## Acceptance criteria confirmation

All criteria from the issue were covered:

- The API no longer uses `AllowAny` as the global default permission.
- Public users can only access intentionally public endpoints.
- Catalog write operations require admin permission.
- Reservation administrative endpoints require admin permission.
- SessionSeat lock/status metadata cannot be mutated by public clients.
- Tickets cannot be created directly outside checkout by public clients.
- Existing reservation and checkout behavior remains unchanged.
- New permission tests validate all critical access boundaries.
- New and existing backend tests pass.

## What was done

### 1. Secure default permissions

Changed the DRF global default permission from `AllowAny` to `IsAuthenticated`.

Intentionally public endpoints continue to declare permissive access explicitly where appropriate, including authentication entrypoints, catalog read endpoints, and the public session seat map.

### 2. Catalog write protection

Kept catalog read operations public while requiring admin users for catalog mutations:

- `POST`, `PUT`, `PATCH`, and `DELETE` genres
- `POST`, `PUT`, `PATCH`, and `DELETE` movies
- `POST`, `PUT`, `PATCH`, and `DELETE` rooms
- `POST`, `PUT`, `PATCH`, and `DELETE` sessions

The existing cache invalidation behavior for catalog create/update/delete flows remains unchanged.

### 3. Reservation admin endpoint protection

Restricted reservation administrative resources to admin users:

- seat rows
- seats
- session seats
- tickets

User-facing reservation flows remain available through the dedicated temporary reservation, release, checkout, session seat map, and my-tickets endpoints.

### 4. Serializer and ticket safety

Made sensitive `SessionSeat` state fields read-only through the API serializer:

- `status`
- `locked_by_user`
- `lock_expires_at`

Changed the direct ticket collection endpoint to list-only, so clients cannot create tickets directly through `/api/v1/reservation/tickets/`. Ticket creation remains owned by the checkout flow.

### 5. Integration test coverage

Added and updated integration coverage proving:

- anonymous users cannot create, update, or delete catalog resources
- regular authenticated users cannot mutate catalog resources
- admin users can still perform catalog admin operations
- public catalog read endpoints still work
- regular users cannot mutate reservation admin resources
- anonymous users cannot mutate reservation admin resources
- direct ticket creation is blocked
- direct session-seat state mutation is blocked for non-admin clients
- global default permissions no longer use `AllowAny`

### 6. Documentation updates

Updated the backend README and PRD so they no longer describe catalog writes or reservation admin endpoints as public. The docs now reflect the admin-only mutation policy and checkout-owned ticket creation.

## How to test

### Automated validation

Run the full backend test suite with Docker:

```bash
docker compose run --rm backend pytest -q
```

### Targeted validation

```bash
docker compose run --rm backend pytest tests/integration/test_catalog_api.py tests/integration/test_reservations_admin_crud_api.py tests/integration/test_session_creation_seats.py -q
```

### Manual validation

1. Start the stack:

```bash
docker compose up --build
```

2. Validate public reads still work without authentication:

- `GET /api/v1/catalog/genres/`
- `GET /api/v1/catalog/movies/`
- `GET /api/v1/catalog/rooms/`
- `GET /api/v1/catalog/sessions/`
- `GET /api/v1/reservation/sessions/{session_id}/seats/`

3. Validate anonymous and non-admin clients cannot mutate protected resources:

- catalog `POST/PATCH/DELETE`
- reservation admin `POST/PATCH/DELETE`
- direct `POST /api/v1/reservation/tickets/`

4. Validate admin users can still perform intended admin operations.

5. Validate user-facing reservation and checkout flows still work:

- temporary reservation
- release reservation
- checkout
- my tickets

## Expected Result

- Global permissions default to authenticated access.
- Catalog browsing remains public.
- Catalog mutations require admin users.
- Reservation administrative resources require admin users.
- Sensitive session-seat state cannot be changed directly by public clients.
- Tickets are created only by checkout, not direct public API writes.
- Existing reservation and checkout behavior remains intact.
- Full Docker-based backend test suite passes.

closes #52
