### PR TITLE
fix: split auth routes and enforce domain consistency

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,7 +40,7 @@ The table below maps implemented requirements to concrete endpoints/components.
 | User registration | Register with email, username, password | `POST /api/v1/auth/register/` (`users.views.UserRegistrationView`) |
 | JWT login | Login returns access + refresh tokens | `POST /api/v1/auth/login/` (`users.views.UserLoginView`) |
 | JWT refresh | Refresh token returns a new access token | `POST /api/v1/auth/token/refresh/` (`users.views.UserTokenRefreshView`) |
-| Current user profile | Returns authenticated user identity | `GET /api/v1/auth/me/` and `GET /api/v1/users/me/` |
+| Current user profile | Returns authenticated user identity | `GET /api/v1/users/me/` |
 | Public catalog | Public list/retrieve for genres, movies, rooms, sessions; admin-only catalog mutations | `catalog.views.*` under `/api/v1/catalog/*` |
 | Reservation admin entities | Admin-only full CRUD for seat rows and seats; admin-only list/create/retrieve/delete for session seats; admin-only list/retrieve/delete for tickets | `reservations.views.*` under `/api/v1/reservation/*` |
 | Session seat map | Public seat status (`AVAILABLE`, `RESERVED`, `PURCHASED`) | `GET /api/v1/reservation/sessions/{session_id}/seats/` |
@@ -293,6 +293,7 @@ session = Session.objects.create(
 	room=room,
 	start_time=timezone.now() + timedelta(hours=2),
 	end_time=timezone.now() + timedelta(hours=5),
+	base_price="30.00",
 )
 
 SessionSeat.objects.create(session=session, seat=seat_1)
@@ -464,7 +465,6 @@ Expected: `200 OK` paginated ticket list. Optional filters:
 | `POST` | `{{BASE_URL}}/api/v1/auth/register/` | No | `{"email":"dev1@example.com","username":"dev1","password":"StrongPass123!"}` |
 | `POST` | `{{BASE_URL}}/api/v1/auth/login/` | No | `{"email":"dev1@example.com","password":"StrongPass123!"}` |
 | `POST` | `{{BASE_URL}}/api/v1/auth/token/refresh/` | No | `{"refresh":"<jwt-refresh-token>"}` |
-| `GET` | `{{BASE_URL}}/api/v1/auth/me/` | Bearer | none |
 | `GET` | `{{BASE_URL}}/api/v1/users/me/` | Bearer | none |
 | `GET` | `{{BASE_URL}}/api/v1/users/me/tickets/` | Bearer | none |
 | `GET` | `{{BASE_URL}}/api/v1/users/me/tickets/?type=upcoming` | Bearer | none |
@@ -500,6 +500,9 @@ Notes:
 - Updating a `Genre` is useful when it is already linked to multiple movies.
 - Updating a `Session` is supported, but changing its `room` after creation is rejected to avoid inconsistency with existing `SessionSeat` records.
 - Creating a `Session` through the API creates its `SessionSeat` records automatically from the seats already registered for that room.
+- `Room.capacity` is the maximum allowed layout size: registered seats cannot exceed it, and it cannot be reduced below the registered seat count.
+- Seat rows and seats cannot be created, updated, or deleted for a room that already has future sessions.
+- A session with reserved or purchased seats cannot change `movie`, `room`, `start_time`, `end_time`, or `base_price`.
 
 ### Reservation routes
 

--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from django.contrib.postgres.constraints import ExclusionConstraint
 from django.contrib.postgres.fields import DateTimeRangeField, RangeOperators
+from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
@@ -72,6 +73,28 @@ class Room(models.Model):
     def __str__(self):
         return self.name
 
