### PR TITLE
feat: connect home catalog discovery

### DIFF
--- a/frontend/src/api/catalog.test.ts
+++ b/frontend/src/api/catalog.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { catalogApi } from "./catalog";
+
+const paginatedMoviesResponse = {
+  count: 0,
+  next: null,
+  previous: null,
+  results: [],
+};
+
+test("catalogApi lists movies through the public catalog endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/");
+      assert.equal(init?.method, "GET");
+
+      return Response.json(paginatedMoviesResponse);
+    };
+
+    const response = await catalogApi.listMovies();
+
+    assert.deepEqual(response, paginatedMoviesResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi builds supported movie filters", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  try {
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return Response.json(paginatedMoviesResponse);
+    };
+
+    await catalogApi.listFeaturedMovies();
+    await catalogApi.listNowShowingMovies();
+    await catalogApi.listPreSaleMovies();
+    await catalogApi.listMovies({
+      is_featured: true,
+      page: 2,
+      status: "em_cartaz",
+    });
+
+    assert.deepEqual(requestedUrls, [
+      "http://localhost:8000/api/v1/catalog/movies/?is_featured=true",
+      "http://localhost:8000/api/v1/catalog/movies/?status=em_cartaz",
+      "http://localhost:8000/api/v1/catalog/movies/?status=pre_venda",
+      "http://localhost:8000/api/v1/catalog/movies/?status=em_cartaz&is_featured=true&page=2",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi rejects unexpected non-paginated movie responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json([]);
+
+    await assert.rejects(
+      catalogApi.listMovies(),
+      /Unexpected catalog movie list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -1,0 +1,65 @@
+import type { MovieStatus, CatalogMovie } from "@/types/catalog";
+
+import {
+  apiRequest,
+  isPaginatedResponse,
+  type PaginatedResponse,
+} from "./client";
+
+export type ListMoviesParams = {
+  is_featured?: boolean;
+  page?: number;
+  status?: MovieStatus;
+};
+
+const MOVIES_PATH = "/api/v1/catalog/movies/";
+
+export const catalogApi = {
+  listMovies(params: ListMoviesParams = {}) {
+    return listMovies(params);
+  },
+
+  listFeaturedMovies() {
+    return listMovies({ is_featured: true });
+  },
+
+  listNowShowingMovies() {
+    return listMovies({ status: "em_cartaz" });
+  },
+
+  listPreSaleMovies() {
+    return listMovies({ status: "pre_venda" });
+  },
+};
+
+async function listMovies(params: ListMoviesParams) {
+  const response = await apiRequest<unknown>(buildMoviesPath(params), {
+    auth: "none",
+    method: "GET",
+  });
+
+  if (!isPaginatedResponse<CatalogMovie>(response)) {
+    throw new Error("Unexpected catalog movie list response.");
+  }
+
+  return response satisfies PaginatedResponse<CatalogMovie>;
+}
+
+function buildMoviesPath({ is_featured, page, status }: ListMoviesParams) {
+  const searchParams = new URLSearchParams();
+
+  if (status) {
+    searchParams.set("status", status);
+  }
+
+  if (is_featured !== undefined) {
+    searchParams.set("is_featured", String(is_featured));
+  }
+
+  if (page !== undefined) {
+    searchParams.set("page", String(page));
+  }
+
+  const query = searchParams.toString();
+  return query ? `${MOVIES_PATH}?${query}` : MOVIES_PATH;
+}

--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { catalogApi } from "@/api/catalog";
+import { FeaturedMovieBanner } from "@/components/movies";
+import { MovieGrid } from "@/components/movies";
+import { StateMessage } from "@/components/ui/StateMessage";
+import type { CatalogMovie } from "@/types/catalog";
+
+type SectionStatus = "error" | "loading" | "success";
+
+export type MovieSectionState = {
+  errorMessage?: string;
+  movies: CatalogMovie[];
+  status: SectionStatus;
+};
+
+type HomeCatalogSectionsProps = {
+  featured: MovieSectionState;
+  nowShowing: MovieSectionState;
+  onRetryFeatured?: () => void;
+  onRetryNowShowing?: () => void;
+  onRetryPreSale?: () => void;
+  preSale: MovieSectionState;
+};
+
+const loadingSectionState: MovieSectionState = {
+  movies: [],
+  status: "loading",
+};
+
+export function HomeCatalog() {
+  const [featured, setFeatured] =
+    useState<MovieSectionState>(loadingSectionState);
+  const [nowShowing, setNowShowing] =
+    useState<MovieSectionState>(loadingSectionState);
+  const [preSale, setPreSale] = useState<MovieSectionState>(loadingSectionState);
+
+  const loadFeatured = useCallback(async () => {
+    await loadMovieSection(
+      () => catalogApi.listFeaturedMovies(),
+      setFeatured
+    );
+  }, []);
+
+  const loadNowShowing = useCallback(async () => {
+    await loadMovieSection(
+      () => catalogApi.listNowShowingMovies(),
+      setNowShowing
+    );
+  }, []);
+
+  const loadPreSale = useCallback(async () => {
+    await loadMovieSection(() => catalogApi.listPreSaleMovies(), setPreSale);
+  }, []);
+
+  useEffect(() => {
+    void loadFeatured();
+    void loadNowShowing();
+    void loadPreSale();
+  }, [loadFeatured, loadNowShowing, loadPreSale]);
+
+  return (
+    <HomeCatalogSections
+      featured={featured}
+      nowShowing={nowShowing}
+      onRetryFeatured={() => void loadFeatured()}
+      onRetryNowShowing={() => void loadNowShowing()}
+      onRetryPreSale={() => void loadPreSale()}
+      preSale={preSale}
+    />
+  );
+}
+
+export function HomeCatalogSections({
+  featured,
+  nowShowing,
+  onRetryFeatured,
+  onRetryNowShowing,
+  onRetryPreSale,
+  preSale,
+}: HomeCatalogSectionsProps) {
+  const featuredMovie = featured.movies[0];
+
+  return (
+    <div className="home-catalog" id="catalogo">
+      {featured.status === "loading" ? (
+        <StateMessage title="Carregando filme em destaque" tone="loading">
+          Buscando os destaques do catálogo.
+        </StateMessage>
+      ) : null}
+
+      {featured.status === "error" ? (
+        <CatalogErrorState
+          message={
+            featured.errorMessage ??
+            "Não foi possível carregar o filme em destaque. Tente novamente."
+          }
+          onRetry={onRetryFeatured}
+          title="Destaque indisponível"
+        />
+      ) : null}
+
+      {featured.status === "success" && !featuredMovie ? (
+        <StateMessage title="Nenhum destaque disponível">
+          Ainda não há filme marcado como destaque no catálogo.
+        </StateMessage>
+      ) : null}
+
+      {featured.status === "success" && featuredMovie ? (
+        <FeaturedMovieBanner movie={featuredMovie} primaryActionLabel="Ver detalhes" />
+      ) : null}
+
+      {nowShowing.status === "error" ? (
+        <CatalogErrorState
+          message={
+            nowShowing.errorMessage ??
+            "Não foi possível carregar os filmes em cartaz. Tente novamente."
+          }
+          onRetry={onRetryNowShowing}
+          title="Em cartaz indisponível"
+        />
+      ) : (
+        <MovieGrid
+          emptyDescription="Ainda não há filmes em cartaz no catálogo."
+          emptyTitle="Nenhum filme em cartaz"
+          isLoading={nowShowing.status === "loading"}
+          loadingLabel="Carregando filmes em cartaz..."
+          movies={nowShowing.movies}
+          title="Em cartaz"
+        />
+      )}
+
+      {preSale.status === "error" ? (
+        <CatalogErrorState
+          message={
+            preSale.errorMessage ??
+            "Não foi possível carregar os filmes em pré-venda. Tente novamente."
+          }
+          onRetry={onRetryPreSale}
+          title="Pré-venda indisponível"
+        />
+      ) : (
+        <MovieGrid
+          emptyDescription="Ainda não há filmes em pré-venda no catálogo."
+          emptyTitle="Nenhum filme em pré-venda"
+          isLoading={preSale.status === "loading"}
+          loadingLabel="Carregando filmes em pré-venda..."
+          movies={preSale.movies}
+          title="Pré-venda"
+        />
+      )}
+    </div>
+  );
+}
+
+async function loadMovieSection(
+  requestMovies: () => Promise<{ results: CatalogMovie[] }>,
+  setSection: (state: MovieSectionState) => void
+) {
+  setSection(loadingSectionState);
+
+  try {
+    const response = await requestMovies();
+    setSection({
+      movies: response.results,
+      status: "success",
+    });
+  } catch {
+    setSection({
+      errorMessage:
+        "Não conseguimos carregar esta seção agora. Verifique sua conexão e tente novamente.",
+      movies: [],
+      status: "error",
+    });
+  }
+}
+
+function CatalogErrorState({
+  message,
+  onRetry,
+  title,
+}: {
+  message: string;
+  onRetry?: () => void;
+  title: string;
+}) {
+  return (
+    <StateMessage
+      action={
+        onRetry ? (
+          <button className="button button-ghost" onClick={onRetry} type="button">
+            Tentar novamente
+          </button>
+        ) : undefined
+      }
+      title={title}
+      tone="error"
+    >
+      {message}
+    </StateMessage>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -378,6 +378,10 @@ h1 {
   margin: 0;
 }
 
+.state-message__action {
+  margin-top: 4px;
+}
+
 .state-message-empty {
   background: #ffffff;
   border-left-color: var(--color-info);
@@ -442,6 +446,11 @@ h1 {
   font-weight: 750;
   line-height: 1.5;
   margin: 0;
+}
+
+.home-catalog {
+  display: grid;
+  gap: 28px;
 }
 
 .movie-grid-section {

--- a/frontend/src/app/home-catalog.test.ts
+++ b/frontend/src/app/home-catalog.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CatalogMovie } from "@/types/catalog";
+
+import { HomeCatalogSections, type MovieSectionState } from "./HomeCatalog";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const featuredMovie: CatalogMovie = {
+  duration_minutes: 120,
+  genres: [{ id: "genre-1", name: "Aventura" }],
+  id: "featured-1",
+  is_featured: true,
+  poster_url: "https://cdn.example.com/featured.jpg",
+  status: "em_cartaz",
+  title: "A Jornada",
+};
+
+const preSaleMovie: CatalogMovie = {
+  ...featuredMovie,
+  id: "pre-sale-1",
+  is_featured: false,
+  status: "pre_venda",
+  title: "Estreia da Semana",
+};
+
+const success = (movies: CatalogMovie[]): MovieSectionState => ({
+  movies,
+  status: "success",
+});
+
+test("home catalog renders featured, now showing, and pre-sale movie sections", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([featuredMovie]),
+      nowShowing: success([featuredMovie]),
+      preSale: success([preSaleMovie]),
+    })
+  );
+
+  assert.match(html, /Filme em destaque: A Jornada/);
+  assert.match(html, /href="\/movies\/featured-1"/);
+  assert.match(html, /Em cartaz/);
+  assert.match(html, /Pré-venda/);
+  assert.match(html, /Estreia da Semana/);
+  assert.doesNotMatch(html, /age_rating|room_type|audio_format/i);
+});
+
+test("home catalog renders pt-BR loading and empty states", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: { movies: [], status: "loading" },
+      nowShowing: success([]),
+      preSale: success([]),
+    })
+  );
+
+  assert.match(html, /Carregando filme em destaque/);
+  assert.match(html, /Nenhum filme em cartaz/);
+  assert.match(html, /Ainda não há filmes em pré-venda no catálogo./);
+});
+
+test("home catalog renders retry-oriented error states", () => {
+  const errorState: MovieSectionState = {
+    errorMessage: "Não conseguimos carregar esta seção agora.",
+    movies: [],
+    status: "error",
+  };
+
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: errorState,
+      nowShowing: errorState,
+      onRetryFeatured: () => undefined,
+      onRetryNowShowing: () => undefined,
+      onRetryPreSale: () => undefined,
+      preSale: errorState,
+    })
+  );
+
+  assert.match(html, /Destaque indisponível/);
+  assert.match(html, /Em cartaz indisponível/);
+  assert.match(html, /Pré-venda indisponível/);
+  assert.match(html, /Tentar novamente/);
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
+import { HomeCatalog } from "./HomeCatalog";
 import { PageSection } from "@/components/ui/PageSection";
