### PR TITLE
feat: implement typed frontend API client

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveApiBaseUrl } from "./client";
+import {
+  API_ERROR_MESSAGES,
+  ApiError,
+  apiRequest,
+  buildApiUrl,
+  getApiErrorUserMessage,
+  isPaginatedResponse,
+  resolveApiBaseUrl,
+  type PaginatedResponse,
+} from "./client";
 
 test("resolveApiBaseUrl uses the configured backend base URL without trailing slashes", () => {
   assert.equal(
@@ -12,4 +21,146 @@ test("resolveApiBaseUrl uses the configured backend base URL without trailing sl
 
 test("resolveApiBaseUrl falls back to the local backend URL", () => {
   assert.equal(resolveApiBaseUrl(""), "http://localhost:8000");
+});
+
+test("buildApiUrl joins relative paths with the normalized backend base URL", () => {
+  assert.equal(
+    buildApiUrl("api/v1/catalog/movies/", "http://api.local:8000/"),
+    "http://api.local:8000/api/v1/catalog/movies/"
+  );
+});
+
+test("apiRequest applies JSON headers, bearer token, and custom request options", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://api.local:8000/api/v1/protected/");
+      assert.equal(init?.method, "POST");
+      assert.equal(init?.cache, "no-store");
+      assert.equal(init?.body, JSON.stringify({ ok: true }));
+
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("Accept"), "application/json");
+      assert.equal(headers.get("Content-Type"), "application/json");
+      assert.equal(headers.get("Authorization"), "Bearer access-token");
+
+      return Response.json({ success: true });
+    };
+
+    const response = await apiRequest<{ success: boolean }>(
+      "/api/v1/protected/",
+      {
+        baseUrl: "http://api.local:8000/",
+        cache: "no-store",
+        json: { ok: true },
+        method: "POST",
+        token: "access-token",
+      }
+    );
+
+    assert.deepEqual(response, { success: true });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("apiRequest safely returns null for empty responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => new Response(null, { status: 204 });
+
+    const response = await apiRequest<null>("/api/v1/logout/", {
+      baseUrl: "http://api.local:8000",
+    });
+
+    assert.equal(response, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("apiRequest throws ApiError with backend envelope metadata", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          error: {
+            code: "SEAT_ALREADY_RESERVED",
+            details: { session_seat_id: 42 },
+            message: "One or more selected seats are already reserved.",
+            status: 409,
+          },
+        },
+        {
+          headers: { "X-Correlation-ID": "request-123" },
+          status: 409,
+        }
+      );
+
+    await assert.rejects(
+      apiRequest("/api/v1/reservations/seats/", {
+        baseUrl: "http://api.local:8000",
+      }),
+      (error) => {
+        assert.ok(error instanceof ApiError);
+        assert.equal(error.status, 409);
+        assert.equal(error.code, "SEAT_ALREADY_RESERVED");
+        assert.equal(error.message, "One or more selected seats are already reserved.");
+        assert.deepEqual(error.details, { session_seat_id: 42 });
+        assert.equal(error.correlationId, "request-123");
+        return true;
+      }
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getApiErrorUserMessage maps known backend codes without exposing raw backend messages", () => {
+  for (const [code, message] of Object.entries(API_ERROR_MESSAGES)) {
+    const error = new ApiError("Raw backend message.", 400, {
+      code,
+      details: {},
+    });
+
+    assert.equal(getApiErrorUserMessage(error), message);
+    assert.notEqual(getApiErrorUserMessage(error), error.message);
+  }
+});
+
+test("getApiErrorUserMessage falls back safely for unknown backend codes", () => {
+  const error = new ApiError("Raw backend detail.", 400, {
+    code: "UNEXPECTED_BACKEND_CODE",
+    details: {},
+  });
+
+  assert.equal(
+    getApiErrorUserMessage(error),
+    "Não foi possível concluir a solicitação. Tente novamente."
+  );
+});
+
+test("isPaginatedResponse recognizes reusable DRF paginated response shape", () => {
+  type MovieSummary = {
+    id: number;
+    title: string;
+  };
+
+  const response: unknown = {
+    count: 1,
+    next: null,
+    previous: null,
+    results: [{ id: 1, title: "Interestelar" }],
+  };
+
+  assert.equal(isPaginatedResponse<MovieSummary>(response), true);
+
+  if (isPaginatedResponse<MovieSummary>(response)) {
+    const paginated: PaginatedResponse<MovieSummary> = response;
+    assert.equal(paginated.results[0]?.title, "Interestelar");
+  }
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,73 +1,270 @@
 const DEFAULT_API_BASE_URL = "http://localhost:8000";
 
-type ApiRequestOptions = RequestInit & {
+export type KnownBackendErrorCode =
+  | "VALIDATION_FAILED"
+  | "INVALID_CREDENTIALS"
+  | "NOT_AUTHENTICATED"
+  | "PERMISSION_DENIED"
+  | "RESOURCE_NOT_FOUND"
+  | "SEAT_ALREADY_RESERVED"
+  | "INVALID_TICKET_TYPE"
+  | "INVALID_PAYMENT_METHOD"
+  | "THROTTLED"
+  | "INTERNAL_SERVER_ERROR";
+
+export type BackendErrorCode = KnownBackendErrorCode | (string & {});
+
+export type ApiErrorEnvelope = {
+  error: {
+    code: BackendErrorCode;
+    message: string;
+    status: number;
+    details: unknown;
+  };
+};
+
+export type PaginatedResponse<T> = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
+
+export type ApiRequestOptions = RequestInit & {
+  baseUrl?: string;
+  json?: unknown;
   token?: string;
 };
 
 export class ApiError extends Error {
+  public readonly code: BackendErrorCode;
+  public readonly details: unknown;
+  public readonly correlationId: string | null;
+
   constructor(
     message: string,
     public readonly status: number,
-    public readonly details: unknown
+    {
+      code,
+      correlationId = null,
+      details,
+    }: {
+      code: BackendErrorCode;
+      correlationId?: string | null;
+      details: unknown;
+    }
   ) {
     super(message);
     this.name = "ApiError";
+    this.code = code;
+    this.details = details;
+    this.correlationId = correlationId;
   }
 }
 
 export function resolveApiBaseUrl(
   configuredUrl = process.env.NEXT_PUBLIC_API_BASE_URL
 ) {
-  return (configuredUrl || DEFAULT_API_BASE_URL).replace(/\/+$/, "");
+  const baseUrl = configuredUrl?.trim() || DEFAULT_API_BASE_URL;
+  return baseUrl.replace(/\/+$/, "") || DEFAULT_API_BASE_URL;
 }
 
 export const API_BASE_URL = resolveApiBaseUrl();
 
+export function buildApiUrl(path: string, baseUrl = API_BASE_URL) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${resolveApiBaseUrl(baseUrl)}${normalizedPath}`;
+}
+
 export async function apiRequest<T>(
   path: string,
-  { token, headers, ...options }: ApiRequestOptions = {}
+  { baseUrl, json, token, headers, ...options }: ApiRequestOptions = {}
 ): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const requestHeaders = buildHeaders(headers, token);
+  const requestBody =
+    json !== undefined && options.body === undefined
+      ? JSON.stringify(json)
+      : options.body;
+
+  const response = await fetch(buildApiUrl(path, baseUrl), {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...headers,
-    },
+    body: requestBody,
+    headers: requestHeaders,
   });
 
-  const body = await readJson(response);
+  const body = await readResponseBody(response);
 
   if (!response.ok) {
-    const message =
-      getApiErrorMessage(body) || `Request failed with status ${response.status}`;
-    throw new ApiError(message, response.status, body);
+    throw buildApiError(response, body);
   }
 
   return body as T;
 }
 
-async function readJson(response: Response) {
-  if (response.status === 204) {
+export function createApiClient({
+  baseUrl,
+  token,
+}: {
+  baseUrl?: string;
+  token?: string;
+} = {}) {
+  return {
+    request<T>(path: string, options: ApiRequestOptions = {}) {
+      return apiRequest<T>(path, {
+        ...options,
+        baseUrl: options.baseUrl ?? baseUrl,
+        token: options.token ?? token,
+      });
+    },
+  };
+}
+
+export const API_ERROR_MESSAGES: Record<KnownBackendErrorCode, string> = {
+  VALIDATION_FAILED: "Confira as informações preenchidas e tente novamente.",
+  INVALID_CREDENTIALS: "E-mail ou senha incorretos.",
+  NOT_AUTHENTICATED: "Sua sessão expirou. Faça login novamente.",
+  PERMISSION_DENIED: "Você não tem permissão para realizar esta ação.",
+  RESOURCE_NOT_FOUND: "Não encontramos o recurso solicitado.",
+  SEAT_ALREADY_RESERVED:
+    "Este assento foi reservado por outra pessoa. Escolha outro assento.",
+  INVALID_TICKET_TYPE: "O tipo de ingresso selecionado é inválido.",
+  INVALID_PAYMENT_METHOD: "A forma de pagamento selecionada é inválida.",
+  THROTTLED: "Muitas tentativas. Aguarde um momento e tente novamente.",
+  INTERNAL_SERVER_ERROR:
+    "Não foi possível concluir a solicitação. Tente novamente mais tarde.",
+};
+
+export function getApiErrorUserMessage(error: unknown) {
+  if (
+    error instanceof ApiError &&
+    Object.hasOwn(API_ERROR_MESSAGES, error.code)
+  ) {
+    return API_ERROR_MESSAGES[
+      error.code as keyof typeof API_ERROR_MESSAGES
+    ];
+  }
+
+  return "Não foi possível concluir a solicitação. Tente novamente.";
+}
+
+export function isPaginatedResponse<T = unknown>(
+  value: unknown
+): value is PaginatedResponse<T> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.count === "number" &&
+    (typeof value.next === "string" || value.next === null) &&
+    (typeof value.previous === "string" || value.previous === null) &&
+    Array.isArray(value.results)
+  );
+}
+
+function buildHeaders(headers: HeadersInit | undefined, token: string | undefined) {
+  const requestHeaders = new Headers(headers);
+
+  if (!requestHeaders.has("Accept")) {
+    requestHeaders.set("Accept", "application/json");
+  }
+
+  if (!requestHeaders.has("Content-Type")) {
+    requestHeaders.set("Content-Type", "application/json");
+  }
+
+  if (token) {
+    requestHeaders.set("Authorization", `Bearer ${token}`);
+  }
+
+  return requestHeaders;
+}
+
+async function readResponseBody(response: Response) {
+  if (response.status === 204 || response.status === 205) {
     return null;
   }
 
   const text = await response.text();
-  return text ? JSON.parse(text) : null;
-}
-
-function getApiErrorMessage(body: unknown) {
-  if (
-    typeof body === "object" &&
-    body !== null &&
-    "error" in body &&
-    typeof body.error === "object" &&
-    body.error !== null &&
-    "message" in body.error &&
-    typeof body.error.message === "string"
-  ) {
-    return body.error.message;
+  if (!text) {
+    return null;
   }
 
-  return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function buildApiError(response: Response, body: unknown) {
+  const envelope = parseApiErrorEnvelope(body, response.status);
+  const error = envelope.error;
+
+  return new ApiError(error.message, response.status, {
+    code: error.code,
+    correlationId: response.headers.get("X-Correlation-ID"),
+    details: error.details,
+  });
+}
+
+function parseApiErrorEnvelope(
+  body: unknown,
+  responseStatus: number
+): ApiErrorEnvelope {
+  if (isRecord(body) && isRecord(body.error)) {
+    const { code, details, message, status } = body.error;
+
+    if (typeof code === "string" && typeof message === "string") {
+      return {
+        error: {
+          code,
+          details: details ?? {},
+          message,
+          status: typeof status === "number" ? status : responseStatus,
+        },
+      };
+    }
+  }
+
+  return {
+    error: {
+      code: fallbackErrorCode(responseStatus),
+      details: {},
+      message: `Request failed with status ${responseStatus}`,
+      status: responseStatus,
+    },
+  };
+}
+
+function fallbackErrorCode(status: number): BackendErrorCode {
+  if (status === 400) {
+    return "VALIDATION_FAILED";
+  }
+
+  if (status === 401) {
+    return "NOT_AUTHENTICATED";
+  }
+
+  if (status === 403) {
+    return "PERMISSION_DENIED";
+  }
+
+  if (status === 404) {
+    return "RESOURCE_NOT_FOUND";
+  }
+
+  if (status === 429) {
+    return "THROTTLED";
+  }
+
+  return "INTERNAL_SERVER_ERROR";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }


### PR DESCRIPTION
## Objective

Implement the shared typed API layer for the frontend so future auth, catalog, reservation, checkout, and tickets pages can consume the Django/DRF API through one consistent client boundary.

## What was done

### 1. API base client

Extended `frontend/src/api/client.ts` with the shared API request foundation:

- Resolves the backend base URL from `NEXT_PUBLIC_API_BASE_URL`.
- Falls back to `http://localhost:8000` for local development.
- Normalizes trailing slashes on the base URL.
- Builds API URLs from both leading-slash and non-leading-slash paths.
- Applies JSON `Accept` and `Content-Type` headers by default.
- Preserves custom `RequestInit` options.
- Supports a `json` request body helper.
- Supports protected calls through an optional Bearer access token.
- Safely handles JSON responses, empty `204`/`205` responses, and empty response bodies.

### 2. Typed backend error support

Added typed support for the backend error envelope:

- Added `ApiErrorEnvelope`.
- Expanded `ApiError` to preserve `status`, `code`, `message`, `details`, and `correlationId`.
- Parse `{ error: { code, message, status, details } }` responses.
- Added status-based fallback error codes for non-standard error responses.

### 3. Safe user-facing error mapping

Added stable pt-BR UI messages derived from backend `error.code` values:

- `VALIDATION_FAILED`
- `INVALID_CREDENTIALS`
- `NOT_AUTHENTICATED`
- `PERMISSION_DENIED`
- `RESOURCE_NOT_FOUND`
- `SEAT_ALREADY_RESERVED`
- `INVALID_TICKET_TYPE`
- `INVALID_PAYMENT_METHOD`
- `THROTTLED`
- `INTERNAL_SERVER_ERROR`

The UI helper uses error codes instead of displaying raw backend English messages.

### 4. DRF pagination contract

Added reusable pagination support for DRF list responses:

- `PaginatedResponse<T>`
- `isPaginatedResponse<T>()`

This matches the documented shape:

```json
{
  "count": 0,
  "next": null,
  "previous": null,
  "results": []
}
```

### 5. Domain-ready client hook point

Added `createApiClient()` so future domain API modules can share a configured base URL and optional access token without hardcoding auth state into the low-level client.

### 6. Unit test coverage

Expanded `frontend/src/api/client.test.ts` to cover:

- base URL fallback and trailing slash normalization
- URL construction
- JSON headers and custom request options
- Bearer token injection
- empty response handling
- backend error envelope parsing
- typed `ApiError` metadata preservation
- safe error-code-to-message mapping
- unknown error-code fallback behavior
- DRF paginated response type usage

## How to test

### Automated validation

Run the frontend checks:

```bash
cd frontend
npm test
npm run lint
npm run build
```

## Expected Result

- Frontend API calls have a shared typed client boundary.
- API base URL resolution honors `NEXT_PUBLIC_API_BASE_URL` and normalizes trailing slashes.
- Failed requests throw `ApiError` with HTTP status and backend metadata preserved.
- Known backend error codes map to stable pt-BR messages without exposing raw backend messages.
- DRF paginated list responses have reusable TypeScript types.
- Protected requests can include a Bearer access token without coupling the low-level client to auth state.
- Future frontend API modules can build on the shared client.
- Frontend tests, lint, and production build pass.

closes #84 