+    def clean(self):
+        super().clean()
+
+        if not self.pk:
+            return
+
+        Seat = apps.get_model("reservations", "Seat")
+        actual_seat_count = Seat.objects.filter(row__room=self).count()
+
+        if self.capacity < actual_seat_count:
+            raise ValidationError(
+                {
+                    "capacity": (
+                        "Room capacity cannot be lower than the number of registered seats."
+                    )
+                }
+            )
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
 
 class Session(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -100,6 +123,43 @@ class Session(models.Model):
 
         if self.end_time <= self.start_time:
             raise ValidationError({"end_time": "End time must be after start time."})
+
+        if self.pk:
+            try:
+                original_session = Session.objects.get(pk=self.pk)
+            except Session.DoesNotExist:
+                original_session = None
+
+        if self.pk and original_session is not None:
+            sensitive_fields = [
+                "movie_id",
+                "room_id",
+                "start_time",
+                "end_time",
+                "base_price",
+            ]
+            sensitive_fields_changed = any(
+                getattr(self, field) != getattr(original_session, field)
+                for field in sensitive_fields
+            )
+
+            if sensitive_fields_changed:
+                SessionSeat = apps.get_model("reservations", "SessionSeat")
+                sensitive_statuses = ["RESERVED", "PURCHASED"]
+
+                has_reserved_or_purchased_seats = SessionSeat.objects.filter(
+                    session=self,
+                    status__in=sensitive_statuses,
+                ).exists()
+
+                if has_reserved_or_purchased_seats:
+                    raise ValidationError(
+                        {
+                            "session": (
+                                "Sessions with reserved or purchased seats cannot change movie, room, time, or price."
+                            )
+                        }
+                    )
 
         overlapping_sessions = Session.objects.filter(
             room=self.room,
@@ -148,6 +208,10 @@ class Session(models.Model):
 
     def __str__(self):
         return f"{self.movie.title} - {self.room.name} - {self.start_time}"
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
 
 
 class Genre(models.Model):

--- a/backend/catalog/serializers.py
+++ b/backend/catalog/serializers.py
@@ -6,6 +6,11 @@ from catalog.models import Genre, Movie, Room, Session
 from reservations.models import SessionSeat, SessionSeatStatus, Seat
 
 
+def raise_serializer_validation_error(exc):
+    details = getattr(exc, "message_dict", None) or getattr(exc, "messages", None)
+    raise serializers.ValidationError(details or str(exc)) from exc
+
+
 class GenreSerializer(serializers.ModelSerializer):
     class Meta:
         model = Genre
@@ -36,6 +41,27 @@ class RoomSerializer(serializers.ModelSerializer):
             )
 
         return value
+
+    def create(self, validated_data):
+        room = Room(**validated_data)
+
+        try:
+            room.save()
+        except DjangoValidationError as exc:
+            raise_serializer_validation_error(exc)
+
+        return room
+
+    def update(self, instance, validated_data):
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+
+        try:
+            instance.save()
+        except DjangoValidationError as exc:
+            raise_serializer_validation_error(exc)
+
+        return instance
 
 
 class RoomSummarySerializer(serializers.ModelSerializer):
@@ -172,11 +198,9 @@ class SessionWriteSerializer(serializers.ModelSerializer):
         session = Session(**validated_data)
 
         try:
-            session.full_clean()
+            session.save()
         except DjangoValidationError as exc:
-            raise serializers.ValidationError(exc.message_dict) from exc
-
-        session.save()
+            raise_serializer_validation_error(exc)
 
         seats = Seat.objects.select_related("row").filter(row__room=session.room)
 
@@ -191,11 +215,10 @@ class SessionWriteSerializer(serializers.ModelSerializer):
             setattr(instance, field, value)
 
         try:
-            instance.full_clean()
+            instance.save()
         except DjangoValidationError as exc:
-            raise serializers.ValidationError(exc.message_dict) from exc
+            raise_serializer_validation_error(exc)
 
-        instance.save()
         return instance
 
 

--- a/backend/catalog/serializers.py
+++ b/backend/catalog/serializers.py
@@ -1,9 +1,9 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from rest_framework import serializers
 
-from django.db import transaction
-
 from catalog.models import Genre, Movie, Room, Session
-from reservations.models import SessionSeat, Seat
+from reservations.models import SessionSeat, SessionSeatStatus, Seat
 
 
 class GenreSerializer(serializers.ModelSerializer):
@@ -24,6 +24,18 @@ class RoomSerializer(serializers.ModelSerializer):
         model = Room
         fields = ["id", "name", "capacity", "created_at", "updated_at"]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    def validate_capacity(self, value):
+        if self.instance is None:
+            return value
+
+        actual_seat_count = Seat.objects.filter(row__room=self.instance).count()
+        if value < actual_seat_count:
+            raise serializers.ValidationError(
+                "Room capacity cannot be lower than the number of registered seats."
+            )
+
+        return value
 
 
 class RoomSummarySerializer(serializers.ModelSerializer):
@@ -120,11 +132,51 @@ class SessionWriteSerializer(serializers.ModelSerializer):
                 {"room": ("Updating the room of an existing session is not supported.")}
             )
 
+        if self.instance is not None:
+            protected_session_fields = [
+                "movie",
+                "room",
+                "start_time",
+                "end_time",
+                "base_price",
+            ]
+            changed_protected_fields = [
+                field
+                for field in protected_session_fields
+                if field in attrs and attrs[field] != getattr(self.instance, field)
+            ]
+
+            if changed_protected_fields:
+                has_reserved_or_purchased_seats = SessionSeat.objects.filter(
+                    session=self.instance,
+                    status__in=[
+                        SessionSeatStatus.RESERVED,
+                        SessionSeatStatus.PURCHASED,
+                    ],
+                ).exists()
+
+                if has_reserved_or_purchased_seats:
+                    raise serializers.ValidationError(
+                        {
+                            field: (
+                                "Sessions with reserved or purchased seats cannot change movie, room, time, or price."
+                            )
+                            for field in changed_protected_fields
+                        }
+                    )
+
         return attrs
 
     @transaction.atomic
     def create(self, validated_data):
