### PR TITLE
feat: build visitor auth pages

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { authApi } from "./auth";
+
+test("register posts visitor data to the canonical auth endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/auth/register/");
+      assert.equal(init?.method, "POST");
+      assert.equal(
+        init?.body,
+        JSON.stringify({
+          email: "ana@example.com",
+          password: "senha-secreta",
+          username: "ana",
+        })
+      );
+
+      return Response.json(
+        {
+          created_at: "2026-05-21T10:00:00Z",
+          email: "ana@example.com",
+          id: "user-1",
+          username: "ana",
+        },
+        { status: 201 }
+      );
+    };
+
+    const response = await authApi.register({
+      email: "ana@example.com",
+      password: "senha-secreta",
+      username: "ana",
+    });
+
+    assert.equal(response.email, "ana@example.com");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("login posts credentials and returns in-memory token data", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/auth/login/");
+      assert.equal(init?.method, "POST");
+      assert.equal(
+        init?.body,
+        JSON.stringify({
+          email: "ana@example.com",
+          password: "senha-secreta",
+        })
+      );
+
+      return Response.json({
+        access: "access-token",
+        refresh: "refresh-token",
+      });
+    };
+
+    const response = await authApi.login({
+      email: "ana@example.com",
+      password: "senha-secreta",
+    });
+
+    assert.deepEqual(response, {
+      access: "access-token",
+      refresh: "refresh-token",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -10,6 +10,19 @@ export type LoginResponse = {
   refresh: string;
 };
 
+export type RegisterPayload = {
+  email: string;
+  password: string;
+  username: string;
+};
+
+export type RegisterResponse = {
+  created_at: string;
+  email: string;
+  id: string;
+  username: string;
+};
+
 export type CurrentUserResponse = {
   created_at: string;
   email: string;
@@ -26,6 +39,14 @@ export const authApi = {
     return apiRequest<LoginResponse>("/api/v1/auth/login/", {
       auth: "none",
       json: credentials,
+      method: "POST",
+    });
+  },
+
+  register(payload: RegisterPayload) {
+    return apiRequest<RegisterResponse>("/api/v1/auth/register/", {
+      auth: "none",
+      json: payload,
       method: "POST",
     });
   },

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -278,6 +278,9 @@ test("sanitizeRedirectPath removes sensitive query parameters", () => {
 test("sanitizeRedirectPath rejects external redirect targets", () => {
   assert.equal(sanitizeRedirectPath("https://evil.example/checkout"), "/");
   assert.equal(sanitizeRedirectPath("//evil.example/checkout"), "/");
+  assert.equal(sanitizeRedirectPath(String.raw`\\evil.example\checkout`), "/");
+  assert.equal(sanitizeRedirectPath(String.raw`\checkout`), "/");
+  assert.equal(sanitizeRedirectPath(String.raw`/checkout\evil`), "/");
   assert.equal(sanitizeRedirectPath("http://[malformed"), "/");
 });
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -275,6 +275,12 @@ test("sanitizeRedirectPath removes sensitive query parameters", () => {
   );
 });
 
+test("sanitizeRedirectPath rejects external redirect targets", () => {
+  assert.equal(sanitizeRedirectPath("https://evil.example/checkout"), "/");
+  assert.equal(sanitizeRedirectPath("//evil.example/checkout"), "/");
+  assert.equal(sanitizeRedirectPath("http://[malformed"), "/");
+});
+
 test("buildLoginRedirectUrl keeps redirects path-only and avoids login loops", () => {
   assert.equal(
     buildLoginRedirectUrl("/my-tickets?access=secret&type=upcoming"),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -177,7 +177,23 @@ export function createApiClient({
 }
 
 export function sanitizeRedirectPath(path: string) {
-  const redirectUrl = new URL(path, "http://frontend.local");
+  const candidate = path.trim();
+
+  if (!candidate || candidate.startsWith("//")) {
+    return "/";
+  }
+
+  let redirectUrl: URL;
+
+  try {
+    redirectUrl = new URL(candidate, "http://frontend.local");
+  } catch {
+    return "/";
+  }
+
+  if (redirectUrl.origin !== "http://frontend.local") {
+    return "/";
+  }
 
   for (const key of Array.from(redirectUrl.searchParams.keys())) {
     if (/token|access|refresh|email/i.test(key)) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -179,7 +179,7 @@ export function createApiClient({
 export function sanitizeRedirectPath(path: string) {
   const candidate = path.trim();
 
-  if (!candidate || candidate.startsWith("//")) {
+  if (!candidate || candidate.startsWith("//") || candidate.includes("\\")) {
     return "/";
   }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -208,6 +208,8 @@ h1 {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 16px;
   padding: 24px;
 }
 
@@ -276,6 +278,14 @@ h1 {
   background: var(--color-surface-muted);
 }
 
+.button:disabled,
+.form-field input:disabled,
+.form-field select:disabled,
+.form-field textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
+}
+
 .text-link {
   color: var(--color-brand);
   font-weight: 800;
@@ -309,6 +319,12 @@ h1 {
   min-height: 44px;
   padding: 10px 12px;
   width: 100%;
+}
+
+.form-field input[aria-invalid="true"],
+.form-field select[aria-invalid="true"],
+.form-field textarea[aria-invalid="true"] {
+  border-color: var(--color-error);
 }
 
 .form-error {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { RegisterForm } from "@/components/auth/RegisterForm";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
@@ -10,43 +11,7 @@ export default function RegisterPage() {
       eyebrow="Autenticação"
       title="Criar conta"
     >
-      <div className="panel">
-        <form className="form-grid">
-          <div className="form-field">
-            <label htmlFor="username">Nome de usuário</label>
-            <input
-              autoComplete="username"
-              id="username"
-              name="username"
-              placeholder="seu_nome"
-              type="text"
-            />
-          </div>
-          <div className="form-field">
-            <label htmlFor="email">E-mail</label>
-            <input
-              autoComplete="email"
-              id="email"
-              name="email"
-              placeholder="voce@email.com"
-              type="email"
-            />
-          </div>
-          <div className="form-field">
-            <label htmlFor="password">Senha</label>
-            <input
-              autoComplete="new-password"
-              id="password"
-              name="password"
-              placeholder="Crie uma senha"
-              type="password"
-            />
-          </div>
-          <button className="button button-primary" type="button">
-            Criar conta
-          </button>
-        </form>
-      </div>
+      <RegisterForm />
       <StateMessage title="Já possui cadastro?">
         <Link className="text-link" href="/login">
           Entrar na sua conta

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,25 +1,23 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { getApiErrorUserMessage, sanitizeRedirectPath } from "@/api/client";
 import { useAuth } from "@/contexts/AuthContext";
-
-function getRedirectPath() {
-  if (typeof window === "undefined") {
-    return "/";
-  }
-
-  const redirect = new URLSearchParams(window.location.search).get("redirect");
-  return redirect ? sanitizeRedirectPath(redirect) : "/";
-}
+import {
+  getLoginConfirmationMessage,
+  getLoginFormErrorMessage,
+  getSafeRedirectFromSearch,
+} from "./auth-form-utils";
 
 export function LoginForm() {
   const router = useRouter();
   const { loading, login } = useAuth();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [confirmationMessage, setConfirmationMessage] = useState<string | null>(
+    null
+  );
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -31,19 +29,37 @@ export function LoginForm() {
 
     try {
       await login({ email, password });
-      router.replace(getRedirectPath());
+      const search = typeof window === "undefined" ? "" : window.location.search;
+      router.replace(getSafeRedirectFromSearch(search));
     } catch (error) {
-      setErrorMessage(getApiErrorUserMessage(error));
+      setErrorMessage(getLoginFormErrorMessage(error));
     }
   }
 
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setConfirmationMessage(getLoginConfirmationMessage(window.location.search));
+    }
+  }, []);
+
+  const isSubmitting = loading;
+  const formErrorId = errorMessage ? "login-form-error" : undefined;
+
   return (
     <div className="panel">
+      {confirmationMessage ? (
+        <p className="inline-status inline-status-success" role="status">
+          {confirmationMessage}
+        </p>
+      ) : null}
       <form className="form-grid" onSubmit={handleSubmit}>
         <div className="form-field">
           <label htmlFor="email">E-mail</label>
           <input
+            aria-describedby={formErrorId}
+            aria-invalid={errorMessage ? "true" : undefined}
             autoComplete="email"
+            disabled={isSubmitting}
             id="email"
             name="email"
             placeholder="voce@email.com"
@@ -54,7 +70,10 @@ export function LoginForm() {
         <div className="form-field">
           <label htmlFor="password">Senha</label>
           <input
+            aria-describedby={formErrorId}
+            aria-invalid={errorMessage ? "true" : undefined}
             autoComplete="current-password"
+            disabled={isSubmitting}
             id="password"
             name="password"
             placeholder="Sua senha"
@@ -63,12 +82,12 @@ export function LoginForm() {
           />
         </div>
         {errorMessage ? (
-          <p className="form-error" role="alert">
+          <p className="form-error" id="login-form-error" role="alert">
             {errorMessage}
           </p>
         ) : null}
-        <button className="button button-primary" disabled={loading} type="submit">
-          {loading ? "Entrando..." : "Entrar"}
+        <button className="button button-primary" disabled={isSubmitting} type="submit">
+          {isSubmitting ? "Entrando..." : "Entrar"}
         </button>
       </form>
     </div>

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { authApi } from "@/api/auth";
+import {
+  buildRegisteredLoginUrl,
+  getRegistrationValidationState,
+  type AuthFieldErrors,
+} from "./auth-form-utils";
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [fieldErrors, setFieldErrors] = useState<AuthFieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFieldErrors({});
+    setFormError(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const username = String(formData.get("username") ?? "");
+    const email = String(formData.get("email") ?? "");
+    const password = String(formData.get("password") ?? "");
+
+    try {
+      await authApi.register({ email, password, username });
+      router.replace(buildRegisteredLoginUrl());
+    } catch (error) {
+      const validationState = getRegistrationValidationState(error);
+      setFieldErrors(validationState.fieldErrors);
+      setFormError(validationState.formError);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="panel">
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <div className="form-field">
+          <label htmlFor="username">Nome de usuário</label>
+          <input
+            aria-describedby={fieldErrors.username ? "username-error" : undefined}
+            aria-invalid={fieldErrors.username ? "true" : undefined}
+            autoComplete="username"
+            disabled={isSubmitting}
+            id="username"
+            name="username"
+            placeholder="seu_nome"
+            required
+            type="text"
+          />
+          {fieldErrors.username ? (
+            <p className="form-error" id="username-error">
+              {fieldErrors.username}
+            </p>
+          ) : null}
+        </div>
+        <div className="form-field">
+          <label htmlFor="email">E-mail</label>
+          <input
+            aria-describedby={fieldErrors.email ? "email-error" : undefined}
+            aria-invalid={fieldErrors.email ? "true" : undefined}
+            autoComplete="email"
+            disabled={isSubmitting}
+            id="email"
+            name="email"
+            placeholder="voce@email.com"
+            required
+            type="email"
+          />
+          {fieldErrors.email ? (
+            <p className="form-error" id="email-error">
+              {fieldErrors.email}
+            </p>
+          ) : null}
+        </div>
+        <div className="form-field">
+          <label htmlFor="password">Senha</label>
+          <input
+            aria-describedby={fieldErrors.password ? "password-error" : undefined}
+            aria-invalid={fieldErrors.password ? "true" : undefined}
+            autoComplete="new-password"
+            disabled={isSubmitting}
+            id="password"
+            name="password"
+            placeholder="Crie uma senha"
+            required
+            type="password"
+          />
+          {fieldErrors.password ? (
+            <p className="form-error" id="password-error">
+              {fieldErrors.password}
+            </p>
+          ) : null}
+        </div>
+        {formError ? (
+          <p className="form-error" role="alert">
+            {formError}
+          </p>
+        ) : null}
+        <button className="button button-primary" disabled={isSubmitting} type="submit">
+          {isSubmitting ? "Criando conta..." : "Criar conta"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/auth/auth-form-utils.test.ts
+++ b/frontend/src/components/auth/auth-form-utils.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiError } from "../../api/client";
+import {
+  buildRegisteredLoginUrl,
+  getLoginConfirmationMessage,
+  getLoginFormErrorMessage,
+  getRegistrationValidationState,
+  getSafeRedirectFromSearch,
+} from "./auth-form-utils";
+
+test("successful registration redirects to login with a confirmation marker", () => {
+  assert.equal(buildRegisteredLoginUrl(), "/login?cadastro=ok");
+  assert.equal(
+    getLoginConfirmationMessage("?cadastro=ok"),
+    "Cadastro criado com sucesso. Entre para continuar."
+  );
+});
+
+test("registration validation errors are shown inline with pt-BR field messages", () => {
+  const error = new ApiError("Validation failed.", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      email: ["Enter a valid email address."],
+      password: ["This password is too common."],
+      username: ["A user with that username already exists."],
+    },
+  });
+
+  const validationState = getRegistrationValidationState(error);
+
+  assert.deepEqual(validationState.fieldErrors, {
+    email: "Informe um e-mail válido.",
+    password: "Informe uma senha válida.",
+    username: "Informe um nome de usuário válido.",
+  });
+  assert.equal(validationState.formError, null);
+});
+
+test("registration validation does not expose raw backend messages", () => {
+  const error = new ApiError("Validation failed.", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      email: ["Raw backend detail."],
+    },
+  });
+
+  const validationState = getRegistrationValidationState(error);
+
+  assert.equal(validationState.fieldErrors.email, "Informe um e-mail válido.");
+  assert.notEqual(validationState.fieldErrors.email, "Raw backend detail.");
+});
+
+test("invalid credentials use the friendly form-level login message", () => {
+  const error = new ApiError("Invalid credentials.", 401, {
+    code: "INVALID_CREDENTIALS",
+    details: {},
+  });
+
+  assert.equal(getLoginFormErrorMessage(error), "E-mail ou senha incorretos.");
+});
+
+test("login redirect accepts safe internal paths and rejects unsafe external URLs", () => {
+  assert.equal(
+    getSafeRedirectFromSearch("?redirect=%2Fcheckout%3Freservation%3D123"),
+    "/checkout?reservation=123"
+  );
+  assert.equal(
+    getSafeRedirectFromSearch("?redirect=https%3A%2F%2Fevil.example%2Fcheckout"),
+    "/"
+  );
+  assert.equal(getSafeRedirectFromSearch(""), "/");
+});

--- a/frontend/src/components/auth/auth-form-utils.ts
+++ b/frontend/src/components/auth/auth-form-utils.ts
@@ -1,0 +1,83 @@
+import {
+  ApiError,
+  getApiErrorUserMessage,
+  sanitizeRedirectPath,
+} from "../../api/client";
+
+export type AuthFieldName = "email" | "password" | "username";
+
+export type AuthFieldErrors = Partial<Record<AuthFieldName, string>>;
+
+export type RegistrationValidationState = {
+  fieldErrors: AuthFieldErrors;
+  formError: string | null;
+};
+
+const REGISTRATION_FIELD_MESSAGES: Record<AuthFieldName, string> = {
+  email: "Informe um e-mail válido.",
+  password: "Informe uma senha válida.",
+  username: "Informe um nome de usuário válido.",
+};
+
+export const REGISTRATION_SUCCESS_PARAM = "cadastro";
+
+export function getSafeRedirectFromSearch(search: string) {
+  const redirect = new URLSearchParams(search).get("redirect");
+  return redirect ? sanitizeRedirectPath(redirect) : "/";
+}
+
+export function buildRegisteredLoginUrl() {
+  return `/login?${REGISTRATION_SUCCESS_PARAM}=ok`;
+}
+
+export function getLoginConfirmationMessage(search: string) {
+  const params = new URLSearchParams(search);
+  return params.get(REGISTRATION_SUCCESS_PARAM) === "ok"
+    ? "Cadastro criado com sucesso. Entre para continuar."
+    : null;
+}
+
+export function getLoginFormErrorMessage(error: unknown) {
+  return getApiErrorUserMessage(error);
+}
+
+export function getRegistrationValidationState(
+  error: unknown
+): RegistrationValidationState {
+  if (!(error instanceof ApiError) || error.code !== "VALIDATION_FAILED") {
+    return {
+      fieldErrors: {},
+      formError: getApiErrorUserMessage(error),
+    };
+  }
+
+  const fieldErrors = mapValidationFieldErrors(error.details);
+
+  return {
+    fieldErrors,
+    formError:
+      Object.keys(fieldErrors).length > 0
+        ? null
+        : "Confira os dados informados e tente novamente.",
+  };
+}
+
+function mapValidationFieldErrors(details: unknown) {
+  const fieldErrors: AuthFieldErrors = {};
+
+  if (!isRecord(details)) {
+    return fieldErrors;
+  }
+
+  for (const field of Object.keys(REGISTRATION_FIELD_MESSAGES) as AuthFieldName[]) {
+    if (Object.hasOwn(details, field)) {
+      fieldErrors[field] = REGISTRATION_FIELD_MESSAGES[field];
+    }
+  }
+
+  return fieldErrors;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## Objective

Build the visitor authentication pages for registration and login, integrating them with the backend auth endpoints and supporting safe redirect-after-login behavior for protected purchase actions.

## What was done

### 1. Registration page

Implemented `/register` with a complete pt-BR registration form:

- username input
- email input
- password input
- keyboard-friendly submit handling
- disabled/loading state while submitting

The form submits to `POST /api/v1/auth/register/`.

### 2. Registration success and validation handling

After successful registration, the user is redirected to `/login?cadastro=ok`.

`VALIDATION_FAILED` responses are mapped to safe, localized inline messages for the relevant fields, without exposing raw backend validation text.

### 3. Login page

Completed `/login` behavior with:

- email input
- password input
- submit handling through `POST /api/v1/auth/login/`
- form-level error handling for `INVALID_CREDENTIALS`
- integration with the existing in-memory global auth state

Successful login stores tokens through `AuthContext`, loads the authenticated user session flow, and redirects afterward.

### 4. Safe redirect-after-login flow

Login now reads `redirect` from the query string and navigates to it after successful authentication.

Redirect handling:

- allows safe internal paths
- removes sensitive query parameters
- rejects external URLs
- rejects malformed targets
- falls back to `/` when no safe redirect exists

### 5. Form accessibility and pt-BR UX

Improved form accessibility and localized copy:

- labels are associated with inputs
- inline errors are connected through `aria-describedby`
- invalid fields use `aria-invalid`
- form-level errors use alert semantics
- success confirmation uses status semantics
- submit buttons and fields are disabled while requests are in flight

### 6. Frontend auth API contract

Expanded `src/api/auth.ts` with typed registration payload and response support while keeping JWT storage out of browser storage.

### 7. Automated tests

Added coverage for:

- successful registration API submission
- successful login API submission
- registration validation error mapping
- invalid credentials friendly message
- safe redirect handling
- rejection of unsafe external redirects

## Acceptance criteria confirmation

- Register Route: `/register` renders username, email, and password fields.
- Register API: successful registration calls `/api/v1/auth/register/` and redirects to login with a confirmation message.
- Register Errors: `VALIDATION_FAILED` responses are shown inline with safe pt-BR copy.
- Login Route: `/login` renders email and password fields.
- Login API: successful login calls `/api/v1/auth/login/`, stores tokens through auth state, and loads the session flow.
- Invalid Credentials: `INVALID_CREDENTIALS` displays a friendly form-level error.
- Redirect Support: login respects a safe internal redirect query parameter and falls back to `/`.
- Accessibility: labels, associated errors, disabled/loading state, and keyboard submission are supported.
- Automated Tests: successful submit, validation errors, invalid credentials, and redirect handling are covered where practical.

## How to test

### Automated validation

Run from `frontend/`:

```bash
npm run test
npm run lint
npm run build
```

### Manual validation

1. Start the frontend:

```bash
npm run dev
```

2. Open:

- `/register`
- `/login`
- `/login?redirect=%2Fcheckout`
- `/login?redirect=https%3A%2F%2Fevil.example%2Fcheckout`

3. Validate the main expected behaviors:

- registration submits to the backend register endpoint
- registration validation errors appear inline in pt-BR
- successful registration redirects to login with a confirmation message
- invalid login credentials show a friendly form-level error
- successful login returns to a safe internal redirect
- unsafe external redirects fall back to `/`

## Expected Result

- Visitors can create accounts through the frontend.
- Visitors can log in through the frontend.
- Authenticated session state is populated without persistent browser token storage.
- Protected purchase actions can send users through a safe login redirect flow.
- Form behavior remains accessible, localized, and covered by automated tests.

closes #86
