### PR TITLE
feat: implement date-based session selection

### DIFF
--- a/frontend/src/api/catalog.test.ts
+++ b/frontend/src/api/catalog.test.ts
@@ -24,6 +24,35 @@ const paginatedMoviesResponse = {
   results: [],
 };
 
+const sessionResponse = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [
+    {
+      base_price: "42.50",
+      end_time: "2026-05-22T21:00:00-03:00",
+      id: "session-123",
+      movie: {
+        duration_minutes: 125,
+        genres: [{ id: "genre-1", name: "Aventura" }],
+        id: "movie-123",
+        is_featured: false,
+        poster_url: "https://cdn.example.com/movie.jpg",
+        release_date: "2026-05-13",
+        status: "em_cartaz",
+        title: "A Jornada",
+      },
+      room: {
+        capacity: 80,
+        id: "room-1",
+        name: "Sala 1",
+      },
+      start_time: "2026-05-22T18:30:00-03:00",
+    },
+  ],
+};
+
 test("catalogApi gets a movie through the public catalog detail endpoint", async () => {
   const originalFetch = globalThis.fetch;
 
@@ -92,6 +121,56 @@ test("catalogApi builds supported movie filters", async () => {
   }
 });
 
+test("catalogApi builds session movie and date filters", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/?movie=movie-123&date=2026-05-22"
+      );
+      assert.equal(init?.method, "GET");
+
+      return Response.json(sessionResponse);
+    };
+
+    const response = await catalogApi.getSessions({
+      date: "2026-05-22",
+      movie: "movie-123",
+    });
+
+    assert.deepEqual(response, sessionResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi builds optional session range filters", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/?movie=movie-123&date=2026-05-22&start_from=2026-05-22T00%3A00%3A00-03%3A00&start_to=2026-05-22T23%3A59%3A59-03%3A00&page=2"
+      );
+
+      return Response.json({ ...sessionResponse, results: [] });
+    };
+
+    await catalogApi.getSessions({
+      date: "2026-05-22",
+      movie: "movie-123",
+      page: 2,
+      start_from: "2026-05-22T00:00:00-03:00",
+      start_to: "2026-05-22T23:59:59-03:00",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("catalogApi rejects unexpected movie detail responses", async () => {
   const originalFetch = globalThis.fetch;
 
@@ -116,6 +195,22 @@ test("catalogApi rejects unexpected non-paginated movie responses", async () => 
     await assert.rejects(
       catalogApi.listMovies(),
       /Unexpected catalog movie list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi rejects unexpected session responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json({ ...sessionResponse, results: [{ id: "session-123" }] });
+
+    await assert.rejects(
+      catalogApi.getSessions({ date: "2026-05-22", movie: "movie-123" }),
+      /Unexpected catalog session list response/
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -2,6 +2,8 @@ import type {
   CatalogGenre,
   CatalogMovie,
   CatalogMovieDetail,
+  CatalogRoomSummary,
+  CatalogSession,
   MovieStatus,
 } from "@/types/catalog";
 
@@ -17,11 +19,24 @@ export type ListMoviesParams = {
   status?: MovieStatus;
 };
 
+export type GetSessionsParams = {
+  date?: string;
+  movie?: string;
+  page?: number;
+  start_from?: string;
+  start_to?: string;
+};
+
 const MOVIES_PATH = "/api/v1/catalog/movies/";
+const SESSIONS_PATH = "/api/v1/catalog/sessions/";
 
 export const catalogApi = {
   getMovie(movieId: string) {
     return getMovie(movieId);
+  },
+
+  getSessions(params: GetSessionsParams = {}) {
+    return getSessions(params);
   },
 
   listMovies(params: ListMoviesParams = {}) {
@@ -67,6 +82,22 @@ async function listMovies(params: ListMoviesParams) {
   return response satisfies PaginatedResponse<CatalogMovie>;
 }
 
+async function getSessions(params: GetSessionsParams) {
+  const response = await apiRequest<unknown>(buildSessionsPath(params), {
+    auth: "none",
+    method: "GET",
+  });
+
+  if (
+    !isPaginatedResponse<CatalogSession>(response) ||
+    !response.results.every(isCatalogSession)
+  ) {
+    throw new Error("Unexpected catalog session list response.");
+  }
+
+  return response satisfies PaginatedResponse<CatalogSession>;
+}
+
 function isCatalogMovieDetail(value: unknown): value is CatalogMovieDetail {
   if (!isRecord(value)) {
     return false;
@@ -88,11 +119,46 @@ function isCatalogMovieDetail(value: unknown): value is CatalogMovieDetail {
   );
 }
 
+function isCatalogMovie(value: unknown): value is CatalogMovie {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    Array.isArray(value.genres) &&
+    value.genres.every(isCatalogGenre) &&
+    typeof value.duration_minutes === "number" &&
+    typeof value.poster_url === "string" &&
+    (value.status === "em_cartaz" || value.status === "pre_venda") &&
+    typeof value.is_featured === "boolean"
+  );
+}
+
 function isCatalogGenre(value: unknown): value is CatalogGenre {
   return (
     isRecord(value) &&
     typeof value.id === "string" &&
     typeof value.name === "string"
+  );
+}
+
+function isCatalogRoom(value: unknown): value is CatalogRoomSummary {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.capacity === "number"
+  );
+}
+
+function isCatalogSession(value: unknown): value is CatalogSession {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    isCatalogMovie(value.movie) &&
+    isCatalogRoom(value.room) &&
+    typeof value.start_time === "string" &&
+    typeof value.end_time === "string" &&
+    typeof value.base_price === "string"
   );
 }
 
@@ -117,4 +183,37 @@ function buildMoviesPath({ is_featured, page, status }: ListMoviesParams) {
 
   const query = searchParams.toString();
   return query ? `${MOVIES_PATH}?${query}` : MOVIES_PATH;
+}
+
+function buildSessionsPath({
+  date,
+  movie,
+  page,
+  start_from,
+  start_to,
+}: GetSessionsParams) {
+  const searchParams = new URLSearchParams();
+
+  if (movie) {
+    searchParams.set("movie", movie);
+  }
+
+  if (date) {
+    searchParams.set("date", date);
+  }
+
+  if (start_from) {
+    searchParams.set("start_from", start_from);
+  }
+
+  if (start_to) {
+    searchParams.set("start_to", start_to);
+  }
+
+  if (page !== undefined) {
+    searchParams.set("page", String(page));
+  }
+
+  const query = searchParams.toString();
+  return query ? `${SESSIONS_PATH}?${query}` : SESSIONS_PATH;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -620,7 +620,7 @@ h1 {
 }
 
 .movie-detail__synopsis,
-.movie-detail__action-panel {
+.movie-detail__sessions {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -629,24 +629,119 @@ h1 {
 }
 
 .movie-detail__synopsis h2,
-.movie-detail__action-panel h2 {
+.movie-detail__sessions h2 {
   font-size: 20px;
   line-height: 1.25;
   margin: 0 0 10px;
 }
 
 .movie-detail__synopsis p,
-.movie-detail__action-panel p {
+.movie-detail__sessions p {
   color: var(--color-muted);
   line-height: 1.65;
   margin: 0;
 }
 
-.movie-detail__action-panel {
-  align-items: center;
+.movie-detail__sessions {
   display: grid;
   gap: 18px;
+}
+
+.movie-detail__sessions-header {
+  align-items: end;
+  display: grid;
+  gap: 12px;
   grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.session-date-selector {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+}
+
+.session-date-selector__button {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  display: grid;
+  gap: 6px;
+  min-height: 72px;
+  padding: 12px;
+  text-align: left;
+}
+
+.session-date-selector__button[aria-pressed="true"] {
+  background: #fff2bf;
+  border-color: #d8a907;
+}
+
+.session-date-selector__button span {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.session-date-selector__button strong {
+  font-size: 17px;
+  line-height: 1;
+}
+
+.session-list {
+  display: grid;
+  gap: 14px;
+}
+
+.session-room-group {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.session-room-group h3 {
+  font-size: 18px;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.session-time-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+}
+
+.session-option {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  min-height: 92px;
+  padding: 14px;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.session-option:hover {
+  background: #fff8df;
+  border-color: #d8a907;
+}
+
+.session-option strong {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.session-option span {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 750;
 }
 
 .movie-detail-loading__poster,
@@ -755,7 +850,7 @@ h1 {
   }
 
   .movie-detail__metadata,
-  .movie-detail__action-panel {
+  .movie-detail__sessions-header {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -1,20 +1,29 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ApiError, getApiErrorUserMessage } from "@/api/client";
 import { catalogApi } from "@/api/catalog";
 import { StateMessage } from "@/components/ui/StateMessage";
-import type { CatalogMovieDetail } from "@/types/catalog";
+import type { CatalogMovieDetail, CatalogSession } from "@/types/catalog";
 
 import {
   formatMovieDuration,
   formatMovieGenres,
   formatMovieReleaseDate,
 } from "./movie-formatters";
+import {
+  buildSessionDateOptions,
+  formatSessionFullDate,
+  formatSessionPrice,
+  formatSessionTime,
+  getSessionSeatsHref,
+  groupSessionsByRoom,
+} from "./session-selection";
 
 type MovieDetailStatus = "error" | "loading" | "not-found" | "success";
+type SessionListStatus = "error" | "loading" | "success";
 
 export type MovieDetailState = {
   errorMessage?: string;
@@ -22,12 +31,17 @@ export type MovieDetailState = {
   status: MovieDetailStatus;
 };
 
+type SessionListState = {
+  errorMessage?: string;
+  sessions: CatalogSession[];
+  status: SessionListStatus;
+};
+
 type MovieDetailProps = {
   movieId: string;
 };
 
 type MovieDetailViewProps = {
-  movieId?: string;
   onRetry?: () => void;
   state: MovieDetailState;
 };
@@ -71,14 +85,13 @@ export function MovieDetail({ movieId }: MovieDetailProps) {
 
   return (
     <MovieDetailView
-      movieId={movieId}
       onRetry={() => void loadMovie()}
       state={state}
     />
   );
 }
 
-export function MovieDetailView({ movieId, onRetry, state }: MovieDetailViewProps) {
+export function MovieDetailView({ onRetry, state }: MovieDetailViewProps) {
   if (state.status === "loading") {
     return <MovieDetailLoadingState />;
   }
@@ -106,20 +119,13 @@ export function MovieDetailView({ movieId, onRetry, state }: MovieDetailViewProp
     return <MovieDetailNotFoundState />;
   }
 
-  return <MovieDetailSuccess movie={state.movie} movieId={movieId} />;
+  return <MovieDetailSuccess movie={state.movie} />;
 }
 
-function MovieDetailSuccess({
-  movie,
-  movieId,
-}: {
-  movie: CatalogMovieDetail;
-  movieId?: string;
-}) {
+function MovieDetailSuccess({ movie }: { movie: CatalogMovieDetail }) {
   const genres = formatMovieGenres(movie.genres);
   const duration = formatMovieDuration(movie.duration_minutes);
   const releaseDate = formatMovieReleaseDate(movie.release_date);
-  const movieHref = movieId ? `/movies/${movieId}` : `/movies/${movie.id}`;
 
   return (
     <div className="movie-detail">
@@ -174,22 +180,193 @@ function MovieDetailSuccess({
           <p>{movie.synopsis || "Sinopse indisponível."}</p>
         </section>
 
-        <section
-          aria-labelledby="selecionar-sessao"
-          className="movie-detail__action-panel"
-        >
-          <div>
-            <h2 id="selecionar-sessao">Sessões</h2>
-            <p>
-              As datas e horários disponíveis serão exibidos antes da escolha dos
-              assentos.
-            </p>
-          </div>
-          <Link className="button button-primary" href={`${movieHref}#selecionar-sessao`}>
-            Escolher sessão
-          </Link>
-        </section>
+        <MovieSessionSelector movieId={movie.id} />
       </article>
+    </div>
+  );
+}
+
+function MovieSessionSelector({ movieId }: { movieId: string }) {
+  const dateOptions = useMemo(() => buildSessionDateOptions(new Date()), []);
+  const [selectedDate, setSelectedDate] = useState(dateOptions[0]?.value ?? "");
+  const [state, setState] = useState<SessionListState>({
+    sessions: [],
+    status: "loading",
+  });
+
+  const loadSessions = useCallback(async () => {
+    if (!selectedDate) {
+      setState({ sessions: [], status: "success" });
+      return;
+    }
+
+    setState({ sessions: [], status: "loading" });
+
+    try {
+      const response = await catalogApi.getSessions({
+        date: selectedDate,
+        movie: movieId,
+      });
+
+      setState({
+        sessions: response.results,
+        status: "success",
+      });
+    } catch (error) {
+      setState({
+        errorMessage: getApiErrorUserMessage(error),
+        sessions: [],
+        status: "error",
+      });
+    }
+  }, [movieId, selectedDate]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function fetchSessions() {
+      if (!selectedDate) {
+        if (isActive) {
+          setState({ sessions: [], status: "success" });
+        }
+        return;
+      }
+
+      setState({ sessions: [], status: "loading" });
+
+      try {
+        const response = await catalogApi.getSessions({
+          date: selectedDate,
+          movie: movieId,
+        });
+
+        if (isActive) {
+          setState({
+            sessions: response.results,
+            status: "success",
+          });
+        }
+      } catch (error) {
+        if (isActive) {
+          setState({
+            errorMessage: getApiErrorUserMessage(error),
+            sessions: [],
+            status: "error",
+          });
+        }
+      }
+    }
+
+    void fetchSessions();
+
+    return () => {
+      isActive = false;
+    };
+  }, [movieId, selectedDate]);
+
+  return (
+    <section
+      aria-labelledby="selecionar-sessao"
+      className="movie-detail__sessions"
+    >
+      <div className="movie-detail__sessions-header">
+        <h2 id="selecionar-sessao">Sessões</h2>
+        <p>{formatSessionFullDate(selectedDate)}</p>
+      </div>
+
+      <div
+        aria-label="Datas disponíveis"
+        className="session-date-selector"
+        role="list"
+      >
+        {dateOptions.map((dateOption) => (
+          <button
+            aria-pressed={dateOption.value === selectedDate}
+            className="session-date-selector__button"
+            key={dateOption.value}
+            onClick={() => setSelectedDate(dateOption.value)}
+            type="button"
+          >
+            <span>{dateOption.weekday}</span>
+            <strong>{dateOption.label}</strong>
+          </button>
+        ))}
+      </div>
+
+      <SessionList
+        date={selectedDate}
+        onRetry={() => void loadSessions()}
+        state={state}
+      />
+    </section>
+  );
+}
+
+function SessionList({
+  date,
+  onRetry,
+  state,
+}: {
+  date: string;
+  onRetry: () => void;
+  state: SessionListState;
+}) {
+  if (state.status === "loading") {
+    return (
+      <StateMessage tone="loading" title="Carregando sessões">
+        Buscando horários para {formatSessionFullDate(date)}.
+      </StateMessage>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <StateMessage
+        action={
+          <button className="button button-ghost" onClick={onRetry} type="button">
+            Tentar novamente
+          </button>
+        }
+        title="Sessões indisponíveis"
+        tone="error"
+      >
+        {state.errorMessage ??
+          "Não conseguimos carregar as sessões agora. Tente novamente em instantes."}
+      </StateMessage>
+    );
+  }
+
+  if (state.sessions.length === 0) {
+    return (
+      <StateMessage title="Nenhuma sessão nesta data">
+        Não há sessões disponíveis para {formatSessionFullDate(date)}. Escolha outra
+        data.
+      </StateMessage>
+    );
+  }
+
+  const groups = groupSessionsByRoom(state.sessions);
+
+  return (
+    <div aria-label="Sessões disponíveis" className="session-list">
+      {groups.map((group) => (
+        <section className="session-room-group" key={group.roomId}>
+          <h3>{group.roomName}</h3>
+          <div className="session-time-grid">
+            {group.sessions.map((session) => (
+              <Link
+                className="session-option"
+                href={getSessionSeatsHref(session.id)}
+                key={session.id}
+              >
+                <strong>{formatSessionTime(session.start_time)}</strong>
+                <span>até {formatSessionTime(session.end_time)}</span>
+                <span>{formatSessionPrice(session.base_price)}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/movies/movie-detail.test.ts
+++ b/frontend/src/components/movies/movie-detail.test.ts
@@ -43,7 +43,8 @@ test("movie detail renders backend movie fields with accessible media", () => {
   assert.match(html, /Aventura, Drama/);
   assert.match(html, /2h 5min/);
   assert.match(html, /13\/05\/2026/);
-  assert.match(html, /Escolher sessão/);
+  assert.match(html, /Sessões/);
+  assert.match(html, /Carregando sessões/);
   assert.doesNotMatch(html, /age_rating|classificação|room_type|audio_format|sala tradicional|legendado/i);
 });
 

--- a/frontend/src/components/movies/session-selection.test.ts
+++ b/frontend/src/components/movies/session-selection.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CatalogSession } from "@/types/catalog";
+
+import {
+  buildSessionDateOptions,
+  formatDateForSessionQuery,
+  formatSessionDateLabel,
+  formatSessionFullDate,
+  formatSessionPrice,
+  formatSessionTime,
+  getSessionSeatsHref,
+  groupSessionsByRoom,
+} from "./session-selection";
+
+const movie = {
+  duration_minutes: 125,
+  genres: [{ id: "genre-1", name: "Aventura" }],
+  id: "movie-123",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/movie.jpg",
+  status: "em_cartaz" as const,
+  title: "A Jornada",
+};
+
+function session(
+  id: string,
+  room: { id: string; name: string },
+  start_time: string,
+  base_price = "42.50"
+): CatalogSession {
+  return {
+    base_price,
+    end_time: "2026-05-22T21:00:00-03:00",
+    id,
+    movie,
+    room: {
+      capacity: 80,
+      ...room,
+    },
+    start_time,
+  };
+}
+
+test("session date helpers use API and Brazilian display formats", () => {
+  assert.equal(
+    formatDateForSessionQuery(new Date("2026-05-22T10:30:00-03:00")),
+    "2026-05-22"
+  );
+  assert.equal(formatSessionDateLabel("2026-05-22"), "22/05");
+  assert.equal(formatSessionFullDate("2026-05-22"), "22 de maio de 2026");
+  assert.equal(formatSessionTime("2026-05-22T18:30:00-03:00"), "18:30");
+  assert.equal(formatSessionPrice("42.50"), "R$ 42,50");
+});
+
+test("session date options keep stable YYYY-MM-DD values", () => {
+  assert.deepEqual(
+    buildSessionDateOptions(new Date("2026-05-22T10:30:00-03:00"), 3).map(
+      (option) => option.value
+    ),
+    ["2026-05-22", "2026-05-23", "2026-05-24"]
+  );
+});
+
+test("groupSessionsByRoom groups by room and orders sessions by time", () => {
+  const groups = groupSessionsByRoom([
+    session("late-room-2", { id: "room-2", name: "Sala 2" }, "2026-05-22T21:00:00-03:00"),
+    session("late-room-1", { id: "room-1", name: "Sala 1" }, "2026-05-22T20:00:00-03:00"),
+    session("early-room-1", { id: "room-1", name: "Sala 1" }, "2026-05-22T18:30:00-03:00"),
+  ]);
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      roomName: group.roomName,
+      sessionIds: group.sessions.map((groupedSession) => groupedSession.id),
+    })),
+    [
+      { roomName: "Sala 1", sessionIds: ["early-room-1", "late-room-1"] },
+      { roomName: "Sala 2", sessionIds: ["late-room-2"] },
+    ]
+  );
+});
+
+test("session navigation targets seat selection route", () => {
+  assert.equal(getSessionSeatsHref("session-123"), "/sessions/session-123/seats");
+});

--- a/frontend/src/components/movies/session-selection.ts
+++ b/frontend/src/components/movies/session-selection.ts
@@ -1,0 +1,145 @@
+import type { CatalogSession } from "@/types/catalog";
+import { formatCurrency, ptBrLocale } from "@/utils/formatters";
+
+export const sessionTimeZone = "America/Fortaleza";
+
+export type SessionDateOption = {
+  label: string;
+  value: string;
+  weekday: string;
+};
+
+export type SessionRoomGroup = {
+  roomId: string;
+  roomName: string;
+  sessions: CatalogSession[];
+};
+
+export function buildSessionDateOptions(
+  startDate: Date,
+  dayCount = 7
+): SessionDateOption[] {
+  const startDateValue = formatDateForSessionQuery(startDate);
+
+  return Array.from({ length: dayCount }, (_, offset) => {
+    const value = addDaysToDateValue(startDateValue, offset);
+
+    return {
+      label: formatSessionDateLabel(value),
+      value,
+      weekday: formatSessionWeekday(value),
+    };
+  });
+}
+
+export function formatDateForSessionQuery(date: Date) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: sessionTimeZone,
+    year: "numeric",
+  }).formatToParts(date);
+
+  return `${getDatePart(parts, "year")}-${getDatePart(parts, "month")}-${getDatePart(parts, "day")}`;
+}
+
+export function formatSessionDateLabel(dateValue: string) {
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: "UTC",
+  }).format(parseSessionDateValue(dateValue));
+}
+
+export function formatSessionFullDate(dateValue: string) {
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    dateStyle: "long",
+    timeZone: "UTC",
+  }).format(parseSessionDateValue(dateValue));
+}
+
+export function formatSessionTime(value: string) {
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: sessionTimeZone,
+  }).format(new Date(value));
+}
+
+export function formatSessionPrice(value: string) {
+  return formatCurrency(Number(value));
+}
+
+export function getSessionSeatsHref(sessionId: string) {
+  return `/sessions/${sessionId}/seats`;
+}
+
+export function groupSessionsByRoom(
+  sessions: CatalogSession[]
+): SessionRoomGroup[] {
+  const groups = new Map<string, SessionRoomGroup>();
+
+  for (const session of [...sessions].sort(compareSessionsByRoomAndTime)) {
+    const roomId = session.room.id;
+    const group = groups.get(roomId);
+
+    if (group) {
+      group.sessions.push(session);
+      continue;
+    }
+
+    groups.set(roomId, {
+      roomId,
+      roomName: session.room.name,
+      sessions: [session],
+    });
+  }
+
+  return Array.from(groups.values());
+}
+
+function compareSessionsByRoomAndTime(
+  first: CatalogSession,
+  second: CatalogSession
+) {
+  const roomComparison = first.room.name.localeCompare(second.room.name, ptBrLocale);
+
+  if (roomComparison !== 0) {
+    return roomComparison;
+  }
+
+  return (
+    new Date(first.start_time).getTime() - new Date(second.start_time).getTime()
+  );
+}
+
+function addDaysToDateValue(dateValue: string, days: number) {
+  const [year, month, day] = parseDateParts(dateValue);
+  const date = new Date(Date.UTC(year, month - 1, day + days, 12, 0, 0));
+  return date.toISOString().slice(0, 10);
+}
+
+function formatSessionWeekday(dateValue: string) {
+  const weekday = new Intl.DateTimeFormat(ptBrLocale, {
+    timeZone: "UTC",
+    weekday: "short",
+  }).format(parseSessionDateValue(dateValue));
+
+  return weekday.replace(".", "");
+}
+
+function getDatePart(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes
+) {
+  return parts.find((part) => part.type === type)?.value ?? "";
+}
+
+function parseSessionDateValue(dateValue: string) {
+  const [year, month, day] = parseDateParts(dateValue);
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+}
+
+function parseDateParts(dateValue: string) {
+  return dateValue.split("-").map(Number) as [number, number, number];
+}

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -21,3 +21,20 @@ export type CatalogMovieDetail = CatalogMovie & {
   synopsis: string;
   updated_at?: string;
 };
+
+export type CatalogRoomSummary = {
+  capacity: number;
+  id: string;
+  name: string;
+};
+
+export type CatalogSession = {
+  base_price: string;
+  created_at?: string;
+  end_time: string;
+  id: string;
+  movie: CatalogMovie;
+  room: CatalogRoomSummary;
+  start_time: string;
+  updated_at?: string;
+};


### PR DESCRIPTION
## Objective

Implement date-based session selection on the movie detail page so users can choose a date, view available sessions grouped by room and time, and continue to seat selection without relying on unsupported backend fields.

## What was done

### 1. Catalog sessions API client

Extended the frontend catalog API module with `catalogApi.getSessions()`.

The client now supports:

- `GET /api/v1/catalog/sessions/`
- `movie`
- `date`
- `start_from`
- `start_to`
- `page`
- DRF paginated response validation

The movie filter intentionally uses `movie`, not `movie_id`, matching the backend contract.

### 2. Session contract types

Added typed frontend models for the current session response shape:

- `id`
- `movie`
- `room`
- `start_time`
- `end_time`
- `base_price`

The UI does not use or display `room_type` or `audio_format`, because the backend does not expose those fields.

### 3. Date selector on movie detail

Added a pt-BR date selector to the movie detail page.

Selecting a date keeps local state stable and fetches sessions with:

```text
/api/v1/catalog/sessions/?movie=<movieId>&date=<YYYY-MM-DD>
```

Dates use `YYYY-MM-DD` for API queries and Brazilian display formatting for users.

### 4. Grouped session list

Rendered fetched sessions grouped by room name, with sessions ordered by start time.

Each session card displays:

- start time
- end time
- base price in BRL

Selecting a session navigates to:

```text
/sessions/{sessionId}/seats
```

### 5. Loading, empty, and error states

Added stable feedback for session fetching:

- loading message while sessions are being fetched
- friendly error state with retry
- clear pt-BR empty state when a date has no sessions

### 6. Styling

Added responsive styles for:

- session date selector
- room groups
- time cards
- mobile-friendly layout in the movie detail panel

### 7. Automated test coverage

Added and updated frontend tests covering:

- session query construction
- correct `movie` filter name
- optional session range filters
- paginated session response validation
- date formatting for API and pt-BR display
- session grouping by room and time
- seat selection navigation target generation
- movie detail rendering without unsupported fields

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run a production build:

```bash
cd frontend
npm run build
```

### Manual validation

1. Start the backend API.
2. Start the frontend:

```bash
cd frontend
npm run dev
```

3. Open a movie detail route:

```text
/movies/{movieId}
```

4. Validate the main expected behaviors:

- selecting a date fetches sessions for that movie and date
- requests use `movie=<movieId>&date=<YYYY-MM-DD>`
- sessions are grouped by room
- session options display Brazilian time and price formatting
- selecting a session navigates to `/sessions/{sessionId}/seats`
- dates without sessions show a clear pt-BR empty message
- loading and error states remain stable
- room type and audio format are not displayed

## Expected Result

- Users can select dates on the movie detail page.
- Sessions load for the selected movie and date.
- Sessions are grouped by room and displayed by time.
- Seat selection navigation uses the selected session ID.
- Empty, loading, and error states are localized and user-friendly.
- The frontend stays aligned with the current backend session contract.
- Automated frontend tests, lint, and production build pass successfully.

closes #97