-        session = Session.objects.create(**validated_data)
+        session = Session(**validated_data)
+
+        try:
+            session.full_clean()
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict) from exc
+
+        session.save()
 
         seats = Seat.objects.select_related("row").filter(row__room=session.room)
 
@@ -133,6 +185,18 @@ class SessionWriteSerializer(serializers.ModelSerializer):
         SessionSeat.objects.bulk_create(session_seats)
 
         return session
+
+    def update(self, instance, validated_data):
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+
+        try:
+            instance.full_clean()
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict) from exc
+
+        instance.save()
+        return instance
 
 
 class SessionReadSerializer(serializers.ModelSerializer):

--- a/backend/cinepolis_natal_api/urls.py
+++ b/backend/cinepolis_natal_api/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="api-schema"),
         name="api-docs",
     ),
-    path("api/v1/auth/", include("users.urls")),
+    path("api/v1/auth/", include("users.auth_urls")),
     path("api/v1/catalog/", include("catalog.urls")),
     path("api/v1/reservation/", include("reservations.urls")),
     path("api/v1/users/", include("users.urls")),

--- a/backend/postman/Cinepolis-Natal-API.postman_collection.json
+++ b/backend/postman/Cinepolis-Natal-API.postman_collection.json
@@ -121,36 +121,6 @@
           }
         },
         {
-          "name": "Auth Me",
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "{{ACCESS_TOKEN}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{BASE_URL}}/api/v1/auth/me/",
-              "host": [
-                "{{BASE_URL}}"
-              ],
-              "path": [
-                "api",
-                "v1",
-                "auth",
-                "me",
-                ""
-              ]
-            }
-          }
-        },
-        {
           "name": "Users Me",
           "request": {
             "auth": {

--- a/backend/reservations/models.py
+++ b/backend/reservations/models.py
@@ -75,6 +75,19 @@ class Seat(models.Model):
         if self.number <= 0:
             raise ValidationError({"number": "Seat number must be greater than zero."})
 
+        if not self.row_id:
+            return
+
+        room = self.row.room
+        existing_seats = Seat.objects.filter(row__room=room)
+        if self.pk:
+            existing_seats = existing_seats.exclude(pk=self.pk)
+
+        if existing_seats.count() >= room.capacity:
+            raise ValidationError(
+                {"row": ("Room capacity cannot be exceeded by adding another seat.")}
+            )
+
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
@@ -273,10 +286,7 @@ class Ticket(models.Model):
 
             if self.amount_paid is None:
                 errors["amount_paid"] = "Ticket amount paid is required."
-            elif (
-                Decimal(self.amount_paid).quantize(Decimal("0.01"))
-                != expected_amount
-            ):
+            elif Decimal(self.amount_paid).quantize(Decimal("0.01")) != expected_amount:
                 errors["amount_paid"] = (
                     "Ticket amount paid must match the session price and ticket type."
                 )

--- a/backend/reservations/serializers.py
+++ b/backend/reservations/serializers.py
@@ -1,5 +1,7 @@
+from django.utils import timezone
 from rest_framework import serializers
 
+from catalog.models import Session
 from reservations.exceptions import (
     InvalidPaymentMethodApiException,
     InvalidTicketTypeApiException,
@@ -15,11 +17,41 @@ from reservations.models import (
 )
 
 
+def validate_room_layout_changes_are_allowed(room_ids):
+    room_ids = {room_id for room_id in room_ids if room_id is not None}
+
+    if Session.objects.filter(
+        room_id__in=room_ids,
+        start_time__gte=timezone.now(),
+    ).exists():
+        raise serializers.ValidationError(
+            {
+                "room": (
+                    "Room seat layout cannot be changed while future sessions exist."
+                )
+            }
+        )
+
+
 class SeatRowSerializer(serializers.ModelSerializer):
     class Meta:
         model = SeatRow
         fields = ["id", "room", "name"]
         read_only_fields = ["id"]
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        room = attrs.get("room", getattr(self.instance, "room", None))
+        if room is None:
+            return attrs
+
+        room_ids = {room.id}
+        if self.instance is not None:
+            room_ids.add(self.instance.room_id)
+
+        validate_room_layout_changes_are_allowed(room_ids)
+        return attrs
 
 
 class SeatSerializer(serializers.ModelSerializer):
@@ -27,6 +59,31 @@ class SeatSerializer(serializers.ModelSerializer):
         model = Seat
         fields = ["id", "row", "number", "is_accessible"]
         read_only_fields = ["id"]
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        row = attrs.get("row", getattr(self.instance, "row", None))
+        if row is None:
+            return attrs
+
+        room_ids = {row.room_id}
+
+        if self.instance is not None:
+            room_ids.add(self.instance.row.room_id)
+
+        validate_room_layout_changes_are_allowed(room_ids)
+
+        seats_in_room = Seat.objects.filter(row__room=row.room)
+        if self.instance is not None:
+            seats_in_room = seats_in_room.exclude(pk=self.instance.pk)
+
+        if seats_in_room.count() >= row.room.capacity:
+            raise serializers.ValidationError(
+                {"row": ("Room capacity cannot be exceeded by adding another seat.")}
+            )
+
+        return attrs
 
 
 class SessionSeatSerializer(serializers.ModelSerializer):

--- a/backend/reservations/views.py
+++ b/backend/reservations/views.py
@@ -34,6 +34,7 @@ from reservations.serializers import (
     TemporaryReservationReleaseResponseSerializer,
     TemporaryReservationRequestSerializer,
     TemporaryReservationResponseSerializer,
+    validate_room_layout_changes_are_allowed,
 )
 from reservations.services import (
     TemporaryReservationReleaseService,
@@ -68,6 +69,10 @@ class SeatRowDetailView(RetrieveUpdateDestroyAPIView):
     serializer_class = SeatRowSerializer
     permission_classes = [IsAdminUser]
 
+    def perform_destroy(self, instance):
+        validate_room_layout_changes_are_allowed({instance.room_id})
+        instance.delete()
+
 
 @extend_schema(tags=["Reservations"], summary="List or create seats")
 class SeatListCreateView(ListCreateAPIView):
@@ -81,6 +86,10 @@ class SeatDetailView(RetrieveUpdateDestroyAPIView):
     queryset = Seat.objects.select_related("row", "row__room").all()
     serializer_class = SeatSerializer
     permission_classes = [IsAdminUser]
+
+    def perform_destroy(self, instance):
+        validate_room_layout_changes_are_allowed({instance.row.room_id})
+        instance.delete()
 
 
 @extend_schema(tags=["Reservations"], summary="List or create session seats")

--- a/backend/tests/integration/test_auth_user_route_contract.py
+++ b/backend/tests/integration/test_auth_user_route_contract.py
@@ -1,0 +1,71 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_auth_routes_exist_only_under_auth_prefix():
+    client = APIClient()
+
+    intended_routes = [
+        "/api/v1/auth/register/",
+        "/api/v1/auth/login/",
+        "/api/v1/auth/token/refresh/",
+    ]
+    wrong_prefix_routes = [
+        "/api/v1/users/register/",
+        "/api/v1/users/login/",
+        "/api/v1/users/token/refresh/",
+    ]
+
+    for route in intended_routes:
+        response = client.post(route, {}, format="json")
+        assert response.status_code != status.HTTP_404_NOT_FOUND
+
+    for route in wrong_prefix_routes:
+        response = client.post(route, {}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_user_routes_exist_only_under_users_prefix():
+    client = APIClient()
+
+    intended_routes = [
+        "/api/v1/users/me/",
+        "/api/v1/users/me/tickets/",
+    ]
+    wrong_prefix_routes = [
+        "/api/v1/auth/me/",
+        "/api/v1/auth/me/tickets/",
+    ]
+
+    for route in intended_routes:
+        response = client.get(route)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    for route in wrong_prefix_routes:
+        response = client.get(route)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_openapi_schema_documents_only_canonical_auth_and_user_routes():
+    client = APIClient()
+
+    response = client.get("/api/schema/")
+
+    assert response.status_code == status.HTTP_200_OK
+    schema = response.content.decode()
+
+    assert "/api/v1/auth/register/" in schema
+    assert "/api/v1/auth/login/" in schema
+    assert "/api/v1/auth/token/refresh/" in schema
+    assert "/api/v1/users/me/" in schema
+    assert "/api/v1/users/me/tickets/" in schema
+
+    assert "/api/v1/users/register/" not in schema
+    assert "/api/v1/users/login/" not in schema
+    assert "/api/v1/users/token/refresh/" not in schema
+    assert "/api/v1/auth/me/" not in schema
+    assert "/api/v1/auth/me/tickets/" not in schema

--- a/backend/tests/integration/test_current_user.py
+++ b/backend/tests/integration/test_current_user.py
@@ -21,7 +21,7 @@ class TestCurrentUserView:
         )
 
     def test_current_user_requires_authentication(self, api_client):
-        response = api_client.get("/api/v1/auth/me/")
+        response = api_client.get("/api/v1/users/me/")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert response.data["error"]["code"] == "NOT_AUTHENTICATED"
@@ -32,7 +32,7 @@ class TestCurrentUserView:
 
         api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
 
-        response = api_client.get("/api/v1/auth/me/")
+        response = api_client.get("/api/v1/users/me/")
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["id"] == str(user.id)
@@ -43,7 +43,7 @@ class TestCurrentUserView:
     def test_current_user_returns_401_with_invalid_token(self, api_client):
         api_client.credentials(HTTP_AUTHORIZATION="Bearer invalid-token")
 
-        response = api_client.get("/api/v1/auth/me/")
+        response = api_client.get("/api/v1/users/me/")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert response.data["error"]["code"] == "NOT_AUTHENTICATED"

--- a/backend/tests/integration/test_domain_consistency_api.py
+++ b/backend/tests/integration/test_domain_consistency_api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from decimal import Decimal
 
 import pytest
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -66,6 +67,31 @@ def test_room_capacity_cannot_be_lower_than_registered_seats(admin_client):
 
 
 @pytest.mark.django_db
+def test_room_save_time_validation_errors_return_400(admin_client, monkeypatch):
+    room = Room.objects.create(name="Save-Time Room", capacity=2)
+    original_save = Room.save
+
+    def raise_on_api_update(self, *args, **kwargs):
+        if self.pk == room.pk and self.name == "Updated Save-Time Room":
+            raise DjangoValidationError(
+                {"capacity": "Room capacity changed concurrently."}
+            )
+
+        return original_save(self, *args, **kwargs)
+
+    monkeypatch.setattr(Room, "save", raise_on_api_update)
+
+    response = admin_client.patch(
+        f"/api/v1/catalog/rooms/{room.id}/",
+        {"name": "Updated Save-Time Room"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "capacity" in response.data["error"]["details"]
+
+
+@pytest.mark.django_db
 def test_room_capacity_cannot_be_exceeded_by_new_seats(admin_client):
     room = Room.objects.create(name="Full Room", capacity=1)
     row = SeatRow.objects.create(room=room, name="A")
@@ -119,6 +145,73 @@ def test_session_creation_generates_seat_map_and_blocks_future_layout_changes(
     assert create_seat_response.status_code == status.HTTP_400_BAD_REQUEST
     assert delete_seat_response.status_code == status.HTTP_400_BAD_REQUEST
     assert SessionSeat.objects.filter(session=session).count() == 1
+
+
+@pytest.mark.django_db
+def test_session_create_save_time_validation_errors_return_400(
+    admin_client,
+    movie,
+    monkeypatch,
+):
+    room = Room.objects.create(name="Create Save-Time Session Room", capacity=1)
+    original_save = Session.save
+
+    def raise_on_api_create(self, *args, **kwargs):
+        if (
+            not Session.objects.filter(pk=self.pk).exists()
+            and str(self.base_price) == "35.00"
+        ):
+            raise DjangoValidationError({"base_price": "Save-time price error."})
+
+        return original_save(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "save", raise_on_api_create)
+
+    response = admin_client.post(
+        "/api/v1/catalog/sessions/",
+        {
+            "movie": str(movie.id),
+            "room": str(room.id),
+            "start_time": (timezone.now() + timedelta(days=1)).isoformat(),
+            "end_time": (timezone.now() + timedelta(days=1, hours=2)).isoformat(),
+            "base_price": "35.00",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "base_price" in response.data["error"]["details"]
+    assert Session.objects.filter(room=room).count() == 0
+
+
+@pytest.mark.django_db
+def test_session_update_save_time_validation_errors_return_400(
+    admin_client,
+    movie,
+    monkeypatch,
+):
+    room = Room.objects.create(name="Update Save-Time Session Room", capacity=1)
+    session = create_future_session(movie, room)
+    original_save = Session.save
+
+    def raise_on_api_update(self, *args, **kwargs):
+        if self.pk == session.pk and str(self.base_price) == "35.00":
+            raise DjangoValidationError({"base_price": "Save-time price error."})
+
+        return original_save(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "save", raise_on_api_update)
+
+    response = admin_client.patch(
+        f"/api/v1/catalog/sessions/{session.id}/",
+        {"base_price": "35.00"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "base_price" in response.data["error"]["details"]
+    session.refresh_from_db()
+    assert session.base_price == Decimal("30.00")
 
 
 @pytest.mark.django_db

--- a/backend/tests/integration/test_domain_consistency_api.py
+++ b/backend/tests/integration/test_domain_consistency_api.py
@@ -1,0 +1,222 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from catalog.models import Movie, Room, Session
+from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus, Ticket
+from users.models import User
+
+
+@pytest.fixture
+def admin_client():
+    admin = User.objects.create_user(
+        email="domain-admin@example.com",
+        username="domain_admin",
+        password="StrongPass123",
+        is_staff=True,
+    )
+    client = APIClient()
+    client.force_authenticate(user=admin)
+    return client
+
+
+@pytest.fixture
+def movie():
+    return Movie.objects.create(
+        title=f"Domain Movie {Movie.objects.count() + 1}",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+
+def create_future_session(movie, room, *, base_price="30.00"):
+    start_time = timezone.now() + timedelta(days=1)
+    return Session.objects.create(
+        movie=movie,
+        room=room,
+        start_time=start_time,
+        end_time=start_time + timedelta(hours=2),
+        base_price=base_price,
+    )
+
+
+@pytest.mark.django_db
+def test_room_capacity_cannot_be_lower_than_registered_seats(admin_client):
+    room = Room.objects.create(name="Capacity Room", capacity=2)
+    row = SeatRow.objects.create(room=room, name="A")
+    Seat.objects.create(row=row, number=1)
+    Seat.objects.create(row=row, number=2)
+
+    response = admin_client.patch(
+        f"/api/v1/catalog/rooms/{room.id}/",
+        {"capacity": 1},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "capacity" in response.data["error"]["details"]
+    room.refresh_from_db()
+    assert room.capacity == 2
+
+
+@pytest.mark.django_db
+def test_room_capacity_cannot_be_exceeded_by_new_seats(admin_client):
+    room = Room.objects.create(name="Full Room", capacity=1)
+    row = SeatRow.objects.create(room=room, name="A")
+    Seat.objects.create(row=row, number=1)
+
+    response = admin_client.post(
+        "/api/v1/reservation/seats/",
+        {"row": str(row.id), "number": 2},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "row" in response.data["error"]["details"]
+    assert Seat.objects.filter(row=row).count() == 1
+
+
+@pytest.mark.django_db
+def test_session_creation_generates_seat_map_and_blocks_future_layout_changes(
+    admin_client,
+    movie,
+):
+    room = Room.objects.create(name="Session Layout Room", capacity=2)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+
+    response = admin_client.post(
+        "/api/v1/catalog/sessions/",
+        {
+            "movie": str(movie.id),
+            "room": str(room.id),
+            "start_time": (timezone.now() + timedelta(days=1)).isoformat(),
+            "end_time": (timezone.now() + timedelta(days=1, hours=2)).isoformat(),
+            "base_price": "30.00",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    session = Session.objects.get(id=response.data["id"])
+    assert list(
+        SessionSeat.objects.filter(session=session).values_list("seat_id", flat=True)
+    ) == [seat.id]
+
+    create_seat_response = admin_client.post(
+        "/api/v1/reservation/seats/",
+        {"row": str(row.id), "number": 2},
+        format="json",
+    )
+    delete_seat_response = admin_client.delete(f"/api/v1/reservation/seats/{seat.id}/")
+
+    assert create_seat_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert delete_seat_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert SessionSeat.objects.filter(session=session).count() == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("field", "value_factory"),
+    [
+        ("movie", lambda context: str(context["other_movie"].id)),
+        ("room", lambda context: str(context["other_room"].id)),
+        (
+            "start_time",
+            lambda context: (timezone.now() + timedelta(days=2)).isoformat(),
+        ),
+        (
+            "end_time",
+            lambda context: (timezone.now() + timedelta(days=2, hours=2)).isoformat(),
+        ),
+        ("base_price", lambda context: "45.00"),
+    ],
+)
+def test_reserved_session_sensitive_fields_cannot_be_mutated(
+    admin_client,
+    movie,
+    field,
+    value_factory,
+):
+    room = Room.objects.create(name="Reserved Session Room", capacity=1)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+    session = create_future_session(movie, room)
+    SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.RESERVED,
+        locked_by_user=User.objects.create_user(
+            email="reserved-user@example.com",
+            username="reserved_user",
+            password="StrongPass123",
+        ),
+        lock_expires_at=timezone.now() + timedelta(minutes=10),
+    )
+    other_room = Room.objects.create(name="Other Session Room", capacity=1)
+    other_movie = Movie.objects.create(
+        title="Other Domain Movie",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-22",
+        poster_url="https://example.com/other-poster.jpg",
+    )
+    context = {"other_room": other_room, "other_movie": other_movie}
+
+    response = admin_client.patch(
+        f"/api/v1/catalog/sessions/{session.id}/",
+        {field: value_factory(context)},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    session.refresh_from_db()
+    assert session.movie_id == movie.id
+    assert session.room_id == room.id
+    assert session.base_price == Decimal("30.00")
+
+
+@pytest.mark.django_db
+def test_purchased_ticket_history_is_protected_from_session_price_changes(
+    admin_client,
+    movie,
+):
+    user = User.objects.create_user(
+        email="ticket-owner@example.com",
+        username="ticket_owner",
+        password="StrongPass123",
+    )
+    room = Room.objects.create(name="Purchased Session Room", capacity=1)
+    row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=row, number=1)
+    session = create_future_session(movie, room)
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.PURCHASED,
+    )
+    ticket = Ticket.objects.create(
+        user=user,
+        session_seat=session_seat,
+        ticket_type="inteira",
+        amount_paid="30.00",
+        payment_method="pix",
+    )
+
+    response = admin_client.patch(
+        f"/api/v1/catalog/sessions/{session.id}/",
+        {"base_price": "45.00"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    session.refresh_from_db()
+    ticket.refresh_from_db()
+    assert session.base_price == Decimal("30.00")
+    assert ticket.amount_paid == Decimal("30.00")

--- a/backend/tests/integration/test_error_handling_api.py
+++ b/backend/tests/integration/test_error_handling_api.py
@@ -12,7 +12,6 @@ from rest_framework.throttling import SimpleRateThrottle
 from catalog.models import Genre, Movie, Room, Session
 from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus
 
-
 User = get_user_model()
 
 
@@ -126,7 +125,7 @@ def test_error_schema_for_400_validation_error(api_client):
 
 @pytest.mark.django_db
 def test_error_schema_for_401_not_authenticated(api_client):
-    response = api_client.get("/api/v1/auth/me/")
+    response = api_client.get("/api/v1/users/me/")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.data["error"]["code"] == "NOT_AUTHENTICATED"

--- a/backend/tests/integration/test_user_login.py
+++ b/backend/tests/integration/test_user_login.py
@@ -6,7 +6,6 @@ from rest_framework.test import APIClient
 
 from users.models import User
 
-
 _ip_counter = count(1)
 
 
@@ -65,7 +64,7 @@ class TestUserLoginView:
         api_client.credentials(
             HTTP_AUTHORIZATION=f"Bearer {refresh_response.data['access']}"
         )
-        current_user_response = api_client.get("/api/v1/auth/me/")
+        current_user_response = api_client.get("/api/v1/users/me/")
 
         assert current_user_response.status_code == status.HTTP_200_OK
         assert current_user_response.data["id"] == str(user.id)

--- a/backend/users/auth_urls.py
+++ b/backend/users/auth_urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from users.views import (
+    UserLoginView,
+    UserRegistrationView,
+    UserTokenRefreshView,
+)
+
+urlpatterns = [
+    path("register/", UserRegistrationView.as_view(), name="user-register"),
+    path("login/", UserLoginView.as_view(), name="user-login"),
+    path(
+        "token/refresh/",
+        UserTokenRefreshView.as_view(),
+        name="token-refresh",
+    ),
+]

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -3,19 +3,9 @@ from django.urls import path
 from users.views import (
     CurrentUserView,
     MyTicketsView,
-    UserLoginView,
-    UserRegistrationView,
-    UserTokenRefreshView,
 )
 
 urlpatterns = [
-    path("register/", UserRegistrationView.as_view(), name="user-register"),
-    path("login/", UserLoginView.as_view(), name="user-login"),
-    path(
-        "token/refresh/",
-        UserTokenRefreshView.as_view(),
-        name="token-refresh",
-    ),
     path("me/", CurrentUserView.as_view(), name="user-current"),
     path("me/tickets/", MyTicketsView.as_view(), name="user-my-tickets"),
 ]

--- a/product-requirements-document.md
+++ b/product-requirements-document.md
@@ -384,7 +384,6 @@ Authentication and user endpoints:
 | `POST` | `/api/v1/auth/register/` | Register a user |
 | `POST` | `/api/v1/auth/login/` | Authenticate and issue access and refresh tokens |
 | `POST` | `/api/v1/auth/token/refresh/` | Refresh an access token from a valid refresh token |
-| `GET` | `/api/v1/auth/me/` | Return current authenticated user profile |
 | `GET` | `/api/v1/users/me/` | Return current authenticated user profile |
 | `GET` | `/api/v1/users/me/tickets/` | Return authenticated user's tickets |
 
@@ -417,10 +416,22 @@ Reservation endpoints:
 | `POST`, `DELETE` | `/api/v1/reservation/sessions/{session_id}/reservations/` | Create or release temporary reservations |
 | `POST` | `/api/v1/reservation/checkout/` | Finalize checkout for temporarily reserved seats |
 
-The backend currently includes `users.urls` under both `/api/v1/auth/` and
-`/api/v1/users/`. The canonical frontend-facing routes are the ones listed above;
-the duplicated user-route aliases are implementation compatibility paths and
-should not be preferred by new clients.
+Authentication routes and user-profile routes are intentionally split. Duplicated
+wrong-prefix aliases such as `/api/v1/users/login/` and `/api/v1/auth/me/`
+return `404` and are not documented in OpenAPI.
+
+### 9.1.1 Room, Seat, and Session Consistency Rules
+
+- `Room.capacity` is a declarative maximum for the room layout. The registered
+  `Seat` count for a room cannot exceed `capacity`, and `capacity` cannot be
+  reduced below the number of registered seats.
+- Creating a `Session` through the API generates one `SessionSeat` for each
+  registered seat in the room at creation time.
+- Room seat layout changes are blocked while future sessions exist for that
+  room. This prevents future session seat maps from becoming silently incomplete
+  after sessions have been published.
+- Existing sessions cannot change `movie`, `room`, `start_time`, `end_time`, or
+  `base_price` after any seat in the session is reserved or purchased.
 
 ### 9.2 Catalog Query Parameters (amended)
 


### PR DESCRIPTION
## Objective

Split accidentally duplicated auth/user routes and enforce domain consistency around room capacity, session seat generation, room seating changes, and protected session mutations after reservations or purchases exist.

## What was done

### 1. Auth and user route cleanup

Separated authentication routes from user profile and ticket routes:

- Kept auth endpoints under `/api/v1/auth/`.
- Kept current-user and my-ticket endpoints under `/api/v1/users/`.
- Removed accidental wrong-prefix routes such as `/api/v1/users/login/` and `/api/v1/auth/me/`.

The selected compatibility policy is immediate `404` for wrong-prefix duplicate routes instead of deprecated aliases.

### 2. OpenAPI route contract

Added route contract coverage proving Swagger/OpenAPI only documents the intended canonical endpoints:

- `POST /api/v1/auth/register/`
- `POST /api/v1/auth/login/`
- `POST /api/v1/auth/token/refresh/`
- `GET /api/v1/users/me/`
- `GET /api/v1/users/me/tickets/`

### 3. Room capacity consistency

Defined `Room.capacity` as the declarative maximum size for the room layout:

- registered seats cannot exceed room capacity
- room capacity cannot be reduced below the registered seat count

This prevents room capacity and actual seats from silently diverging.

### 4. Session seat generation and layout safety

Preserved automatic `SessionSeat` generation when a session is created through the API.

Added safeguards to block seat row and seat layout changes while future sessions exist for that room. This prevents already-published future sessions from silently having incomplete seat maps after room layout edits.

### 5. Session mutation safety

Blocked sensitive session changes once any seat in the session is reserved or purchased:

- `movie`
- `room`
- `start_time`
- `end_time`
- `base_price`

This protects reservation state and purchased ticket history from being corrupted by later session edits.

### 6. Integration test coverage

Added and updated tests for:

- auth routes existing only under `/api/v1/auth/`
- user routes existing only under `/api/v1/users/`
- OpenAPI excluding wrong-prefix duplicates
- room capacity consistency
- session seat generation behavior
- layout changes being blocked when future sessions exist
- protected session fields being blocked for reserved sessions
- purchased ticket history remaining stable after attempted session edits

### 7. Documentation and Postman updates

Updated the PRD, backend README, and Postman collection to reflect the final route structure and documented business rules.

## How to test

### Automated validation

Run the full backend test suite with Docker:

```bash
docker compose run --rm backend pytest -q
```

### Optional targeted runs

```bash
docker compose run --rm backend pytest tests/integration/test_auth_user_route_contract.py tests/integration/test_domain_consistency_api.py -q
```

### Formatting and contract checks

```bash
docker compose run --rm backend black --check cinepolis_natal_api/urls.py users/auth_urls.py users/urls.py catalog/models.py catalog/serializers.py reservations/models.py reservations/serializers.py reservations/views.py tests/integration/test_auth_user_route_contract.py tests/integration/test_domain_consistency_api.py tests/integration/test_current_user.py tests/integration/test_user_login.py tests/integration/test_error_handling_api.py
docker compose run --rm backend python -m json.tool postman/Cinepolis-Natal-API.postman_collection.json
```

## Expected Result

- Auth and user routes are no longer accidentally duplicated.
- Wrong-prefix duplicate routes return `404`.
- API docs reflect only the canonical route structure.
- Room capacity and actual seats cannot silently diverge.
- Existing future sessions cannot become inconsistent with room seat layout changes.
- Reserved and purchased sessions cannot be mutated in ways that corrupt ticket history.
- Documentation and Postman assets match the final API contract.
- Full Docker-based backend test suite passes successfully.

closes #75 
