### PR TITLE
feat: build reusable catalog movie components

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -398,6 +398,179 @@ h1 {
   border-left-color: var(--color-error);
 }
 
+.featured-movie {
+  align-items: stretch;
+  background: #231f20;
+  border-radius: 8px;
+  color: #ffffff;
+  display: grid;
+  gap: 0;
+  grid-template-columns: minmax(220px, 360px) minmax(0, 1fr);
+  min-height: 360px;
+  overflow: hidden;
+}
+
+.featured-movie__media {
+  background: #111111;
+  min-height: 320px;
+}
+
+.featured-movie__poster {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.featured-movie__content {
+  align-content: center;
+  display: grid;
+  gap: 18px;
+  padding: 36px;
+}
+
+.featured-movie__content h2 {
+  color: #ffffff;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.05;
+  margin: 0;
+}
+
+.featured-movie__meta {
+  color: #f7e4a4;
+  font-size: 17px;
+  font-weight: 750;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.movie-grid-section {
+  display: grid;
+  gap: 16px;
+}
+
+.movie-grid-section__header h2 {
+  font-size: 24px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.movie-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.movie-grid__item {
+  min-width: 0;
+}
+
+.movie-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  height: 100%;
+  overflow: hidden;
+}
+
+.movie-card__link {
+  display: grid;
+  height: 100%;
+}
+
+.movie-card__link:hover .movie-card__title {
+  color: var(--color-brand);
+}
+
+.movie-card__poster {
+  aspect-ratio: 2 / 3;
+  background: var(--color-surface-muted);
+  display: block;
+  object-fit: cover;
+  width: 100%;
+}
+
+.movie-card__body {
+  align-content: start;
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+}
+
+.movie-card__title {
+  font-size: 17px;
+  line-height: 1.25;
+  margin: 0;
+  transition: color 160ms ease;
+}
+
+.movie-card__genres,
+.movie-card__duration {
+  color: var(--color-muted);
+  font-size: 14px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.movie-card__duration {
+  color: var(--color-text);
+  font-weight: 800;
+}
+
+.movie-grid-loading {
+  display: grid;
+  gap: 12px;
+}
+
+.movie-grid-loading > span {
+  color: var(--color-muted);
+  font-weight: 750;
+}
+
+.movie-card--skeleton {
+  box-shadow: none;
+}
+
+.movie-card__poster--skeleton,
+.skeleton-line {
+  animation: skeleton-pulse 1300ms ease-in-out infinite;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface-muted),
+    #f9fafc,
+    var(--color-surface-muted)
+  );
+  background-size: 220% 100%;
+}
+
+.skeleton-line {
+  border-radius: 999px;
+  display: block;
+  height: 12px;
+}
+
+.skeleton-line--title {
+  height: 18px;
+}
+
+.skeleton-line--short {
+  width: 52%;
+}
+
+@keyframes skeleton-pulse {
+  from {
+    background-position: 120% 0;
+  }
+
+  to {
+    background-position: -120% 0;
+  }
+}
+
 @media (max-width: 820px) {
   .header-container {
     align-items: stretch;
@@ -418,6 +591,18 @@ h1 {
 
   .panel-grid {
     grid-template-columns: 1fr;
+  }
+
+  .featured-movie {
+    grid-template-columns: 1fr;
+  }
+
+  .featured-movie__media {
+    min-height: 420px;
+  }
+
+  .featured-movie__content {
+    padding: 24px;
   }
 }
 
@@ -441,5 +626,13 @@ h1 {
 
   .panel {
     padding: 18px;
+  }
+
+  .featured-movie__media {
+    min-height: 320px;
+  }
+
+  .movie-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/components/movies/FeaturedMovieBanner.tsx
+++ b/frontend/src/components/movies/FeaturedMovieBanner.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+
+import type { CatalogMovie } from "@/types/catalog";
+
+import {
+  formatMovieDuration,
+  formatMovieGenres,
+  getMovieDetailsHref,
+} from "./movie-formatters";
+
+type FeaturedMovieBannerProps = {
+  movie: CatalogMovie;
+  primaryActionLabel?: string;
+};
+
+export function FeaturedMovieBanner({
+  movie,
+  primaryActionLabel = "Ver sessões",
+}: FeaturedMovieBannerProps) {
+  return (
+    <section
+      aria-label={`Filme em destaque: ${movie.title}`}
+      className="featured-movie"
+    >
+      <div className="featured-movie__media">
+        {/* API poster URLs are arbitrary remote images until image domains are configured. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt={`Poster de ${movie.title}`}
+          className="featured-movie__poster"
+          loading="eager"
+          src={movie.poster_url}
+        />
+      </div>
+      <div className="featured-movie__content">
+        <p className="eyebrow">Destaque</p>
+        <h2>{movie.title}</h2>
+        <p className="featured-movie__meta">
+          {formatMovieGenres(movie.genres)} |{" "}
+          {formatMovieDuration(movie.duration_minutes)}
+        </p>
+        <Link
+          aria-label={`${primaryActionLabel} de ${movie.title}`}
+          className="button button-primary"
+          href={getMovieDetailsHref(movie.id)}
+        >
+          {primaryActionLabel}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/movies/MovieCard.tsx
+++ b/frontend/src/components/movies/MovieCard.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+import type { CatalogMovie } from "@/types/catalog";
+
+import {
+  formatMovieDuration,
+  formatMovieGenres,
+  getMovieDetailsHref,
+} from "./movie-formatters";
+
+type MovieCardProps = {
+  movie: CatalogMovie;
+};
+
+export function MovieCard({ movie }: MovieCardProps) {
+  const genres = formatMovieGenres(movie.genres);
+  const duration = formatMovieDuration(movie.duration_minutes);
+
+  return (
+    <article className="movie-card">
+      <Link
+        aria-label={`Ver detalhes de ${movie.title}`}
+        className="movie-card__link"
+        href={getMovieDetailsHref(movie.id)}
+      >
+        {/* API poster URLs are arbitrary remote images until image domains are configured. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt={`Poster de ${movie.title}`}
+          className="movie-card__poster"
+          loading="lazy"
+          src={movie.poster_url}
+        />
+        <div className="movie-card__body">
+          <h2 className="movie-card__title">{movie.title}</h2>
+          <p className="movie-card__genres">{genres}</p>
+          <p className="movie-card__duration">{duration}</p>
+        </div>
+      </Link>
+    </article>
+  );
+}

--- a/frontend/src/components/movies/MovieGrid.tsx
+++ b/frontend/src/components/movies/MovieGrid.tsx
@@ -1,0 +1,87 @@
+import type { CatalogMovie } from "@/types/catalog";
+
+import { StateMessage } from "@/components/ui/StateMessage";
+
+import { MovieCard } from "./MovieCard";
+
+type MovieGridProps = {
+  ariaLabel?: string;
+  emptyDescription?: string;
+  emptyTitle?: string;
+  isLoading?: boolean;
+  loadingLabel?: string;
+  movies: CatalogMovie[];
+  skeletonCount?: number;
+  title?: string;
+};
+
+export function MovieGrid({
+  ariaLabel,
+  emptyDescription = "Nenhum filme foi encontrado para esta seção.",
+  emptyTitle = "Nenhum filme disponível",
+  isLoading = false,
+  loadingLabel = "Carregando filmes...",
+  movies,
+  skeletonCount = 6,
+  title,
+}: MovieGridProps) {
+  const headingId = title ? `movie-grid-${slugify(title)}` : undefined;
+
+  return (
+    <section
+      aria-busy={isLoading || undefined}
+      aria-label={headingId ? undefined : (ariaLabel ?? "Lista de filmes")}
+      aria-labelledby={headingId}
+      className="movie-grid-section"
+    >
+      {title ? (
+        <div className="movie-grid-section__header">
+          <h2 id={headingId}>{title}</h2>
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <div className="movie-grid-loading" role="status">
+          <span>{loadingLabel}</span>
+          <ul aria-hidden="true" className="movie-grid" role="list">
+            {Array.from({ length: skeletonCount }, (_, index) => (
+              <li className="movie-grid__item" key={index}>
+                <div className="movie-card movie-card--skeleton">
+                  <div className="movie-card__poster movie-card__poster--skeleton" />
+                  <div className="movie-card__body">
+                    <span className="skeleton-line skeleton-line--title" />
+                    <span className="skeleton-line" />
+                    <span className="skeleton-line skeleton-line--short" />
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {!isLoading && movies.length === 0 ? (
+        <StateMessage title={emptyTitle}>{emptyDescription}</StateMessage>
+      ) : null}
+
+      {!isLoading && movies.length > 0 ? (
+        <ul className="movie-grid" role="list">
+          {movies.map((movie) => (
+            <li className="movie-grid__item" key={movie.id}>
+              <MovieCard movie={movie} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function slugify(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}

--- a/frontend/src/components/movies/index.ts
+++ b/frontend/src/components/movies/index.ts
@@ -1,0 +1,8 @@
+export { FeaturedMovieBanner } from "./FeaturedMovieBanner";
+export { MovieCard } from "./MovieCard";
+export { MovieGrid } from "./MovieGrid";
+export {
+  formatMovieDuration,
+  formatMovieGenres,
+  getMovieDetailsHref,
+} from "./movie-formatters";

--- a/frontend/src/components/movies/movie-components.test.ts
+++ b/frontend/src/components/movies/movie-components.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CatalogMovie } from "@/types/catalog";
+
+import { FeaturedMovieBanner } from "./FeaturedMovieBanner";
+import { MovieCard } from "./MovieCard";
+import { MovieGrid } from "./MovieGrid";
+import {
+  formatMovieDuration,
+  formatMovieGenres,
+  getMovieDetailsHref,
+} from "./movie-formatters";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const movie: CatalogMovie = {
+  duration_minutes: 166,
+  genres: [
+    { id: "genre-1", name: "Ficção científica" },
+    { id: "genre-2", name: "Aventura" },
+  ],
+  id: "movie-123",
+  is_featured: true,
+  poster_url: "https://cdn.example.com/duna.jpg",
+  status: "em_cartaz",
+  title: "Duna: Parte Dois",
+};
+
+test("movie card renders backend movie fields and navigates to the detail route", () => {
+  const html = renderToStaticMarkup(createElement(MovieCard, { movie }));
+
+  assert.match(html, /href="\/movies\/movie-123"/);
+  assert.match(html, /Ver detalhes de Duna: Parte Dois/);
+  assert.match(html, /Poster de Duna: Parte Dois/);
+  assert.match(html, /loading="lazy"/);
+  assert.match(html, /Duna: Parte Dois/);
+  assert.match(html, /Ficção científica, Aventura/);
+  assert.match(html, /2h 46min/);
+  assert.doesNotMatch(html, /age_rating|room_type|audio_format/i);
+});
+
+test("movie grid renders an accessible list of movie cards", () => {
+  const html = renderToStaticMarkup(
+    createElement(MovieGrid, {
+      movies: [movie],
+      title: "Em cartaz",
+    })
+  );
+
+  assert.match(html, /<section/);
+  assert.match(html, /role="list"/);
+  assert.match(html, /Em cartaz/);
+  assert.match(html, /Duna: Parte Dois/);
+});
+
+test("movie grid renders pt-BR empty and loading states", () => {
+  const emptyHtml = renderToStaticMarkup(
+    createElement(MovieGrid, {
+      movies: [],
+      title: "Pré-venda",
+    })
+  );
+
+  assert.match(emptyHtml, /Nenhum filme disponível/);
+  assert.match(emptyHtml, /Nenhum filme foi encontrado para esta seção./);
+
+  const loadingHtml = renderToStaticMarkup(
+    createElement(MovieGrid, {
+      isLoading: true,
+      movies: [],
+      skeletonCount: 2,
+    })
+  );
+
+  assert.match(loadingHtml, /role="status"/);
+  assert.match(loadingHtml, /Carregando filmes.../);
+  assert.match(loadingHtml, /aria-busy="true"/);
+});
+
+test("featured banner renders featured movie media and primary action", () => {
+  const html = renderToStaticMarkup(
+    createElement(FeaturedMovieBanner, { movie })
+  );
+
+  assert.match(html, /Filme em destaque: Duna: Parte Dois/);
+  assert.match(html, /Poster de Duna: Parte Dois/);
+  assert.match(html, /Destaque/);
+  assert.match(html, /Ver sessões/);
+  assert.match(html, /href="\/movies\/movie-123"/);
+  assert.match(html, /Ficção científica, Aventura \| 2h 46min/);
+});
+
+test("movie component helpers format API-shaped values", () => {
+  assert.equal(formatMovieDuration(45), "45min");
+  assert.equal(formatMovieDuration(120), "2h");
+  assert.equal(formatMovieDuration(125), "2h 5min");
+  assert.equal(formatMovieDuration(0), "Duração indisponível");
+  assert.equal(formatMovieGenres([]), "Gênero indisponível");
+  assert.equal(formatMovieGenres(movie.genres), "Ficção científica, Aventura");
+  assert.equal(getMovieDetailsHref(movie.id), "/movies/movie-123");
+});

--- a/frontend/src/components/movies/movie-formatters.ts
+++ b/frontend/src/components/movies/movie-formatters.ts
@@ -1,0 +1,32 @@
+import type { CatalogMovie } from "@/types/catalog";
+
+export function formatMovieDuration(durationMinutes: number) {
+  if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+    return "Duração indisponível";
+  }
+
+  const hours = Math.floor(durationMinutes / 60);
+  const minutes = durationMinutes % 60;
+
+  if (hours === 0) {
+    return `${minutes}min`;
+  }
+
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${minutes}min`;
+}
+
+export function formatMovieGenres(genres: CatalogMovie["genres"]) {
+  if (genres.length === 0) {
+    return "Gênero indisponível";
+  }
+
+  return genres.map((genre) => genre.name).join(", ");
+}
+
+export function getMovieDetailsHref(movieId: CatalogMovie["id"]) {
+  return `/movies/${movieId}`;
+}

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -1,0 +1,16 @@
+export type MovieStatus = "em_cartaz" | "pre_venda";
+
+export type CatalogGenre = {
+  id: string;
+  name: string;
+};
+
+export type CatalogMovie = {
+  id: string;
+  title: string;
+  genres: CatalogGenre[];
+  duration_minutes: number;
+  poster_url: string;
+  status: MovieStatus;
+  is_featured: boolean;
+};


### PR DESCRIPTION
## Objective

Build the reusable catalog UI components needed for movie discovery while keeping the frontend aligned with the current backend movie contract. This prepares the home page and movie detail flow for later API integration without introducing unsupported catalog fields or a new UI library.

## What was done

### 1. Catalog movie API types

Added shared frontend types compatible with the backend movie response shape:

- `id`
- `title`
- `genres`
- `duration_minutes`
- `poster_url`
- `status`
- `is_featured`

The components intentionally do not include unsupported fields such as `age_rating`, `room_type`, or `audio_format`.

### 2. Movie card component

Added a reusable `MovieCard` component that renders:

- responsive poster image
- meaningful poster alt text
- movie title
- genres
- formatted duration
- keyboard-accessible navigation to `/movies/{movieId}`

Poster images are lazy-loaded for catalog grids.

### 3. Movie grid component

Added a reusable `MovieGrid` component for catalog sections with:

- responsive card layout
- accessible region/list structure
- loading state with skeleton cards
- empty state with pt-BR fallback copy
- typed props compatible with catalog API movies

### 4. Featured movie banner

Added a reusable `FeaturedMovieBanner` component that renders:

- featured poster or visual media
- movie title
- supported movie metadata
- clear primary action to view sessions/details
- responsive mobile and desktop layout

### 5. Catalog formatting helpers

Added small formatting helpers for:

- duration display
- genre display
- movie detail route generation

This keeps presentation logic reusable across the card, grid, and banner.

### 6. Styling

Extended the existing global CSS approach with styles for:

- movie cards
- responsive movie grids
- loading skeletons
- featured movie banner

No new UI library was added.

### 7. Automated test coverage

Added component/unit coverage using the existing Node.js test runner and server-side React rendering:

- movie card rendering and navigation
- absence of unsupported catalog fields
- movie grid list rendering
- movie grid empty state
- movie grid loading state
- featured banner rendering
- catalog formatting helpers

## How to test

### Automated validation

Run the frontend checks:

```bash
cd frontend
npm run lint
npm test
npm run build
```

## Expected Result

- Movie cards render only backend-supported movie fields.
- Movie cards navigate to `/movies/{movieId}` when clicked or keyboard-activated.
- Movie grids can be reused by catalog sections with responsive layout, loading state, and empty state.
- Featured banners can highlight a movie with a clear primary action.
- Poster images are responsive and include meaningful alt text.
- Visible fallback copy remains in pt-BR.
- The frontend remains aligned with the current catalog API contract.
- Automated frontend validation passes.

closes #88
