### PR TITLE
feat: implement reservation api module and purchase state

### DIFF
--- a/frontend/src/api/catalog.test.ts
+++ b/frontend/src/api/catalog.test.ts
@@ -24,6 +24,35 @@ const paginatedMoviesResponse = {
   results: [],
 };
 
+const sessionResponse = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [
+    {
+      base_price: "42.50",
+      end_time: "2026-05-22T21:00:00-03:00",
+      id: "session-123",
+      movie: {
+        duration_minutes: 125,
+        genres: [{ id: "genre-1", name: "Aventura" }],
+        id: "movie-123",
+        is_featured: false,
+        poster_url: "https://cdn.example.com/movie.jpg",
+        release_date: "2026-05-13",
+        status: "em_cartaz",
+        title: "A Jornada",
+      },
+      room: {
+        capacity: 80,
+        id: "room-1",
+        name: "Sala 1",
+      },
+      start_time: "2026-05-22T18:30:00-03:00",
+    },
+  ],
+};
+
 test("catalogApi gets a movie through the public catalog detail endpoint", async () => {
   const originalFetch = globalThis.fetch;
 
@@ -92,6 +121,56 @@ test("catalogApi builds supported movie filters", async () => {
   }
 });
 
+test("catalogApi builds session movie and date filters", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/?movie=movie-123&date=2026-05-22"
+      );
+      assert.equal(init?.method, "GET");
+
+      return Response.json(sessionResponse);
+    };
+
+    const response = await catalogApi.getSessions({
+      date: "2026-05-22",
+      movie: "movie-123",
+    });
+
+    assert.deepEqual(response, sessionResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi builds optional session range filters", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/?movie=movie-123&date=2026-05-22&start_from=2026-05-22T00%3A00%3A00-03%3A00&start_to=2026-05-22T23%3A59%3A59-03%3A00&page=2"
+      );
+
+      return Response.json({ ...sessionResponse, results: [] });
+    };
+
+    await catalogApi.getSessions({
+      date: "2026-05-22",
+      movie: "movie-123",
+      page: 2,
+      start_from: "2026-05-22T00:00:00-03:00",
+      start_to: "2026-05-22T23:59:59-03:00",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("catalogApi rejects unexpected movie detail responses", async () => {
   const originalFetch = globalThis.fetch;
 
@@ -116,6 +195,22 @@ test("catalogApi rejects unexpected non-paginated movie responses", async () => 
     await assert.rejects(
       catalogApi.listMovies(),
       /Unexpected catalog movie list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi rejects unexpected session responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json({ ...sessionResponse, results: [{ id: "session-123" }] });
+
+    await assert.rejects(
+      catalogApi.getSessions({ date: "2026-05-22", movie: "movie-123" }),
+      /Unexpected catalog session list response/
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -2,6 +2,8 @@ import type {
   CatalogGenre,
   CatalogMovie,
   CatalogMovieDetail,
+  CatalogRoomSummary,
+  CatalogSession,
   MovieStatus,
 } from "@/types/catalog";
 
@@ -17,11 +19,24 @@ export type ListMoviesParams = {
   status?: MovieStatus;
 };
 
+export type GetSessionsParams = {
+  date?: string;
+  movie?: string;
+  page?: number;
+  start_from?: string;
+  start_to?: string;
+};
+
 const MOVIES_PATH = "/api/v1/catalog/movies/";
+const SESSIONS_PATH = "/api/v1/catalog/sessions/";
 
 export const catalogApi = {
   getMovie(movieId: string) {
     return getMovie(movieId);
+  },
+
+  getSessions(params: GetSessionsParams = {}) {
+    return getSessions(params);
   },
 
   listMovies(params: ListMoviesParams = {}) {
@@ -67,6 +82,22 @@ async function listMovies(params: ListMoviesParams) {
   return response satisfies PaginatedResponse<CatalogMovie>;
 }
 
+async function getSessions(params: GetSessionsParams) {
+  const response = await apiRequest<unknown>(buildSessionsPath(params), {
+    auth: "none",
+    method: "GET",
+  });
+
+  if (
+    !isPaginatedResponse<CatalogSession>(response) ||
+    !response.results.every(isCatalogSession)
+  ) {
+    throw new Error("Unexpected catalog session list response.");
+  }
+
+  return response satisfies PaginatedResponse<CatalogSession>;
+}
+
 function isCatalogMovieDetail(value: unknown): value is CatalogMovieDetail {
   if (!isRecord(value)) {
     return false;
@@ -88,11 +119,46 @@ function isCatalogMovieDetail(value: unknown): value is CatalogMovieDetail {
   );
 }
 
+function isCatalogMovie(value: unknown): value is CatalogMovie {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    Array.isArray(value.genres) &&
+    value.genres.every(isCatalogGenre) &&
+    typeof value.duration_minutes === "number" &&
+    typeof value.poster_url === "string" &&
+    (value.status === "em_cartaz" || value.status === "pre_venda") &&
+    typeof value.is_featured === "boolean"
+  );
+}
+
 function isCatalogGenre(value: unknown): value is CatalogGenre {
   return (
     isRecord(value) &&
     typeof value.id === "string" &&
     typeof value.name === "string"
+  );
+}
+
+function isCatalogRoom(value: unknown): value is CatalogRoomSummary {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.capacity === "number"
+  );
+}
+
+function isCatalogSession(value: unknown): value is CatalogSession {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    isCatalogMovie(value.movie) &&
+    isCatalogRoom(value.room) &&
+    typeof value.start_time === "string" &&
+    typeof value.end_time === "string" &&
+    typeof value.base_price === "string"
   );
 }
 
@@ -117,4 +183,37 @@ function buildMoviesPath({ is_featured, page, status }: ListMoviesParams) {
 
   const query = searchParams.toString();
   return query ? `${MOVIES_PATH}?${query}` : MOVIES_PATH;
+}
+
+function buildSessionsPath({
+  date,
+  movie,
+  page,
+  start_from,
+  start_to,
+}: GetSessionsParams) {
+  const searchParams = new URLSearchParams();
+
+  if (movie) {
+    searchParams.set("movie", movie);
+  }
+
+  if (date) {
+    searchParams.set("date", date);
+  }
+
+  if (start_from) {
+    searchParams.set("start_from", start_from);
+  }
+
+  if (start_to) {
+    searchParams.set("start_to", start_to);
+  }
+
+  if (page !== undefined) {
+    searchParams.set("page", String(page));
+  }
+
+  const query = searchParams.toString();
+  return query ? `${SESSIONS_PATH}?${query}` : SESSIONS_PATH;
 }

--- a/frontend/src/api/reservation.test.ts
+++ b/frontend/src/api/reservation.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { setApiAuthController } from "./client";
+import { reservationApi } from "./reservation";
+
+const seatMapResponse = [
+  {
+    is_accessible: false,
+    lock_expires_at: null,
+    number: 7,
+    reserved_by_current_user: false,
+    row: "B",
+    seat_id: "seat-1",
+    session_seat_id: "session-seat-1",
+    status: "AVAILABLE",
+  },
+];
+
+const reservationResponse = {
+  expires_at: "2026-05-22T18:40:00-03:00",
+  seats: [
+    {
+      number: 7,
+      row: "B",
+      seat_id: "seat-1",
+      status: "RESERVED",
+    },
+  ],
+  session_id: "session-1",
+  status: "RESERVED",
+};
+
+const releaseResponse = {
+  seats: [
+    {
+      is_accessible: false,
+      number: 7,
+      row: "B",
+      seat_id: "seat-1",
+      session_seat_id: "session-seat-1",
+      status: "AVAILABLE",
+    },
+  ],
+  session_id: "session-1",
+  status: "RELEASED",
+};
+
+test("reservationApi fetches a public session seat map", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/reservation/sessions/session-1/seats/"
+      );
+      assert.equal(init?.method, "GET");
+
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("Authorization"), null);
+
+      return Response.json(seatMapResponse);
+    };
+
+    const response = await reservationApi.getSeatMap("session-1");
+
+    assert.deepEqual(response, seatMapResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("reservationApi submits seat_ids to the authenticated temporary reservation endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "access-token",
+      refreshAccessToken: async () => null,
+    });
+
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/reservation/sessions/session-1/reservations/"
+      );
+      assert.equal(init?.method, "POST");
+      assert.equal(init?.body, JSON.stringify({ seat_ids: ["seat-1"] }));
+
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("Authorization"), "Bearer access-token");
+      assert.equal(headers.get("Content-Type"), "application/json");
+
+      return Response.json(reservationResponse, { status: 201 });
+    };
+
+    const response = await reservationApi.reserveSeats("session-1", ["seat-1"]);
+
+    assert.deepEqual(response, reservationResponse);
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("reservationApi submits session_seat_ids to release current user reservations", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "access-token",
+      refreshAccessToken: async () => null,
+    });
+
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/reservation/sessions/session-1/reservations/"
+      );
+      assert.equal(init?.method, "DELETE");
+      assert.equal(
+        init?.body,
+        JSON.stringify({ session_seat_ids: ["session-seat-1"] })
+      );
+
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("Authorization"), "Bearer access-token");
+
+      return Response.json(releaseResponse);
+    };
+
+    const response = await reservationApi.releaseReservations("session-1", [
+      "session-seat-1",
+    ]);
+
+    assert.deepEqual(response, releaseResponse);
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("reservationApi rejects unexpected reservation responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ session_id: "session-1" });
+
+    await assert.rejects(
+      reservationApi.getSeatMap("session-1"),
+      /Unexpected reservation seat map response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/reservation.ts
+++ b/frontend/src/api/reservation.ts
@@ -1,0 +1,179 @@
+import type {
+  SessionSeatMapItem,
+  SessionSeatMapResponse,
+  SessionSeatStatus,
+  TemporaryReservationReleaseResponse,
+  TemporaryReservationReleaseSeat,
+  TemporaryReservationResponse,
+  TemporaryReservationSeat,
+} from "@/types/reservation";
+
+import { apiRequest } from "./client";
+
+export type ReserveSeatsPayload = {
+  seat_ids: string[];
+};
+
+export type ReleaseReservationsPayload = {
+  session_seat_ids: string[];
+};
+
+const RESERVATION_SESSIONS_PATH = "/api/v1/reservation/sessions";
+
+export const reservationApi = {
+  getSeatMap(sessionId: string) {
+    return getSeatMap(sessionId);
+  },
+
+  reserveSeats(sessionId: string, seatIds: string[]) {
+    return reserveSeats(sessionId, seatIds);
+  },
+
+  releaseReservations(sessionId: string, sessionSeatIds: string[]) {
+    return releaseReservations(sessionId, sessionSeatIds);
+  },
+};
+
+async function getSeatMap(sessionId: string) {
+  const response = await apiRequest<unknown>(buildSessionSeatMapPath(sessionId), {
+    auth: "none",
+    method: "GET",
+  });
+
+  if (!isSessionSeatMapResponse(response)) {
+    throw new Error("Unexpected reservation seat map response.");
+  }
+
+  return response satisfies SessionSeatMapResponse;
+}
+
+async function reserveSeats(sessionId: string, seatIds: string[]) {
+  const response = await apiRequest<unknown>(
+    buildSessionReservationsPath(sessionId),
+    {
+      auth: "required",
+      json: { seat_ids: seatIds } satisfies ReserveSeatsPayload,
+      method: "POST",
+    }
+  );
+
+  if (!isTemporaryReservationResponse(response)) {
+    throw new Error("Unexpected temporary reservation response.");
+  }
+
+  return response satisfies TemporaryReservationResponse;
+}
+
+async function releaseReservations(sessionId: string, sessionSeatIds: string[]) {
+  const response = await apiRequest<unknown>(
+    buildSessionReservationsPath(sessionId),
+    {
+      auth: "required",
+      json: {
+        session_seat_ids: sessionSeatIds,
+      } satisfies ReleaseReservationsPayload,
+      method: "DELETE",
+    }
+  );
+
+  if (!isTemporaryReservationReleaseResponse(response)) {
+    throw new Error("Unexpected temporary reservation release response.");
+  }
+
+  return response satisfies TemporaryReservationReleaseResponse;
+}
+
+function buildSessionSeatMapPath(sessionId: string) {
+  return `${RESERVATION_SESSIONS_PATH}/${sessionId}/seats/`;
+}
+
+function buildSessionReservationsPath(sessionId: string) {
+  return `${RESERVATION_SESSIONS_PATH}/${sessionId}/reservations/`;
+}
+
+function isSessionSeatMapResponse(
+  value: unknown
+): value is SessionSeatMapResponse {
+  return Array.isArray(value) && value.every(isSessionSeatMapItem);
+}
+
+function isSessionSeatMapItem(value: unknown): value is SessionSeatMapItem {
+  return (
+    isRecord(value) &&
+    typeof value.session_seat_id === "string" &&
+    typeof value.seat_id === "string" &&
+    typeof value.row === "string" &&
+    typeof value.number === "number" &&
+    isSessionSeatStatus(value.status) &&
+    typeof value.is_accessible === "boolean" &&
+    optionalBoolean(value.reserved_by_current_user) &&
+    optionalNullableString(value.lock_expires_at)
+  );
+}
+
+function isTemporaryReservationResponse(
+  value: unknown
+): value is TemporaryReservationResponse {
+  return (
+    isRecord(value) &&
+    typeof value.session_id === "string" &&
+    typeof value.status === "string" &&
+    typeof value.expires_at === "string" &&
+    Array.isArray(value.seats) &&
+    value.seats.every(isTemporaryReservationSeat)
+  );
+}
+
+function isTemporaryReservationSeat(
+  value: unknown
+): value is TemporaryReservationSeat {
+  return (
+    isRecord(value) &&
+    typeof value.seat_id === "string" &&
+    typeof value.row === "string" &&
+    typeof value.number === "number" &&
+    isSessionSeatStatus(value.status)
+  );
+}
+
+function isTemporaryReservationReleaseResponse(
+  value: unknown
+): value is TemporaryReservationReleaseResponse {
+  return (
+    isRecord(value) &&
+    typeof value.session_id === "string" &&
+    typeof value.status === "string" &&
+    Array.isArray(value.seats) &&
+    value.seats.every(isTemporaryReservationReleaseSeat)
+  );
+}
+
+function isTemporaryReservationReleaseSeat(
+  value: unknown
+): value is TemporaryReservationReleaseSeat {
+  return (
+    isRecord(value) &&
+    typeof value.session_seat_id === "string" &&
+    typeof value.seat_id === "string" &&
+    typeof value.row === "string" &&
+    typeof value.number === "number" &&
+    isSessionSeatStatus(value.status) &&
+    typeof value.is_accessible === "boolean"
+  );
+}
+
+function isSessionSeatStatus(value: unknown): value is SessionSeatStatus {
+  return value === "AVAILABLE" || value === "RESERVED" || value === "PURCHASED";
+}
+
+function optionalBoolean(value: unknown) {
+  return value === undefined || typeof value === "boolean";
+}
+
+function optionalNullableString(value: unknown) {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -620,7 +620,7 @@ h1 {
 }
 
 .movie-detail__synopsis,
-.movie-detail__action-panel {
+.movie-detail__sessions {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -629,24 +629,119 @@ h1 {
 }
 
 .movie-detail__synopsis h2,
-.movie-detail__action-panel h2 {
+.movie-detail__sessions h2 {
   font-size: 20px;
   line-height: 1.25;
   margin: 0 0 10px;
 }
 
 .movie-detail__synopsis p,
-.movie-detail__action-panel p {
+.movie-detail__sessions p {
   color: var(--color-muted);
   line-height: 1.65;
   margin: 0;
 }
 
-.movie-detail__action-panel {
-  align-items: center;
+.movie-detail__sessions {
   display: grid;
   gap: 18px;
+}
+
+.movie-detail__sessions-header {
+  align-items: end;
+  display: grid;
+  gap: 12px;
   grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.session-date-selector {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+}
+
+.session-date-selector__button {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  display: grid;
+  gap: 6px;
+  min-height: 72px;
+  padding: 12px;
+  text-align: left;
+}
+
+.session-date-selector__button[aria-pressed="true"] {
+  background: #fff2bf;
+  border-color: #d8a907;
+}
+
+.session-date-selector__button span {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.session-date-selector__button strong {
+  font-size: 17px;
+  line-height: 1;
+}
+
+.session-list {
+  display: grid;
+  gap: 14px;
+}
+
+.session-room-group {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.session-room-group h3 {
+  font-size: 18px;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.session-time-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+}
+
+.session-option {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  min-height: 92px;
+  padding: 14px;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.session-option:hover {
+  background: #fff8df;
+  border-color: #d8a907;
+}
+
+.session-option strong {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.session-option span {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 750;
 }
 
 .movie-detail-loading__poster,
@@ -755,7 +850,7 @@ h1 {
   }
 
   .movie-detail__metadata,
-  .movie-detail__action-panel {
+  .movie-detail__sessions-header {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { AppHeader } from "@/components/layout/AppHeader";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ReservationProvider } from "@/contexts/ReservationContext";
 
 import "./globals.css";
 
@@ -19,15 +20,17 @@ export default function RootLayout({
     <html lang="pt-BR">
       <body>
         <AuthProvider>
-          <div className="app-shell">
-            <a className="skip-link" href="#conteudo">
-              Pular para o conteúdo
-            </a>
-            <AppHeader />
-            <main className="main-content" id="conteudo" tabIndex={-1}>
-              <div className="shell-container">{children}</div>
-            </main>
-          </div>
+          <ReservationProvider>
+            <div className="app-shell">
+              <a className="skip-link" href="#conteudo">
+                Pular para o conteúdo
+              </a>
+              <AppHeader />
+              <main className="main-content" id="conteudo" tabIndex={-1}>
+                <div className="shell-container">{children}</div>
+              </main>
+            </div>
+          </ReservationProvider>
         </AuthProvider>
       </body>
     </html>

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -1,20 +1,29 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ApiError, getApiErrorUserMessage } from "@/api/client";
 import { catalogApi } from "@/api/catalog";
 import { StateMessage } from "@/components/ui/StateMessage";
-import type { CatalogMovieDetail } from "@/types/catalog";
+import type { CatalogMovieDetail, CatalogSession } from "@/types/catalog";
 
 import {
   formatMovieDuration,
   formatMovieGenres,
   formatMovieReleaseDate,
 } from "./movie-formatters";
+import {
+  buildSessionDateOptions,
+  formatSessionFullDate,
+  formatSessionPrice,
+  formatSessionTime,
+  getSessionSeatsHref,
+  groupSessionsByRoom,
+} from "./session-selection";
 
 type MovieDetailStatus = "error" | "loading" | "not-found" | "success";
+type SessionListStatus = "error" | "loading" | "success";
 
 export type MovieDetailState = {
   errorMessage?: string;
@@ -22,12 +31,17 @@ export type MovieDetailState = {
   status: MovieDetailStatus;
 };
 
+type SessionListState = {
+  errorMessage?: string;
+  sessions: CatalogSession[];
+  status: SessionListStatus;
+};
+
 type MovieDetailProps = {
   movieId: string;
 };
 
 type MovieDetailViewProps = {
-  movieId?: string;
   onRetry?: () => void;
   state: MovieDetailState;
 };
@@ -71,14 +85,13 @@ export function MovieDetail({ movieId }: MovieDetailProps) {
 
   return (
     <MovieDetailView
-      movieId={movieId}
       onRetry={() => void loadMovie()}
       state={state}
     />
   );
 }
 
-export function MovieDetailView({ movieId, onRetry, state }: MovieDetailViewProps) {
+export function MovieDetailView({ onRetry, state }: MovieDetailViewProps) {
   if (state.status === "loading") {
     return <MovieDetailLoadingState />;
   }
@@ -106,20 +119,13 @@ export function MovieDetailView({ movieId, onRetry, state }: MovieDetailViewProp
     return <MovieDetailNotFoundState />;
   }
 
-  return <MovieDetailSuccess movie={state.movie} movieId={movieId} />;
+  return <MovieDetailSuccess movie={state.movie} />;
 }
 
-function MovieDetailSuccess({
-  movie,
-  movieId,
-}: {
-  movie: CatalogMovieDetail;
-  movieId?: string;
-}) {
+function MovieDetailSuccess({ movie }: { movie: CatalogMovieDetail }) {
   const genres = formatMovieGenres(movie.genres);
   const duration = formatMovieDuration(movie.duration_minutes);
   const releaseDate = formatMovieReleaseDate(movie.release_date);
-  const movieHref = movieId ? `/movies/${movieId}` : `/movies/${movie.id}`;
 
   return (
     <div className="movie-detail">
@@ -174,22 +180,193 @@ function MovieDetailSuccess({
           <p>{movie.synopsis || "Sinopse indisponível."}</p>
         </section>
 
-        <section
-          aria-labelledby="selecionar-sessao"
-          className="movie-detail__action-panel"
-        >
-          <div>
-            <h2 id="selecionar-sessao">Sessões</h2>
-            <p>
-              As datas e horários disponíveis serão exibidos antes da escolha dos
-              assentos.
-            </p>
-          </div>
-          <Link className="button button-primary" href={`${movieHref}#selecionar-sessao`}>
-            Escolher sessão
-          </Link>
-        </section>
+        <MovieSessionSelector movieId={movie.id} />
       </article>
+    </div>
+  );
+}
+
+function MovieSessionSelector({ movieId }: { movieId: string }) {
+  const dateOptions = useMemo(() => buildSessionDateOptions(new Date()), []);
+  const [selectedDate, setSelectedDate] = useState(dateOptions[0]?.value ?? "");
+  const [state, setState] = useState<SessionListState>({
+    sessions: [],
+    status: "loading",
+  });
+
+  const loadSessions = useCallback(async () => {
+    if (!selectedDate) {
+      setState({ sessions: [], status: "success" });
+      return;
+    }
+
+    setState({ sessions: [], status: "loading" });
+
+    try {
+      const response = await catalogApi.getSessions({
+        date: selectedDate,
+        movie: movieId,
+      });
+
+      setState({
+        sessions: response.results,
+        status: "success",
+      });
+    } catch (error) {
+      setState({
+        errorMessage: getApiErrorUserMessage(error),
+        sessions: [],
+        status: "error",
+      });
+    }
+  }, [movieId, selectedDate]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function fetchSessions() {
+      if (!selectedDate) {
+        if (isActive) {
+          setState({ sessions: [], status: "success" });
+        }
+        return;
+      }
+
+      setState({ sessions: [], status: "loading" });
+
+      try {
+        const response = await catalogApi.getSessions({
+          date: selectedDate,
+          movie: movieId,
+        });
+
+        if (isActive) {
+          setState({
+            sessions: response.results,
+            status: "success",
+          });
+        }
+      } catch (error) {
+        if (isActive) {
+          setState({
+            errorMessage: getApiErrorUserMessage(error),
+            sessions: [],
+            status: "error",
+          });
+        }
+      }
+    }
+
+    void fetchSessions();
+
+    return () => {
+      isActive = false;
+    };
+  }, [movieId, selectedDate]);
+
+  return (
+    <section
+      aria-labelledby="selecionar-sessao"
+      className="movie-detail__sessions"
+    >
+      <div className="movie-detail__sessions-header">
+        <h2 id="selecionar-sessao">Sessões</h2>
+        <p>{formatSessionFullDate(selectedDate)}</p>
+      </div>
+
+      <div
+        aria-label="Datas disponíveis"
+        className="session-date-selector"
+        role="list"
+      >
+        {dateOptions.map((dateOption) => (
+          <button
+            aria-pressed={dateOption.value === selectedDate}
+            className="session-date-selector__button"
+            key={dateOption.value}
+            onClick={() => setSelectedDate(dateOption.value)}
+            type="button"
+          >
+            <span>{dateOption.weekday}</span>
+            <strong>{dateOption.label}</strong>
+          </button>
+        ))}
+      </div>
+
+      <SessionList
+        date={selectedDate}
+        onRetry={() => void loadSessions()}
+        state={state}
+      />
+    </section>
+  );
+}
+
+function SessionList({
+  date,
+  onRetry,
+  state,
+}: {
+  date: string;
+  onRetry: () => void;
+  state: SessionListState;
+}) {
+  if (state.status === "loading") {
+    return (
+      <StateMessage tone="loading" title="Carregando sessões">
+        Buscando horários para {formatSessionFullDate(date)}.
+      </StateMessage>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <StateMessage
+        action={
+          <button className="button button-ghost" onClick={onRetry} type="button">
+            Tentar novamente
+          </button>
+        }
+        title="Sessões indisponíveis"
+        tone="error"
+      >
+        {state.errorMessage ??
+          "Não conseguimos carregar as sessões agora. Tente novamente em instantes."}
+      </StateMessage>
+    );
+  }
+
+  if (state.sessions.length === 0) {
+    return (
+      <StateMessage title="Nenhuma sessão nesta data">
+        Não há sessões disponíveis para {formatSessionFullDate(date)}. Escolha outra
+        data.
+      </StateMessage>
+    );
+  }
+
+  const groups = groupSessionsByRoom(state.sessions);
+
+  return (
+    <div aria-label="Sessões disponíveis" className="session-list">
+      {groups.map((group) => (
+        <section className="session-room-group" key={group.roomId}>
+          <h3>{group.roomName}</h3>
+          <div className="session-time-grid">
+            {group.sessions.map((session) => (
+              <Link
+                className="session-option"
+                href={getSessionSeatsHref(session.id)}
+                key={session.id}
+              >
+                <strong>{formatSessionTime(session.start_time)}</strong>
+                <span>até {formatSessionTime(session.end_time)}</span>
+                <span>{formatSessionPrice(session.base_price)}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/movies/movie-detail.test.ts
+++ b/frontend/src/components/movies/movie-detail.test.ts
@@ -43,7 +43,8 @@ test("movie detail renders backend movie fields with accessible media", () => {
   assert.match(html, /Aventura, Drama/);
   assert.match(html, /2h 5min/);
   assert.match(html, /13\/05\/2026/);
-  assert.match(html, /Escolher sessão/);
+  assert.match(html, /Sessões/);
+  assert.match(html, /Carregando sessões/);
   assert.doesNotMatch(html, /age_rating|classificação|room_type|audio_format|sala tradicional|legendado/i);
 });
 

--- a/frontend/src/components/movies/session-selection.test.ts
+++ b/frontend/src/components/movies/session-selection.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CatalogSession } from "@/types/catalog";
+
+import {
+  buildSessionDateOptions,
+  formatDateForSessionQuery,
+  formatSessionDateLabel,
+  formatSessionFullDate,
+  formatSessionPrice,
+  formatSessionTime,
+  getSessionSeatsHref,
+  groupSessionsByRoom,
+} from "./session-selection";
+
+const movie = {
+  duration_minutes: 125,
+  genres: [{ id: "genre-1", name: "Aventura" }],
+  id: "movie-123",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/movie.jpg",
+  status: "em_cartaz" as const,
+  title: "A Jornada",
+};
+
+function session(
+  id: string,
+  room: { id: string; name: string },
+  start_time: string,
+  base_price = "42.50"
+): CatalogSession {
+  return {
+    base_price,
+    end_time: "2026-05-22T21:00:00-03:00",
+    id,
+    movie,
+    room: {
+      capacity: 80,
+      ...room,
+    },
+    start_time,
+  };
+}
+
+test("session date helpers use API and Brazilian display formats", () => {
+  assert.equal(
+    formatDateForSessionQuery(new Date("2026-05-22T10:30:00-03:00")),
+    "2026-05-22"
+  );
+  assert.equal(formatSessionDateLabel("2026-05-22"), "22/05");
+  assert.equal(formatSessionFullDate("2026-05-22"), "22 de maio de 2026");
+  assert.equal(formatSessionTime("2026-05-22T18:30:00-03:00"), "18:30");
+  assert.equal(formatSessionPrice("42.50"), "R$ 42,50");
+});
+
+test("session date options keep stable YYYY-MM-DD values", () => {
+  assert.deepEqual(
+    buildSessionDateOptions(new Date("2026-05-22T10:30:00-03:00"), 3).map(
+      (option) => option.value
+    ),
+    ["2026-05-22", "2026-05-23", "2026-05-24"]
+  );
+});
+
+test("groupSessionsByRoom groups by room and orders sessions by time", () => {
+  const groups = groupSessionsByRoom([
+    session("late-room-2", { id: "room-2", name: "Sala 2" }, "2026-05-22T21:00:00-03:00"),
+    session("late-room-1", { id: "room-1", name: "Sala 1" }, "2026-05-22T20:00:00-03:00"),
+    session("early-room-1", { id: "room-1", name: "Sala 1" }, "2026-05-22T18:30:00-03:00"),
+  ]);
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      roomName: group.roomName,
+      sessionIds: group.sessions.map((groupedSession) => groupedSession.id),
+    })),
+    [
+      { roomName: "Sala 1", sessionIds: ["early-room-1", "late-room-1"] },
+      { roomName: "Sala 2", sessionIds: ["late-room-2"] },
+    ]
+  );
+});
+
+test("session navigation targets seat selection route", () => {
+  assert.equal(getSessionSeatsHref("session-123"), "/sessions/session-123/seats");
+});

--- a/frontend/src/components/movies/session-selection.ts
+++ b/frontend/src/components/movies/session-selection.ts
@@ -1,0 +1,145 @@
+import type { CatalogSession } from "@/types/catalog";
+import { formatCurrency, ptBrLocale } from "@/utils/formatters";
+
+export const sessionTimeZone = "America/Fortaleza";
+
+export type SessionDateOption = {
+  label: string;
+  value: string;
+  weekday: string;
+};
+
+export type SessionRoomGroup = {
+  roomId: string;
+  roomName: string;
+  sessions: CatalogSession[];
+};
+
+export function buildSessionDateOptions(
+  startDate: Date,
+  dayCount = 7
+): SessionDateOption[] {
+  const startDateValue = formatDateForSessionQuery(startDate);
+
+  return Array.from({ length: dayCount }, (_, offset) => {
+    const value = addDaysToDateValue(startDateValue, offset);
+
+    return {
+      label: formatSessionDateLabel(value),
+      value,
+      weekday: formatSessionWeekday(value),
+    };
+  });
+}
+
+export function formatDateForSessionQuery(date: Date) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: sessionTimeZone,
+    year: "numeric",
+  }).formatToParts(date);
+
+  return `${getDatePart(parts, "year")}-${getDatePart(parts, "month")}-${getDatePart(parts, "day")}`;
+}
+
+export function formatSessionDateLabel(dateValue: string) {
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: "UTC",
+  }).format(parseSessionDateValue(dateValue));
+}
+
+export function formatSessionFullDate(dateValue: string) {
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    dateStyle: "long",
+    timeZone: "UTC",
+  }).format(parseSessionDateValue(dateValue));
+}
+
+export function formatSessionTime(value: string) {
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: sessionTimeZone,
+  }).format(new Date(value));
+}
+
+export function formatSessionPrice(value: string) {
+  return formatCurrency(Number(value));
+}
+
+export function getSessionSeatsHref(sessionId: string) {
+  return `/sessions/${sessionId}/seats`;
+}
+
+export function groupSessionsByRoom(
+  sessions: CatalogSession[]
+): SessionRoomGroup[] {
+  const groups = new Map<string, SessionRoomGroup>();
+
+  for (const session of [...sessions].sort(compareSessionsByRoomAndTime)) {
+    const roomId = session.room.id;
+    const group = groups.get(roomId);
+
+    if (group) {
+      group.sessions.push(session);
+      continue;
+    }
+
+    groups.set(roomId, {
+      roomId,
+      roomName: session.room.name,
+      sessions: [session],
+    });
+  }
+
+  return Array.from(groups.values());
+}
+
+function compareSessionsByRoomAndTime(
+  first: CatalogSession,
+  second: CatalogSession
+) {
+  const roomComparison = first.room.name.localeCompare(second.room.name, ptBrLocale);
+
+  if (roomComparison !== 0) {
+    return roomComparison;
+  }
+
+  return (
+    new Date(first.start_time).getTime() - new Date(second.start_time).getTime()
+  );
+}
+
+function addDaysToDateValue(dateValue: string, days: number) {
+  const [year, month, day] = parseDateParts(dateValue);
+  const date = new Date(Date.UTC(year, month - 1, day + days, 12, 0, 0));
+  return date.toISOString().slice(0, 10);
+}
+
+function formatSessionWeekday(dateValue: string) {
+  const weekday = new Intl.DateTimeFormat(ptBrLocale, {
+    timeZone: "UTC",
+    weekday: "short",
+  }).format(parseSessionDateValue(dateValue));
+
+  return weekday.replace(".", "");
+}
+
+function getDatePart(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes
+) {
+  return parts.find((part) => part.type === type)?.value ?? "";
+}
+
+function parseSessionDateValue(dateValue: string) {
+  const [year, month, day] = parseDateParts(dateValue);
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+}
+
+function parseDateParts(dateValue: string) {
+  return dateValue.split("-").map(Number) as [number, number, number];
+}

--- a/frontend/src/contexts/ReservationContext.tsx
+++ b/frontend/src/contexts/ReservationContext.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { AUTH_PROTECTED_STATE_RESET_EVENT } from "./AuthContext";
+import {
+  addSeatsToReservation,
+  initialReservationState,
+  removeSeatFromReservation,
+  resetReservation as getResetReservationState,
+  setReservationPaymentMethod,
+  setReservationTicketType,
+  type ReservationState,
+} from "./reservation-state";
+import type {
+  PaymentMethod,
+  ReservedSeat,
+  TicketType,
+} from "@/types/reservation";
+
+type ReservationContextValue = ReservationState & {
+  addSeats: (
+    seats: ReservedSeat[],
+    options?: { defaultTicketType?: TicketType; sessionId?: string }
+  ) => void;
+  removeSeat: (sessionSeatId: string) => void;
+  resetReservation: () => void;
+  setPaymentMethod: (method: PaymentMethod) => void;
+  setTicketType: (sessionSeatId: string, type: TicketType) => void;
+};
+
+const ReservationContext = createContext<ReservationContextValue | null>(null);
+
+export function ReservationProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ReservationState>(initialReservationState);
+
+  const addSeats = useCallback(
+    (
+      seats: ReservedSeat[],
+      {
+        defaultTicketType,
+        sessionId,
+      }: { defaultTicketType?: TicketType; sessionId?: string } = {}
+    ) => {
+      setState((currentState) =>
+        addSeatsToReservation(
+          currentState,
+          seats,
+          sessionId,
+          defaultTicketType
+        )
+      );
+    },
+    []
+  );
+
+  const removeSeat = useCallback((sessionSeatId: string) => {
+    setState((currentState) =>
+      removeSeatFromReservation(currentState, sessionSeatId)
+    );
+  }, []);
+
+  const setTicketType = useCallback(
+    (sessionSeatId: string, type: TicketType) => {
+      setState((currentState) =>
+        setReservationTicketType(currentState, sessionSeatId, type)
+      );
+    },
+    []
+  );
+
+  const setPaymentMethod = useCallback((method: PaymentMethod) => {
+    setState((currentState) => setReservationPaymentMethod(currentState, method));
+  }, []);
+
+  const resetReservation = useCallback(() => {
+    setState(getResetReservationState());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.addEventListener(AUTH_PROTECTED_STATE_RESET_EVENT, resetReservation);
+
+    return () => {
+      window.removeEventListener(
+        AUTH_PROTECTED_STATE_RESET_EVENT,
+        resetReservation
+      );
+    };
+  }, [resetReservation]);
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      addSeats,
+      removeSeat,
+      resetReservation,
+      setPaymentMethod,
+      setTicketType,
+    }),
+    [
+      addSeats,
+      removeSeat,
+      resetReservation,
+      setPaymentMethod,
+      setTicketType,
+      state,
+    ]
+  );
+
+  return (
+    <ReservationContext.Provider value={value}>
+      {children}
+    </ReservationContext.Provider>
+  );
+}
+
+export function useReservation() {
+  const context = useContext(ReservationContext);
+
+  if (!context) {
+    throw new Error("useReservation deve ser usado dentro de ReservationProvider.");
+  }
+
+  return context;
+}

--- a/frontend/src/contexts/reservation-state.test.ts
+++ b/frontend/src/contexts/reservation-state.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ReservedSeat } from "@/types/reservation";
+
+import {
+  addSeatsToReservation,
+  initialReservationState,
+  removeSeatFromReservation,
+  resetReservation,
+  setReservationPaymentMethod,
+  setReservationTicketType,
+} from "./reservation-state";
+
+const firstSeat: ReservedSeat = {
+  basePrice: 42.5,
+  expiresAt: new Date("2026-05-22T21:40:00.000Z"),
+  isAccessible: false,
+  number: 7,
+  row: "B",
+  seatId: "seat-1",
+  sessionSeatId: "session-seat-1",
+};
+
+const secondSeat: ReservedSeat = {
+  basePrice: 42.5,
+  expiresAt: new Date("2026-05-22T21:35:00.000Z"),
+  isAccessible: true,
+  number: 8,
+  row: "B",
+  seatId: "seat-2",
+  sessionSeatId: "session-seat-2",
+};
+
+test("reservation state starts without persisted purchase data", () => {
+  assert.deepEqual(initialReservationState, {
+    paymentMethod: null,
+    reservationExpiresAt: null,
+    reservedSeats: [],
+    sessionId: null,
+    ticketTypes: {},
+  });
+});
+
+test("addSeats preserves seat identifiers and applies default ticket types", () => {
+  const state = addSeatsToReservation(
+    initialReservationState,
+    [firstSeat],
+    "session-1"
+  );
+
+  assert.equal(state.sessionId, "session-1");
+  assert.deepEqual(state.reservedSeats, [firstSeat]);
+  assert.equal(state.reservedSeats[0].sessionSeatId, "session-seat-1");
+  assert.equal(state.reservedSeats[0].seatId, "seat-1");
+  assert.equal(state.ticketTypes["session-seat-1"], "inteira");
+  assert.equal(state.reservationExpiresAt, firstSeat.expiresAt);
+});
+
+test("addSeats can use a custom default ticket type and keeps the earliest expiration", () => {
+  const state = addSeatsToReservation(
+    addSeatsToReservation(initialReservationState, [firstSeat], "session-1"),
+    [secondSeat],
+    "session-1",
+    "meia"
+  );
+
+  assert.deepEqual(state.reservedSeats, [firstSeat, secondSeat]);
+  assert.equal(state.ticketTypes["session-seat-1"], "inteira");
+  assert.equal(state.ticketTypes["session-seat-2"], "meia");
+  assert.equal(state.reservationExpiresAt, secondSeat.expiresAt);
+});
+
+test("setTicketType only updates seats currently held in reservation state", () => {
+  const state = addSeatsToReservation(
+    initialReservationState,
+    [firstSeat],
+    "session-1"
+  );
+  const updated = setReservationTicketType(state, "session-seat-1", "meia");
+  const unchanged = setReservationTicketType(updated, "unknown-seat", "inteira");
+
+  assert.equal(updated.ticketTypes["session-seat-1"], "meia");
+  assert.equal(unchanged, updated);
+});
+
+test("setPaymentMethod stores the selected checkout method", () => {
+  const state = setReservationPaymentMethod(initialReservationState, "pix");
+
+  assert.equal(state.paymentMethod, "pix");
+});
+
+test("removeSeat clears seat-specific ticket type and preserves remaining reservation data", () => {
+  const state = setReservationPaymentMethod(
+    addSeatsToReservation(
+      initialReservationState,
+      [firstSeat, secondSeat],
+      "session-1"
+    ),
+    "cartao_credito"
+  );
+  const updated = removeSeatFromReservation(state, "session-seat-1");
+
+  assert.deepEqual(updated.reservedSeats, [secondSeat]);
+  assert.deepEqual(updated.ticketTypes, { "session-seat-2": "inteira" });
+  assert.equal(updated.paymentMethod, "cartao_credito");
+  assert.equal(updated.sessionId, "session-1");
+});
+
+test("removeSeat clears the flow when the last seat is removed", () => {
+  const state = setReservationPaymentMethod(
+    addSeatsToReservation(initialReservationState, [firstSeat], "session-1"),
+    "pix"
+  );
+  const updated = removeSeatFromReservation(state, "session-seat-1");
+
+  assert.deepEqual(updated, initialReservationState);
+});
+
+test("resetReservation clears selected seats, ticket types, payment method, and expiration", () => {
+  const state = setReservationPaymentMethod(
+    addSeatsToReservation(initialReservationState, [firstSeat], "session-1"),
+    "pix"
+  );
+
+  assert.notDeepEqual(state, initialReservationState);
+  assert.deepEqual(resetReservation(), initialReservationState);
+});

--- a/frontend/src/contexts/reservation-state.test.ts
+++ b/frontend/src/contexts/reservation-state.test.ts
@@ -104,7 +104,32 @@ test("removeSeat clears seat-specific ticket type and preserves remaining reserv
   assert.deepEqual(updated.reservedSeats, [secondSeat]);
   assert.deepEqual(updated.ticketTypes, { "session-seat-2": "inteira" });
   assert.equal(updated.paymentMethod, "cartao_credito");
+  assert.equal(updated.reservationExpiresAt, secondSeat.expiresAt);
   assert.equal(updated.sessionId, "session-1");
+});
+
+test("removeSeat recalculates expiration from remaining reserved seats", () => {
+  const thirdSeat: ReservedSeat = {
+    basePrice: 42.5,
+    expiresAt: new Date("2026-05-22T21:50:00.000Z"),
+    isAccessible: false,
+    number: 9,
+    row: "B",
+    seatId: "seat-3",
+    sessionSeatId: "session-seat-3",
+  };
+  const state = addSeatsToReservation(
+    initialReservationState,
+    [firstSeat, secondSeat, thirdSeat],
+    "session-1"
+  );
+
+  assert.equal(state.reservationExpiresAt, secondSeat.expiresAt);
+
+  const updated = removeSeatFromReservation(state, "session-seat-2");
+
+  assert.deepEqual(updated.reservedSeats, [firstSeat, thirdSeat]);
+  assert.equal(updated.reservationExpiresAt, firstSeat.expiresAt);
 });
 
 test("removeSeat clears the flow when the last seat is removed", () => {

--- a/frontend/src/contexts/reservation-state.ts
+++ b/frontend/src/contexts/reservation-state.ts
@@ -61,12 +61,12 @@ export function removeSeatFromReservation(
   const reservedSeats = state.reservedSeats.filter(
     (seat) => seat.sessionSeatId !== sessionSeatId
   );
+  const reservationExpiresAt = getEarliestExpiration(reservedSeats);
 
   return {
     ...state,
     paymentMethod: reservedSeats.length === 0 ? null : state.paymentMethod,
-    reservationExpiresAt:
-      reservedSeats.length === 0 ? null : state.reservationExpiresAt,
+    reservationExpiresAt,
     reservedSeats,
     sessionId: reservedSeats.length === 0 ? null : state.sessionId,
     ticketTypes,
@@ -103,4 +103,12 @@ export function setReservationPaymentMethod(
 
 export function resetReservation(): ReservationState {
   return { ...initialReservationState };
+}
+
+function getEarliestExpiration(seats: ReservedSeat[]) {
+  return (
+    seats
+      .map((seat) => seat.expiresAt)
+      .sort((left, right) => left.getTime() - right.getTime())[0] ?? null
+  );
 }

--- a/frontend/src/contexts/reservation-state.ts
+++ b/frontend/src/contexts/reservation-state.ts
@@ -1,0 +1,106 @@
+import type {
+  PaymentMethod,
+  ReservedSeat,
+  TicketType,
+} from "@/types/reservation";
+
+export type ReservationState = {
+  sessionId: string | null;
+  reservedSeats: ReservedSeat[];
+  ticketTypes: Record<string, TicketType>;
+  paymentMethod: PaymentMethod | null;
+  reservationExpiresAt: Date | null;
+};
+
+export const DEFAULT_TICKET_TYPE: TicketType = "inteira";
+
+export const initialReservationState: ReservationState = {
+  paymentMethod: null,
+  reservationExpiresAt: null,
+  reservedSeats: [],
+  sessionId: null,
+  ticketTypes: {},
+};
+
+export function addSeatsToReservation(
+  state: ReservationState,
+  seats: ReservedSeat[],
+  sessionId = state.sessionId,
+  defaultTicketType: TicketType = DEFAULT_TICKET_TYPE
+): ReservationState {
+  const nextSeatsById = new Map(
+    state.reservedSeats.map((seat) => [seat.sessionSeatId, seat])
+  );
+  const nextTicketTypes = { ...state.ticketTypes };
+  let nextExpiresAt = state.reservationExpiresAt;
+
+  for (const seat of seats) {
+    nextSeatsById.set(seat.sessionSeatId, seat);
+    nextTicketTypes[seat.sessionSeatId] ??= defaultTicketType;
+
+    if (!nextExpiresAt || seat.expiresAt < nextExpiresAt) {
+      nextExpiresAt = seat.expiresAt;
+    }
+  }
+
+  return {
+    ...state,
+    reservationExpiresAt: nextExpiresAt,
+    reservedSeats: Array.from(nextSeatsById.values()),
+    sessionId: sessionId ?? state.sessionId,
+    ticketTypes: nextTicketTypes,
+  };
+}
+
+export function removeSeatFromReservation(
+  state: ReservationState,
+  sessionSeatId: string
+): ReservationState {
+  const ticketTypes = { ...state.ticketTypes };
+  delete ticketTypes[sessionSeatId];
+  const reservedSeats = state.reservedSeats.filter(
+    (seat) => seat.sessionSeatId !== sessionSeatId
+  );
+
+  return {
+    ...state,
+    paymentMethod: reservedSeats.length === 0 ? null : state.paymentMethod,
+    reservationExpiresAt:
+      reservedSeats.length === 0 ? null : state.reservationExpiresAt,
+    reservedSeats,
+    sessionId: reservedSeats.length === 0 ? null : state.sessionId,
+    ticketTypes,
+  };
+}
+
+export function setReservationTicketType(
+  state: ReservationState,
+  sessionSeatId: string,
+  type: TicketType
+): ReservationState {
+  if (!state.reservedSeats.some((seat) => seat.sessionSeatId === sessionSeatId)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    ticketTypes: {
+      ...state.ticketTypes,
+      [sessionSeatId]: type,
+    },
+  };
+}
+
+export function setReservationPaymentMethod(
+  state: ReservationState,
+  method: PaymentMethod
+): ReservationState {
+  return {
+    ...state,
+    paymentMethod: method,
+  };
+}
+
+export function resetReservation(): ReservationState {
+  return { ...initialReservationState };
+}

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -21,3 +21,20 @@ export type CatalogMovieDetail = CatalogMovie & {
   synopsis: string;
   updated_at?: string;
 };
+
+export type CatalogRoomSummary = {
+  capacity: number;
+  id: string;
+  name: string;
+};
+
+export type CatalogSession = {
+  base_price: string;
+  created_at?: string;
+  end_time: string;
+  id: string;
+  movie: CatalogMovie;
+  room: CatalogRoomSummary;
+  start_time: string;
+  updated_at?: string;
+};

--- a/frontend/src/types/reservation.ts
+++ b/frontend/src/types/reservation.ts
@@ -1,0 +1,57 @@
+export type SessionSeatStatus = "AVAILABLE" | "RESERVED" | "PURCHASED";
+
+export type TicketType = "inteira" | "meia";
+
+export type PaymentMethod = "cartao_credito" | "pix";
+
+export type SessionSeatMapItem = {
+  session_seat_id: string;
+  seat_id: string;
+  row: string;
+  number: number;
+  status: SessionSeatStatus;
+  is_accessible: boolean;
+  reserved_by_current_user?: boolean;
+  lock_expires_at?: string | null;
+};
+
+export type SessionSeatMapResponse = SessionSeatMapItem[];
+
+export type TemporaryReservationSeat = {
+  seat_id: string;
+  row: string;
+  number: number;
+  status: SessionSeatStatus;
+};
+
+export type TemporaryReservationResponse = {
+  session_id: string;
+  status: string;
+  expires_at: string;
+  seats: TemporaryReservationSeat[];
+};
+
+export type TemporaryReservationReleaseSeat = {
+  session_seat_id: string;
+  seat_id: string;
+  row: string;
+  number: number;
+  status: SessionSeatStatus;
+  is_accessible: boolean;
+};
+
+export type TemporaryReservationReleaseResponse = {
+  session_id: string;
+  status: string;
+  seats: TemporaryReservationReleaseSeat[];
+};
+
+export type ReservedSeat = {
+  sessionSeatId: string;
+  seatId: string;
+  row: string;
+  number: number;
+  isAccessible: boolean;
+  basePrice: number;
+  expiresAt: Date;
+};


### PR DESCRIPTION
## Objective

Implement the frontend reservation API module and purchase-flow state required to carry the selected session, reserved seats, ticket types, payment method, and reservation expiration across the reservation journey.

## What was done

### 1. Reservation API module

Added a domain-specific reservation API module under `frontend/src/api/reservation.ts` covering:

- public seat map retrieval with `GET /api/v1/reservation/sessions/{sessionId}/seats/`
- authenticated temporary reservation with `POST /api/v1/reservation/sessions/{sessionId}/reservations/`
- authenticated reservation release with `DELETE /api/v1/reservation/sessions/{sessionId}/reservations/`

The protected calls rely on the existing API client auth flow, including bearer token attachment and refresh handling.

### 2. Typed reservation models

Added reservation types in `frontend/src/types/reservation.ts` for:

- session seat map items
- temporary reservation responses
- release responses
- reserved seat state
- ticket type and payment method values

The state-level reserved seat shape preserves both `seatId` and `sessionSeatId`, plus row, number, accessibility, base price, and expiration.

### 3. Shared reservation state

Implemented shared in-memory reservation state with:

- `sessionId`
- `reservedSeats`
- `ticketTypes`
- `paymentMethod`
- `reservationExpiresAt`

The state is available through `ReservationProvider` and `useReservation()` across the App Router tree.

### 4. Purchase-flow actions

Exposed the actions required by later purchase pages:

- `addSeats(seats)`
- `removeSeat(sessionSeatId)`
- `setTicketType(sessionSeatId, type)`
- `setPaymentMethod(method)`
- `resetReservation()`

Reserved seats receive a default ticket type value of `inteira`, while later pages can override the selection.

### 5. Reset behavior

Added reset behavior that clears selected seats, ticket types, payment method, expiration, and session id.

The reservation provider also listens to the existing protected-state reset event emitted by auth logout/refresh failure, so protected purchase state is cleared with authentication state.

### 6. Automated test coverage

Added frontend tests for:

- seat map API URL/auth shape
- temporary reservation payload shape
- release payload shape
- unexpected reservation response guards
- reservation state transitions
- identifier preservation
- default and overridden ticket types
- payment method updates
- full reset behavior

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm run test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

## Expected Result

- The frontend can fetch the public seat map for a session.
- Authenticated reservation calls submit the backend contract payloads.
- Reservation release preserves and submits `session_seat_id`.
- Typed models match the PRD/backend reservation contract.
- Purchase state survives navigation between reservation steps without persistent storage.
- State preserves both `seat_id` and `session_seat_id`.
- Reserved seats receive default ticket types that later pages can override.
- `resetReservation()` clears the purchase-flow state.
- Automated coverage validates API payload shape and state transitions.

closes #98
