### PR TITLE
feat: build movie detail page with catalog data

### DIFF
--- a/frontend/src/api/catalog.test.ts
+++ b/frontend/src/api/catalog.test.ts
@@ -3,12 +3,45 @@ import test from "node:test";
 
 import { catalogApi } from "./catalog";
 
+const movieDetailResponse = {
+  created_at: "2026-05-20T10:00:00-03:00",
+  duration_minutes: 125,
+  genres: [{ id: "genre-1", name: "Aventura" }],
+  id: "movie-123",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/movie.jpg",
+  release_date: "2026-05-13",
+  status: "em_cartaz",
+  synopsis: "Uma aventura em Natal.",
+  title: "A Jornada",
+  updated_at: "2026-05-21T10:00:00-03:00",
+};
+
 const paginatedMoviesResponse = {
   count: 0,
   next: null,
   previous: null,
   results: [],
 };
+
+test("catalogApi gets a movie through the public catalog detail endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/movie-123/");
+      assert.equal(init?.method, "GET");
+
+      return Response.json(movieDetailResponse);
+    };
+
+    const response = await catalogApi.getMovie("movie-123");
+
+    assert.deepEqual(response, movieDetailResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
 
 test("catalogApi lists movies through the public catalog endpoint", async () => {
   const originalFetch = globalThis.fetch;
@@ -54,6 +87,21 @@ test("catalogApi builds supported movie filters", async () => {
       "http://localhost:8000/api/v1/catalog/movies/?status=pre_venda",
       "http://localhost:8000/api/v1/catalog/movies/?status=em_cartaz&is_featured=true&page=2",
     ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi rejects unexpected movie detail responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ id: "movie-123" });
+
+    await assert.rejects(
+      catalogApi.getMovie("movie-123"),
+      /Unexpected catalog movie detail response/
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -1,4 +1,9 @@
-import type { MovieStatus, CatalogMovie } from "@/types/catalog";
+import type {
+  CatalogGenre,
+  CatalogMovie,
+  CatalogMovieDetail,
+  MovieStatus,
+} from "@/types/catalog";
 
 import {
   apiRequest,
@@ -15,6 +20,10 @@ export type ListMoviesParams = {
 const MOVIES_PATH = "/api/v1/catalog/movies/";
 
 export const catalogApi = {
+  getMovie(movieId: string) {
+    return getMovie(movieId);
+  },
+
   listMovies(params: ListMoviesParams = {}) {
     return listMovies(params);
   },
@@ -32,6 +41,19 @@ export const catalogApi = {
   },
 };
 
+async function getMovie(movieId: string) {
+  const response = await apiRequest<unknown>(`${MOVIES_PATH}${movieId}/`, {
+    auth: "none",
+    method: "GET",
+  });
+
+  if (!isCatalogMovieDetail(response)) {
+    throw new Error("Unexpected catalog movie detail response.");
+  }
+
+  return response satisfies CatalogMovieDetail;
+}
+
 async function listMovies(params: ListMoviesParams) {
   const response = await apiRequest<unknown>(buildMoviesPath(params), {
     auth: "none",
@@ -43,6 +65,39 @@ async function listMovies(params: ListMoviesParams) {
   }
 
   return response satisfies PaginatedResponse<CatalogMovie>;
+}
+
+function isCatalogMovieDetail(value: unknown): value is CatalogMovieDetail {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    Array.isArray(value.genres) &&
+    value.genres.every(isCatalogGenre) &&
+    typeof value.duration_minutes === "number" &&
+    typeof value.poster_url === "string" &&
+    (value.status === "em_cartaz" || value.status === "pre_venda") &&
+    typeof value.is_featured === "boolean" &&
+    typeof value.synopsis === "string" &&
+    (typeof value.release_date === "string" ||
+      value.release_date === null ||
+      value.release_date === undefined)
+  );
+}
+
+function isCatalogGenre(value: unknown): value is CatalogGenre {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function buildMoviesPath({ is_featured, page, status }: ListMoviesParams) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -540,6 +540,136 @@ h1 {
   font-weight: 750;
 }
 
+.movie-detail,
+.movie-detail-loading {
+  align-items: start;
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(220px, 340px) minmax(0, 1fr);
+}
+
+.movie-detail__poster-frame,
+.movie-detail-loading__poster {
+  aspect-ratio: 2 / 3;
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  width: 100%;
+}
+
+.movie-detail__poster {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.movie-detail__poster-placeholder {
+  align-items: center;
+  color: var(--color-muted);
+  display: flex;
+  font-weight: 800;
+  height: 100%;
+  justify-content: center;
+  padding: 18px;
+  text-align: center;
+}
+
+.movie-detail__content,
+.movie-detail-loading__content {
+  display: grid;
+  gap: 22px;
+  min-width: 0;
+}
+
+.movie-detail__heading {
+  display: grid;
+  gap: 8px;
+}
+
+.movie-detail__metadata {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+}
+
+.movie-detail__metadata > div {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.movie-detail__metadata dt {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 850;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+.movie-detail__metadata dd {
+  font-weight: 800;
+  line-height: 1.4;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.movie-detail__synopsis,
+.movie-detail__action-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  padding: 22px;
+}
+
+.movie-detail__synopsis h2,
+.movie-detail__action-panel h2 {
+  font-size: 20px;
+  line-height: 1.25;
+  margin: 0 0 10px;
+}
+
+.movie-detail__synopsis p,
+.movie-detail__action-panel p {
+  color: var(--color-muted);
+  line-height: 1.65;
+  margin: 0;
+}
+
+.movie-detail__action-panel {
+  align-items: center;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.movie-detail-loading__poster,
+.movie-detail-loading .skeleton-line {
+  animation: skeleton-pulse 1300ms ease-in-out infinite;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface-muted),
+    #f9fafc,
+    var(--color-surface-muted)
+  );
+  background-size: 220% 100%;
+}
+
+.movie-detail-loading__content {
+  padding-top: 8px;
+}
+
+.movie-detail-loading__content > span:first-child {
+  color: var(--color-muted);
+  font-weight: 750;
+}
+
 .movie-card--skeleton {
   box-shadow: none;
 }
@@ -613,6 +743,25 @@ h1 {
   .featured-movie__content {
     padding: 24px;
   }
+
+  .movie-detail,
+  .movie-detail-loading {
+    grid-template-columns: 1fr;
+  }
+
+  .movie-detail__poster-frame,
+  .movie-detail-loading__poster {
+    max-width: 340px;
+  }
+
+  .movie-detail__metadata,
+  .movie-detail__action-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .movie-detail__action-panel .button {
+    width: 100%;
+  }
 }
 
 @media (max-width: 420px) {
@@ -643,5 +792,15 @@ h1 {
 
   .movie-grid {
     grid-template-columns: 1fr;
+  }
+
+  .movie-detail__poster-frame,
+  .movie-detail-loading__poster {
+    max-width: none;
+  }
+
+  .movie-detail__synopsis,
+  .movie-detail__action-panel {
+    padding: 18px;
   }
 }

--- a/frontend/src/app/movies/[movieId]/page.tsx
+++ b/frontend/src/app/movies/[movieId]/page.tsx
@@ -1,17 +1,13 @@
-import { PageSection } from "@/components/ui/PageSection";
-import { StateMessage } from "@/components/ui/StateMessage";
+import { MovieDetail } from "@/components/movies";
 
-export default function MovieDetailPage() {
-  return (
-    <PageSection
-      description="Veja sinopse, duração, gêneros e sessões disponíveis para o filme selecionado."
-      eyebrow="Filme"
-      title="Detalhes do filme"
-    >
-      <StateMessage title="Filme não carregado">
-        Os detalhes serão buscados no catálogo público quando a integração da
-        página for implementada.
-      </StateMessage>
-    </PageSection>
-  );
+type MovieDetailPageProps = {
+  params: Promise<{
+    movieId: string;
+  }>;
+};
+
+export default async function MovieDetailPage({ params }: MovieDetailPageProps) {
+  const { movieId } = await params;
+
+  return <MovieDetail movieId={movieId} />;
 }

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { ApiError, getApiErrorUserMessage } from "@/api/client";
+import { catalogApi } from "@/api/catalog";
+import { StateMessage } from "@/components/ui/StateMessage";
+import type { CatalogMovieDetail } from "@/types/catalog";
+
+import {
+  formatMovieDuration,
+  formatMovieGenres,
+  formatMovieReleaseDate,
+} from "./movie-formatters";
+
+type MovieDetailStatus = "error" | "loading" | "not-found" | "success";
+
+export type MovieDetailState = {
+  errorMessage?: string;
+  movie?: CatalogMovieDetail;
+  status: MovieDetailStatus;
+};
+
+type MovieDetailProps = {
+  movieId: string;
+};
+
+type MovieDetailViewProps = {
+  movieId?: string;
+  onRetry?: () => void;
+  state: MovieDetailState;
+};
+
+const loadingState: MovieDetailState = {
+  status: "loading",
+};
+
+export function MovieDetail({ movieId }: MovieDetailProps) {
+  const [state, setState] = useState<MovieDetailState>(loadingState);
+
+  const loadMovie = useCallback(async () => {
+    const trimmedMovieId = movieId.trim();
+
+    if (!trimmedMovieId) {
+      setState({ status: "not-found" });
+      return;
+    }
+
+    setState(loadingState);
+
+    try {
+      const movie = await catalogApi.getMovie(trimmedMovieId);
+
+      setState(
+        movie?.id
+          ? {
+              movie,
+              status: "success",
+            }
+          : { status: "not-found" }
+      );
+    } catch (error) {
+      setState(toMovieDetailErrorState(error));
+    }
+  }, [movieId]);
+
+  useEffect(() => {
+    void loadMovie();
+  }, [loadMovie]);
+
+  return (
+    <MovieDetailView
+      movieId={movieId}
+      onRetry={() => void loadMovie()}
+      state={state}
+    />
+  );
+}
+
+export function MovieDetailView({ movieId, onRetry, state }: MovieDetailViewProps) {
+  if (state.status === "loading") {
+    return <MovieDetailLoadingState />;
+  }
+
+  if (state.status === "error") {
+    return (
+      <StateMessage
+        action={
+          onRetry ? (
+            <button className="button button-ghost" onClick={onRetry} type="button">
+              Tentar novamente
+            </button>
+          ) : undefined
+        }
+        title="Detalhes indisponíveis"
+        tone="error"
+      >
+        {state.errorMessage ??
+          "Não conseguimos carregar este filme agora. Tente novamente em instantes."}
+      </StateMessage>
+    );
+  }
+
+  if (state.status === "not-found" || !state.movie) {
+    return <MovieDetailNotFoundState />;
+  }
+
+  return <MovieDetailSuccess movie={state.movie} movieId={movieId} />;
+}
+
+function MovieDetailSuccess({
+  movie,
+  movieId,
+}: {
+  movie: CatalogMovieDetail;
+  movieId?: string;
+}) {
+  const genres = formatMovieGenres(movie.genres);
+  const duration = formatMovieDuration(movie.duration_minutes);
+  const releaseDate = formatMovieReleaseDate(movie.release_date);
+  const movieHref = movieId ? `/movies/${movieId}` : `/movies/${movie.id}`;
+
+  return (
+    <div className="movie-detail">
+      <div className="movie-detail__poster-frame">
+        {movie.poster_url ? (
+          <>
+            {/* API poster URLs are arbitrary remote images until image domains are configured. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              alt={`Poster de ${movie.title}`}
+              className="movie-detail__poster"
+              loading="eager"
+              src={movie.poster_url}
+            />
+          </>
+        ) : (
+          <div
+            aria-label={`Poster indisponível de ${movie.title}`}
+            className="movie-detail__poster-placeholder"
+            role="img"
+          >
+            Poster indisponível
+          </div>
+        )}
+      </div>
+
+      <article className="movie-detail__content">
+        <div className="movie-detail__heading">
+          <p className="eyebrow">Filme</p>
+          <h1>{movie.title}</h1>
+        </div>
+
+        <dl className="movie-detail__metadata" aria-label="Informações do filme">
+          <div>
+            <dt>Gêneros</dt>
+            <dd>{genres}</dd>
+          </div>
+          <div>
+            <dt>Duração</dt>
+            <dd>{duration}</dd>
+          </div>
+          {movie.release_date ? (
+            <div>
+              <dt>Estreia</dt>
+              <dd>{releaseDate}</dd>
+            </div>
+          ) : null}
+        </dl>
+
+        <section className="movie-detail__synopsis" aria-labelledby="sinopse">
+          <h2 id="sinopse">Sinopse</h2>
+          <p>{movie.synopsis || "Sinopse indisponível."}</p>
+        </section>
+
+        <section
+          aria-labelledby="selecionar-sessao"
+          className="movie-detail__action-panel"
+        >
+          <div>
+            <h2 id="selecionar-sessao">Sessões</h2>
+            <p>
+              As datas e horários disponíveis serão exibidos antes da escolha dos
+              assentos.
+            </p>
+          </div>
+          <Link className="button button-primary" href={`${movieHref}#selecionar-sessao`}>
+            Escolher sessão
+          </Link>
+        </section>
+      </article>
+    </div>
+  );
+}
+
+function MovieDetailLoadingState() {
+  return (
+    <div aria-busy="true" className="movie-detail-loading" role="status">
+      <div className="movie-detail-loading__poster" />
+      <div className="movie-detail-loading__content">
+        <span>Carregando detalhes do filme...</span>
+        <span className="skeleton-line skeleton-line--title" />
+        <span className="skeleton-line" />
+        <span className="skeleton-line skeleton-line--short" />
+        <span className="skeleton-line" />
+      </div>
+    </div>
+  );
+}
+
+function MovieDetailNotFoundState() {
+  return (
+    <StateMessage title="Filme não encontrado">
+      Não encontramos esse filme no catálogo. Volte para a página inicial e escolha
+      outro título disponível.
+    </StateMessage>
+  );
+}
+
+function toMovieDetailErrorState(error: unknown): MovieDetailState {
+  if (error instanceof ApiError && error.code === "RESOURCE_NOT_FOUND") {
+    return { status: "not-found" };
+  }
+
+  return {
+    errorMessage: getApiErrorUserMessage(error),
+    status: "error",
+  };
+}

--- a/frontend/src/components/movies/index.ts
+++ b/frontend/src/components/movies/index.ts
@@ -1,8 +1,10 @@
 export { FeaturedMovieBanner } from "./FeaturedMovieBanner";
+export { MovieDetail, MovieDetailView, type MovieDetailState } from "./MovieDetail";
 export { MovieCard } from "./MovieCard";
 export { MovieGrid } from "./MovieGrid";
 export {
   formatMovieDuration,
   formatMovieGenres,
+  formatMovieReleaseDate,
   getMovieDetailsHref,
 } from "./movie-formatters";

--- a/frontend/src/components/movies/movie-components.test.ts
+++ b/frontend/src/components/movies/movie-components.test.ts
@@ -13,6 +13,7 @@ import { MovieGrid } from "./MovieGrid";
 import {
   formatMovieDuration,
   formatMovieGenres,
+  formatMovieReleaseDate,
   getMovieDetailsHref,
 } from "./movie-formatters";
 
@@ -102,5 +103,7 @@ test("movie component helpers format API-shaped values", () => {
   assert.equal(formatMovieDuration(0), "Duração indisponível");
   assert.equal(formatMovieGenres([]), "Gênero indisponível");
   assert.equal(formatMovieGenres(movie.genres), "Ficção científica, Aventura");
+  assert.equal(formatMovieReleaseDate("2026-05-13"), "13/05/2026");
+  assert.equal(formatMovieReleaseDate(null), "Estreia indisponível");
   assert.equal(getMovieDetailsHref(movie.id), "/movies/movie-123");
 });

--- a/frontend/src/components/movies/movie-detail.test.ts
+++ b/frontend/src/components/movies/movie-detail.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CatalogMovieDetail } from "@/types/catalog";
+
+import { MovieDetailView } from "./MovieDetail";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const movie: CatalogMovieDetail = {
+  duration_minutes: 125,
+  genres: [
+    { id: "genre-1", name: "Aventura" },
+    { id: "genre-2", name: "Drama" },
+  ],
+  id: "movie-123",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/jornada.jpg",
+  release_date: "2026-05-13",
+  status: "em_cartaz",
+  synopsis: "Uma família encontra novas histórias em uma viagem por Natal.",
+  title: "A Jornada",
+};
+
+test("movie detail renders backend movie fields with accessible media", () => {
+  const html = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      movieId: movie.id,
+      state: {
+        movie,
+        status: "success",
+      },
+    })
+  );
+
+  assert.match(html, /A Jornada/);
+  assert.match(html, /Poster de A Jornada/);
+  assert.match(html, /Uma família encontra novas histórias/);
+  assert.match(html, /Aventura, Drama/);
+  assert.match(html, /2h 5min/);
+  assert.match(html, /13\/05\/2026/);
+  assert.match(html, /Escolher sessão/);
+  assert.doesNotMatch(html, /age_rating|classificação|room_type|audio_format|sala tradicional|legendado/i);
+});
+
+test("movie detail omits release date when unavailable", () => {
+  const html = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      state: {
+        movie: {
+          ...movie,
+          release_date: null,
+        },
+        status: "success",
+      },
+    })
+  );
+
+  assert.doesNotMatch(html, /Estreia/);
+  assert.doesNotMatch(html, /Estreia indisponível/);
+});
+
+test("movie detail renders stable loading state", () => {
+  const html = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      state: {
+        status: "loading",
+      },
+    })
+  );
+
+  assert.match(html, /role="status"/);
+  assert.match(html, /aria-busy="true"/);
+  assert.match(html, /Carregando detalhes do filme/);
+});
+
+test("movie detail renders pt-BR not-found and error states", () => {
+  const notFoundHtml = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      state: {
+        status: "not-found",
+      },
+    })
+  );
+
+  assert.match(notFoundHtml, /Filme não encontrado/);
+  assert.match(notFoundHtml, /Não encontramos esse filme no catálogo/);
+
+  const errorHtml = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      state: {
+        errorMessage: "Não foi possível concluir a solicitação. Tente novamente.",
+        status: "error",
+      },
+    })
+  );
+
+  assert.match(errorHtml, /Detalhes indisponíveis/);
+  assert.match(errorHtml, /Não foi possível concluir a solicitação/);
+  assert.doesNotMatch(errorHtml, /Request failed|Traceback|RESOURCE_NOT_FOUND/i);
+});

--- a/frontend/src/components/movies/movie-formatters.ts
+++ b/frontend/src/components/movies/movie-formatters.ts
@@ -1,5 +1,9 @@
 import type { CatalogMovie } from "@/types/catalog";
 
+const ptBrDateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  timeZone: "UTC",
+});
+
 export function formatMovieDuration(durationMinutes: number) {
   if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
     return "Duração indisponível";
@@ -25,6 +29,20 @@ export function formatMovieGenres(genres: CatalogMovie["genres"]) {
   }
 
   return genres.map((genre) => genre.name).join(", ");
+}
+
+export function formatMovieReleaseDate(releaseDate?: string | null) {
+  if (!releaseDate) {
+    return "Estreia indisponível";
+  }
+
+  const parsedDate = new Date(`${releaseDate}T00:00:00.000Z`);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return "Estreia indisponível";
+  }
+
+  return ptBrDateFormatter.format(parsedDate);
 }
 
 export function getMovieDetailsHref(movieId: CatalogMovie["id"]) {

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -14,3 +14,10 @@ export type CatalogMovie = {
   status: MovieStatus;
   is_featured: boolean;
 };
+
+export type CatalogMovieDetail = CatalogMovie & {
+  created_at?: string;
+  release_date?: string | null;
+  synopsis: string;
+  updated_at?: string;
+};


### PR DESCRIPTION
## Objective

Implement the movie detail page with real catalog data so users can review the movie poster, title, synopsis, genres, duration, and release information before moving toward session selection.

## What was done

### 1. Movie detail API function

Extended the frontend catalog API module with:

- `catalogApi.getMovie(movieId)`
- `GET /api/v1/catalog/movies/{id}/`
- typed `CatalogMovieDetail` response support
- response-shape validation for movie detail payloads

### 2. Movie detail route

Updated `/movies/{movieId}` to fetch and render real catalog information:

- poster image
- movie title
- synopsis
- genres
- duration
- release date when available

### 3. Detail page UX

Added a responsive detail layout for mobile and desktop:

- poster and metadata layout adapts from two columns to one column
- loading state uses stable skeleton structure
- not-found state uses friendly pt-BR copy
- recoverable errors use friendly pt-BR feedback
- poster media includes meaningful alt text
- missing optional release date is omitted gracefully

### 4. Contract accuracy

Kept the page aligned with fields currently exposed by the backend:

- no age rating is rendered
- no room type is rendered
- no audio format is rendered
- no session fetching, checkout, ticket type, or reservation state was introduced

### 5. Brazilian formatting

Added frontend formatting for movie detail values:

- duration remains in Brazilian-friendly display, such as `2h 5min`
- release date renders as `DD/MM/YYYY`

### 6. Automated test coverage

Added and updated frontend tests covering:

- `catalogApi.getMovie(movieId)` endpoint construction
- invalid movie detail response rejection
- release date formatting
- successful movie detail rendering
- missing release date behavior
- loading state
- not-found state
- API error state
- absence of unsupported fields

## Acceptance Criteria

- API Function: `catalogApi.getMovie(movieId)` calls `/api/v1/catalog/movies/{id}/`.
- Detail Rendering: `/movies/{movieId}` displays poster, title, synopsis, genres, duration, and release date when available.
- Not Found State: `RESOURCE_NOT_FOUND` or missing movie data shows a friendly pt-BR not-found message.
- Loading State: the route shows a stable loading state while movie data is being fetched.
- Error State: recoverable API errors show friendly feedback without raw backend messages.
- Responsive Layout: the page uses responsive CSS for mobile and desktop layouts.
- Accessible Media: poster image includes meaningful alt text.
- No Unsupported Fields: the page does not render age rating, room type, or audio format.
- Automated Tests: tests cover the API function and the main rendering states.

## How to test

### Automated validation

Run from `frontend/`:

```bash
npm test
npm run lint
npm run build
```

## Expected Result

- Users can open a movie detail route and see real catalog data.
- The page handles loading, not-found, and API error states with pt-BR copy.
- The UI remains aligned with the current backend contract.
- The session selection area is prepared without fetching sessions in this issue.
- Frontend tests, lint, and production build pass successfully.

closes #96