-import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function HomePage() {
   return (
@@ -20,34 +20,7 @@ export default function HomePage() {
       eyebrow="Catálogo"
       title="Cinepolis Natal"
     >
-      <div className="panel-grid" id="catalogo">
-        <article className="panel">
-          <span className="inline-status inline-status-success">Em breve</span>
-          <h2 className="panel-title">Em cartaz</h2>
-          <p className="panel-copy">
-            Espaço reservado para os filmes disponíveis no catálogo público.
-          </p>
-        </article>
-        <article className="panel">
-          <span className="inline-status inline-status-info">Pré-venda</span>
-          <h2 className="panel-title">Próximas sessões</h2>
-          <p className="panel-copy">
-            A base visual já está pronta para receber filmes em pré-venda.
-          </p>
-        </article>
-        <article className="panel">
-          <span className="inline-status inline-status-info">Ingressos</span>
-          <h2 className="panel-title">Compra guiada</h2>
-          <p className="panel-copy">
-            O fluxo compartilha layout, estados e navegação em português do Brasil.
-          </p>
-        </article>
-      </div>
-
-      <StateMessage title="Catálogo em preparação">
-        Os cards reais de filmes serão conectados à lista de programação nas
-        próximas etapas.
-      </StateMessage>
+      <HomeCatalog />
     </PageSection>
   );
 }

--- a/frontend/src/components/ui/StateMessage.tsx
+++ b/frontend/src/components/ui/StateMessage.tsx
@@ -3,12 +3,14 @@ import type { ReactNode } from "react";
 type StateTone = "empty" | "error" | "loading" | "success";
 
 type StateMessageProps = {
+  action?: ReactNode;
   children: ReactNode;
   title: string;
   tone?: StateTone;
 };
 
 export function StateMessage({
+  action,
   children,
   title,
   tone = "empty",
@@ -19,6 +21,7 @@ export function StateMessage({
     <div className={`state-message state-message-${tone}`} role={role}>
       <strong>{title}</strong>
       <p>{children}</p>
+      {action ? <div className="state-message__action">{action}</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Objective

Connect the home page to the public catalog API and replace placeholder content with the real movie discovery experience required by the frontend PRD: featured movies, now showing movies, and pre-sale movies.

## What was done

### 1. Catalog API module

Added a reusable catalog API module for public movie discovery:

- `GET /api/v1/catalog/movies/`
- `is_featured=true` featured movie filter
- `status=em_cartaz` now showing filter
- `status=pre_venda` pre-sale filter
- DRF paginated response validation through the shared API client helpers

### 2. Home page catalog loading

Updated `/` to load the three home catalog sections from the API:

- featured movie data from `is_featured=true`
- now showing movies from `status=em_cartaz`
- pre-sale movies from `status=pre_venda`

Each section has independent loading, empty, and recoverable error states.

### 3. Component integration

Wired the existing movie components into the real home experience:

- `FeaturedMovieBanner`
- `MovieGrid`
- `MovieCard`
- shared `StateMessage`

`StateMessage` now supports an optional action slot so catalog error states can offer a retry action without duplicating UI state markup.

### 4. Backend contract alignment

Kept the UI aligned with the current backend movie contract:

- uses `id`
- uses `title`
- uses `genres`
- uses `duration_minutes`
- uses `poster_url`
- uses `status`
- uses `is_featured`

No unsupported metadata such as age rating, room type, or audio format is displayed or invented.

### 5. Placeholder removal

Removed the hard-coded home placeholder panels and replaced them with API-driven catalog sections.

### 6. Automated test coverage

Added frontend unit coverage for:

- catalog API endpoint/query construction
- DRF paginated response handling
- featured, now showing, and pre-sale home rendering
- loading states
- empty states
- retry-oriented error states
- avoiding unsupported backend fields in rendered movie UI

## How to test

### Automated validation

Run the frontend checks:

```bash
cd frontend
npm test
npm run lint
npm run build
```

In this workspace, `npm run build` was validated from a clean temporary frontend copy because the repository `.next` directory is generated by Docker and contains files owned by `nobody`.

### Manual validation

1. Start the stack:

```bash
docker compose up --build
```

2. Open the frontend:

```text
http://localhost:3000
```

3. Validate the home page:

- featured section requests `is_featured=true`
- now showing section requests `status=em_cartaz`
- pre-sale section requests `status=pre_venda`
- movie cards navigate to `/movies/{movieId}`
- empty catalog sections remain readable in pt-BR
- failed catalog requests show friendly retry-oriented feedback

## Expected Result

- The home page renders catalog discovery from the public API.
- Featured movies appear in the banner when `is_featured=true` movies exist.
- Now showing and pre-sale sections render backend-filtered movie lists.
- Loading, empty, and error states are handled per section.
- The UI remains aligned with the current backend fields and does not display unsupported movie metadata.
- Frontend test, lint, and build validation pass.

closes #95
