### PR TITLE
feat: add frontend route guards and safe redirects

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -273,6 +273,7 @@ test("sanitizeRedirectPath removes sensitive query parameters", () => {
     ),
     "/checkout?reservation=123#summary"
   );
+  assert.equal(sanitizeRedirectPath("/checkout#access=secret"), "/checkout");
 });
 
 test("sanitizeRedirectPath rejects external redirect targets", () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -201,7 +201,10 @@ export function sanitizeRedirectPath(path: string) {
     }
   }
 
-  const sanitizedPath = `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
+  const sanitizedHash = /token|access|refresh|email/i.test(redirectUrl.hash)
+    ? ""
+    : redirectUrl.hash;
+  const sanitizedPath = `${redirectUrl.pathname}${redirectUrl.search}${sanitizedHash}`;
   return sanitizedPath.startsWith("/") ? sanitizedPath : "/";
 }
 

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -1,31 +1,34 @@
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function CheckoutPage() {
   return (
-    <PageSection
-      description="Revise a compra, escolha a forma de pagamento e finalize seu pedido com mensagens claras de carregamento e erro."
-      eyebrow="Pagamento"
-      title="Finalizar compra"
-    >
-      <div className="panel-grid">
-        <article className="panel">
-          <h2 className="panel-title">Cartão de crédito</h2>
-          <p className="panel-copy">Opção preparada para pagamento com cartão.</p>
-        </article>
-        <article className="panel">
-          <h2 className="panel-title">PIX</h2>
-          <p className="panel-copy">Opção preparada para pagamento via PIX.</p>
-        </article>
-        <article className="panel">
-          <h2 className="panel-title">Resumo</h2>
-          <p className="panel-copy">Filme, sessão, assentos e total ficarão reunidos aqui.</p>
-        </article>
-      </div>
-      <StateMessage tone="error" title="Compra não iniciada">
-        Se a reserva expirar ou o pedido não puder ser concluído, a mensagem será
-        apresentada em português do Brasil.
-      </StateMessage>
-    </PageSection>
+    <ProtectedRoute>
+      <PageSection
+        description="Revise a compra, escolha a forma de pagamento e finalize seu pedido com mensagens claras de carregamento e erro."
+        eyebrow="Pagamento"
+        title="Finalizar compra"
+      >
+        <div className="panel-grid">
+          <article className="panel">
+            <h2 className="panel-title">Cartão de crédito</h2>
+            <p className="panel-copy">Opção preparada para pagamento com cartão.</p>
+          </article>
+          <article className="panel">
+            <h2 className="panel-title">PIX</h2>
+            <p className="panel-copy">Opção preparada para pagamento via PIX.</p>
+          </article>
+          <article className="panel">
+            <h2 className="panel-title">Resumo</h2>
+            <p className="panel-copy">Filme, sessão, assentos e total ficarão reunidos aqui.</p>
+          </article>
+        </div>
+        <StateMessage tone="error" title="Compra não iniciada">
+          Se a reserva expirar ou o pedido não puder ser concluído, a mensagem será
+          apresentada em português do Brasil.
+        </StateMessage>
+      </PageSection>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/confirmation/page.tsx
+++ b/frontend/src/app/confirmation/page.tsx
@@ -1,17 +1,20 @@
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function ConfirmationPage() {
   return (
-    <PageSection
-      description="Confira os ingressos gerados depois da aprovação do pedido."
-      eyebrow="Pedido"
-      title="Confirmação"
-    >
-      <StateMessage tone="success" title="Pronto para exibir ingressos">
-        Esta página receberá os dados da compra concluída e mostrará os
-        ingressos com identificação visual.
-      </StateMessage>
-    </PageSection>
+    <ProtectedRoute>
+      <PageSection
+        description="Confira os ingressos gerados depois da aprovação do pedido."
+        eyebrow="Pedido"
+        title="Confirmação"
+      >
+        <StateMessage tone="success" title="Pronto para exibir ingressos">
+          Esta página receberá os dados da compra concluída e mostrará os
+          ingressos com identificação visual.
+        </StateMessage>
+      </PageSection>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/my-tickets/page.tsx
+++ b/frontend/src/app/my-tickets/page.tsx
@@ -1,16 +1,19 @@
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function MyTicketsPage() {
   return (
-    <PageSection
-      description="Consulte ingressos futuros e compras anteriores quando estiver autenticado."
-      eyebrow="Conta"
-      title="Meus ingressos"
-    >
-      <StateMessage title="Nenhum ingresso carregado">
-        A lista de ingressos será conectada à conta do usuário.
-      </StateMessage>
-    </PageSection>
+    <ProtectedRoute>
+      <PageSection
+        description="Consulte ingressos futuros e compras anteriores quando estiver autenticado."
+        eyebrow="Conta"
+        title="Meus ingressos"
+      >
+        <StateMessage title="Nenhum ingresso carregado">
+          A lista de ingressos será conectada à conta do usuário.
+        </StateMessage>
+      </PageSection>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/sessions/[sessionId]/seats/page.tsx
+++ b/frontend/src/app/sessions/[sessionId]/seats/page.tsx
@@ -1,3 +1,4 @@
+import { SeatSelectionActions } from "@/components/seats/SeatSelectionActions";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
@@ -19,6 +20,7 @@ export default function SeatSelectionPage() {
         A estrutura responsiva permite rolagem horizontal quando a sala for mais
         larga que a tela do dispositivo.
       </StateMessage>
+      <SeatSelectionActions />
     </PageSection>
   );
 }

--- a/frontend/src/app/ticket-types/page.tsx
+++ b/frontend/src/app/ticket-types/page.tsx
@@ -1,32 +1,35 @@
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 import { formatCurrency } from "@/utils/formatters";
 
 export default function TicketTypeSelectionPage() {
   return (
-    <PageSection
-      description={`Escolha entre inteira e meia-entrada. A exibição de valores já usa o padrão ${formatCurrency(42.5)}.`}
-      eyebrow="Ingressos"
-      title="Tipos de ingresso"
-    >
-      <div className="panel-grid">
-        <article className="panel">
-          <h2 className="panel-title">Inteira</h2>
-          <p className="panel-copy">Valor cheio da sessão selecionada.</p>
-        </article>
-        <article className="panel">
-          <h2 className="panel-title">Meia-entrada</h2>
-          <p className="panel-copy">Metade do valor base, conforme regras aplicáveis.</p>
-        </article>
-        <article className="panel">
-          <h2 className="panel-title">Cupom</h2>
-          <p className="panel-copy">Campo preparado para validação em etapa futura.</p>
-        </article>
-      </div>
-      <StateMessage tone="loading" title="Seleção de assentos necessária">
-        Os tipos de ingresso serão calculados depois que os assentos forem
-        reservados.
-      </StateMessage>
-    </PageSection>
+    <ProtectedRoute>
+      <PageSection
+        description={`Escolha entre inteira e meia-entrada. A exibição de valores já usa o padrão ${formatCurrency(42.5)}.`}
+        eyebrow="Ingressos"
+        title="Tipos de ingresso"
+      >
+        <div className="panel-grid">
+          <article className="panel">
+            <h2 className="panel-title">Inteira</h2>
+            <p className="panel-copy">Valor cheio da sessão selecionada.</p>
+          </article>
+          <article className="panel">
+            <h2 className="panel-title">Meia-entrada</h2>
+            <p className="panel-copy">Metade do valor base, conforme regras aplicáveis.</p>
+          </article>
+          <article className="panel">
+            <h2 className="panel-title">Cupom</h2>
+            <p className="panel-copy">Campo preparado para validação em etapa futura.</p>
+          </article>
+        </div>
+        <StateMessage tone="loading" title="Seleção de assentos necessária">
+          Os tipos de ingresso serão calculados depois que os assentos forem
+          reservados.
+        </StateMessage>
+      </PageSection>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { buildLoginRedirectUrl } from "@/api/client";
+import { StateMessage } from "@/components/ui/StateMessage";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getBrowserCurrentPath,
+  getProtectedRouteDecision,
+} from "./route-guards";
+
+type ProtectedRouteProps = {
+  children: ReactNode;
+};
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const router = useRouter();
+  const { isAuthenticated, status } = useAuth();
+  const decision = getProtectedRouteDecision({ isAuthenticated, status });
+
+  useEffect(() => {
+    if (decision.redirectToLogin) {
+      router.replace(buildLoginRedirectUrl(getBrowserCurrentPath()));
+    }
+  }, [decision.redirectToLogin, router]);
+
+  if (decision.renderContent) {
+    return children;
+  }
+
+  return (
+    <StateMessage tone="loading" title="Verificando acesso">
+      Aguarde enquanto confirmamos sua sessão.
+    </StateMessage>
+  );
+}

--- a/frontend/src/components/auth/route-guards.test.ts
+++ b/frontend/src/components/auth/route-guards.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCurrentInternalPath,
+  getGuardedActionDecision,
+  getProtectedRouteDecision,
+  isProtectedRoute,
+} from "./route-guards";
+
+test("protected route list matches purchase and ticket pages", () => {
+  assert.equal(isProtectedRoute("/ticket-types"), true);
+  assert.equal(isProtectedRoute("/checkout"), true);
+  assert.equal(isProtectedRoute("/confirmation"), true);
+  assert.equal(isProtectedRoute("/my-tickets"), true);
+  assert.equal(isProtectedRoute("/sessions/123/seats"), false);
+});
+
+test("protected route decision never renders protected content before auth is confirmed", () => {
+  assert.deepEqual(
+    getProtectedRouteDecision({
+      isAuthenticated: false,
+      status: "loading",
+    }),
+    {
+      redirectToLogin: false,
+      renderContent: false,
+    }
+  );
+
+  assert.deepEqual(
+    getProtectedRouteDecision({
+      isAuthenticated: false,
+      status: "unauthenticated",
+    }),
+    {
+      redirectToLogin: true,
+      renderContent: false,
+    }
+  );
+});
+
+test("protected route decision renders content only for authenticated users", () => {
+  assert.deepEqual(
+    getProtectedRouteDecision({
+      isAuthenticated: true,
+      status: "authenticated",
+    }),
+    {
+      redirectToLogin: false,
+      renderContent: true,
+    }
+  );
+});
+
+test("guarded seat actions redirect unauthenticated users with the current internal URL", () => {
+  const currentPath = buildCurrentInternalPath({
+    hash: "#A1",
+    pathname: "/sessions/session-123/seats",
+    search: "?date=2026-05-21",
+  });
+
+  assert.deepEqual(
+    getGuardedActionDecision({
+      currentPath,
+      isAuthenticated: false,
+      status: "unauthenticated",
+    }),
+    {
+      allowed: false,
+      loginUrl:
+        "/login?redirect=%2Fsessions%2Fsession-123%2Fseats%3Fdate%3D2026-05-21%23A1",
+      pending: false,
+    }
+  );
+});
+
+test("guarded actions wait during auth resolution and allow authenticated users", () => {
+  assert.deepEqual(
+    getGuardedActionDecision({
+      currentPath: "/checkout",
+      isAuthenticated: false,
+      status: "loading",
+    }),
+    {
+      allowed: false,
+      loginUrl: null,
+      pending: true,
+    }
+  );
+
+  assert.deepEqual(
+    getGuardedActionDecision({
+      currentPath: "/checkout",
+      isAuthenticated: true,
+      status: "authenticated",
+    }),
+    {
+      allowed: true,
+      loginUrl: null,
+      pending: false,
+    }
+  );
+});
+
+test("guarded actions normalize unsafe current URLs through the login redirect builder", () => {
+  assert.deepEqual(
+    getGuardedActionDecision({
+      currentPath: "https://evil.example/checkout",
+      isAuthenticated: false,
+      status: "unauthenticated",
+    }),
+    {
+      allowed: false,
+      loginUrl: "/login?redirect=%2F",
+      pending: false,
+    }
+  );
+});

--- a/frontend/src/components/auth/route-guards.ts
+++ b/frontend/src/components/auth/route-guards.ts
@@ -1,0 +1,109 @@
+import { buildLoginRedirectUrl } from "@/api/client";
+import type { AuthStatus } from "@/contexts/auth-state";
+
+export const PROTECTED_ROUTES = [
+  "/ticket-types",
+  "/checkout",
+  "/confirmation",
+  "/my-tickets",
+] as const;
+
+type ProtectedRouteDecision = {
+  renderContent: boolean;
+  redirectToLogin: boolean;
+};
+
+type GuardedActionDecision =
+  | {
+      allowed: true;
+      loginUrl: null;
+      pending: false;
+    }
+  | {
+      allowed: false;
+      loginUrl: string;
+      pending: false;
+    }
+  | {
+      allowed: false;
+      loginUrl: null;
+      pending: true;
+    };
+
+type AuthGateInput = {
+  isAuthenticated: boolean;
+  status: AuthStatus;
+};
+
+type LocationParts = {
+  hash?: string;
+  pathname: string;
+  search?: string;
+};
+
+export function isProtectedRoute(pathname: string) {
+  return PROTECTED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}
+
+export function getProtectedRouteDecision({
+  isAuthenticated,
+  status,
+}: AuthGateInput): ProtectedRouteDecision {
+  if (isAuthenticated) {
+    return {
+      redirectToLogin: false,
+      renderContent: true,
+    };
+  }
+
+  return {
+    redirectToLogin: status !== "loading",
+    renderContent: false,
+  };
+}
+
+export function getGuardedActionDecision({
+  currentPath,
+  isAuthenticated,
+  status,
+}: AuthGateInput & { currentPath: string }): GuardedActionDecision {
+  if (isAuthenticated) {
+    return {
+      allowed: true,
+      loginUrl: null,
+      pending: false,
+    };
+  }
+
+  if (status === "loading") {
+    return {
+      allowed: false,
+      loginUrl: null,
+      pending: true,
+    };
+  }
+
+  return {
+    allowed: false,
+    loginUrl: buildLoginRedirectUrl(currentPath),
+    pending: false,
+  };
+}
+
+export function buildCurrentInternalPath({
+  hash = "",
+  pathname,
+  search = "",
+}: LocationParts) {
+  return `${pathname}${search}${hash}`;
+}
+
+export function getBrowserCurrentPath() {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+
+  return buildCurrentInternalPath(window.location);
+}

--- a/frontend/src/components/auth/useGuardedAction.ts
+++ b/frontend/src/components/auth/useGuardedAction.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getBrowserCurrentPath,
+  getGuardedActionDecision,
+} from "./route-guards";
+
+export function useGuardedAction() {
+  const router = useRouter();
+  const { isAuthenticated, status } = useAuth();
+
+  return useCallback(
+    (action: () => void) => {
+      const decision = getGuardedActionDecision({
+        currentPath: getBrowserCurrentPath(),
+        isAuthenticated,
+        status,
+      });
+
+      if (decision.allowed) {
+        action();
+        return true;
+      }
+
+      if (decision.loginUrl) {
+        router.push(decision.loginUrl);
+      }
+
+      return false;
+    },
+    [isAuthenticated, router, status]
+  );
+}

--- a/frontend/src/components/seats/SeatSelectionActions.tsx
+++ b/frontend/src/components/seats/SeatSelectionActions.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+import { useGuardedAction } from "@/components/auth/useGuardedAction";
+
+export function SeatSelectionActions() {
+  const guardAction = useGuardedAction();
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  function handleReserveAttempt() {
+    guardAction(() => {
+      setStatusMessage("Reserva autenticada pronta para integração com a API.");
+    });
+  }
+
+  function handleReleaseAttempt() {
+    guardAction(() => {
+      setStatusMessage("Liberação autenticada pronta para integração com a API.");
+    });
+  }
+
+  return (
+    <div className="page-actions" aria-label="Ações de assento">
+      <button
+        className="button button-primary"
+        onClick={handleReserveAttempt}
+        type="button"
+      >
+        Reservar assento
+      </button>
+      <button
+        className="button button-ghost"
+        onClick={handleReleaseAttempt}
+        type="button"
+      >
+        Liberar assento
+      </button>
+      {statusMessage ? (
+        <p className="inline-status inline-status-info" role="status">
+          {statusMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -11,7 +11,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { authApi, type LoginCredentials } from "@/api/auth";
 import {
@@ -54,6 +54,7 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
+  const pathname = usePathname();
   const [state, setState] = useState<AuthState>(initialAuthState);
   const accessTokenRef = useRef<string | null>(null);
   const refreshTokenRef = useRef<string | null>(null);
@@ -208,10 +209,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const redirect = new URLSearchParams(window.location.search).get("redirect");
 
-    if (state.status === "authenticated" && redirect) {
+    if (pathname === "/login" && state.status === "authenticated" && redirect) {
       router.replace(sanitizeRedirectPath(redirect));
     }
-  }, [router, state.status]);
+  }, [pathname, router, state.status]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Objective

Add frontend route guards for protected purchase and ticket pages, preserving safe internal redirects while keeping public browsing flows available. This prevents unauthenticated visitors from seeing protected page content before authentication state is known.

## What was done

### 1. Protected route guard

Implemented a reusable client-side `ProtectedRoute` wrapper for routes that require authentication:

- `/ticket-types`
- `/checkout`
- `/confirmation`
- `/my-tickets`

The guard renders a neutral loading state while auth is resolving and redirects unauthenticated users to login after the auth state is known.

### 2. Redirect preservation

Added route-guard utilities that preserve the current internal destination when redirecting users to login.

The redirect flow uses `/login?redirect=<current_url>` and continues to sanitize redirect targets before navigation.

### 3. Unsafe redirect defense

Strengthened redirect sanitization so unsafe or sensitive redirect data is normalized safely:

- external URLs are rejected
- malformed URLs fall back to `/`
- backslash-based redirect attempts are rejected
- sensitive query parameters are removed
- sensitive hash fragments are removed
- login redirect loops are avoided

### 4. Post-login return handling

Kept successful login return behavior through the existing login redirect flow, and restricted automatic redirect consumption to the `/login` route only.

This prevents authenticated users from being unexpectedly navigated away from unrelated pages that happen to contain a `redirect` query parameter.

### 5. Public seat map with protected actions

Kept `/sessions/{sessionId}/seats` publicly viewable.

Added guarded reserve/release action controls so unauthenticated users attempting protected seat actions are redirected to login with the current seat-map URL preserved.

### 6. Protected content flash prevention

Protected pages now render only a neutral "Verificando acesso" state until authentication is confirmed.

The protected page content is only rendered when the auth context reports an authenticated user.

### 7. Automated test coverage

Added unit coverage for:

- protected route matching
- no protected-content render while auth is loading
- unauthenticated protected-route redirect decision
- guarded seat action redirect preservation
- safe redirect normalization for unsafe targets
- sensitive redirect fragment removal

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

## Expected Result

- `/ticket-types`, `/checkout`, `/confirmation`, and `/my-tickets` require authentication.
- Protected page content is not shown before authentication state is confirmed.
- Unauthenticated users are redirected to `/login` with a safe internal `redirect` parameter.
- Successful login returns users to the intended protected route when possible.
- Seat maps remain publicly viewable without authentication.
- Reserve/release actions from seat selection require authentication and preserve the current URL.
- External, malformed, or sensitive redirect targets are ignored or normalized safely.
- Frontend tests, lint, and build pass.

closes #87
