### PR TITLE
feat: build accessible interactive seat map

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -744,6 +744,227 @@ h1 {
   font-weight: 750;
 }
 
+.seat-map-section {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+}
+
+.seat-map-section__header {
+  display: grid;
+  gap: 8px;
+}
+
+.seat-map-section__header h2 {
+  font-size: 22px;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.seat-map-section__header p {
+  color: var(--color-muted);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.seat-map__legend {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+}
+
+.seat-map__legend-item {
+  align-items: center;
+  color: var(--color-text);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 750;
+  gap: 8px;
+}
+
+.seat-map__legend-swatch {
+  align-items: center;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 900;
+  height: 26px;
+  justify-content: center;
+  line-height: 1;
+  width: 26px;
+}
+
+.seat-map__legend-swatch--available {
+  background: #ffffff;
+  border-color: #6b7686;
+  color: var(--color-text);
+}
+
+.seat-map__legend-swatch--selected {
+  background: #157347;
+  border-color: #0f5c38;
+  color: #ffffff;
+}
+
+.seat-map__legend-swatch--reserved {
+  background: #d9dee7;
+  border-color: #8a94a6;
+  color: #354052;
+}
+
+.seat-map__legend-swatch--purchased {
+  background: #3a414d;
+  border-color: #252b34;
+  color: #ffffff;
+}
+
+.seat-map__legend-swatch--accessible {
+  background: #eaf2ff;
+  border-color: var(--color-info);
+  color: #0b57b7;
+}
+
+.seat-map-scroll {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow-x: auto;
+  padding: 18px;
+}
+
+.seat-map-scroll:focus-visible {
+  outline-offset: 4px;
+}
+
+.seat-map {
+  display: grid;
+  gap: 18px;
+  margin: 0 auto;
+  min-width: max-content;
+  width: fit-content;
+}
+
+.seat-map__screen {
+  background: #1f6feb;
+  border-radius: 999px 999px 12px 12px;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 1;
+  margin: 0 auto;
+  min-width: 280px;
+  padding: 12px 34px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.seat-map__rows {
+  display: grid;
+  gap: 10px;
+}
+
+.seat-map__row {
+  align-items: center;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 28px minmax(0, 1fr) 28px;
+}
+
+.seat-map__row-label {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 900;
+  text-align: center;
+}
+
+.seat-map__seat-list {
+  display: flex;
+  gap: 8px;
+}
+
+.seat-map__seat {
+  align-items: center;
+  background: #ffffff;
+  border: 2px solid #6b7686;
+  border-radius: 6px;
+  color: var(--color-text);
+  display: grid;
+  flex: 0 0 42px;
+  gap: 2px;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto;
+  height: 42px;
+  justify-items: center;
+  line-height: 1;
+  min-width: 42px;
+  padding: 4px;
+  position: relative;
+}
+
+.seat-map__seat:hover {
+  border-color: var(--color-info);
+}
+
+.seat-map__seat[aria-disabled="true"] {
+  cursor: not-allowed;
+}
+
+.seat-map__seat--selected {
+  background: #157347;
+  border-color: #0f5c38;
+  color: #ffffff;
+}
+
+.seat-map__seat--reserved {
+  background: #d9dee7;
+  border-color: #8a94a6;
+  color: #354052;
+}
+
+.seat-map__seat--purchased {
+  background: #3a414d;
+  border-color: #252b34;
+  color: #ffffff;
+}
+
+.seat-map__seat--accessible {
+  box-shadow: inset 0 -4px 0 #1f6feb;
+}
+
+.seat-map__seat--after-aisle {
+  margin-right: 20px;
+}
+
+.seat-map__seat-number {
+  font-size: 14px;
+  font-weight: 900;
+  grid-column: 1 / 3;
+}
+
+.seat-map__seat-marker,
+.seat-map__seat-accessible {
+  font-size: 10px;
+  font-weight: 900;
+}
+
+.seat-map__seat-accessible {
+  color: inherit;
+}
+
+.seat-map__back-label {
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 900;
+  text-align: center;
+  text-transform: uppercase;
+}
+
 .movie-detail-loading__poster,
 .movie-detail-loading .skeleton-line {
   animation: skeleton-pulse 1300ms ease-in-out infinite;

--- a/frontend/src/app/sessions/[sessionId]/seats/page.tsx
+++ b/frontend/src/app/sessions/[sessionId]/seats/page.tsx
@@ -1,26 +1,24 @@
-import { SeatSelectionActions } from "@/components/seats/SeatSelectionActions";
+import { SeatMap } from "@/components/seats/SeatMap";
 import { PageSection } from "@/components/ui/PageSection";
-import { StateMessage } from "@/components/ui/StateMessage";
 
-export default function SeatSelectionPage() {
+type SeatSelectionPageProps = {
+  params: Promise<{
+    sessionId: string;
+  }>;
+};
+
+export default async function SeatSelectionPage({
+  params,
+}: SeatSelectionPageProps) {
+  const { sessionId } = await params;
+
   return (
     <PageSection
-      description="Escolha assentos disponíveis, acompanhe reservas temporárias e avance para os tipos de ingresso."
+      description="Consulte a disposição da sala, veja os estados dos assentos e navegue pelo mapa com teclado ou toque."
       eyebrow="Sessão"
-      title="Seleção de assentos"
+      title="Mapa de assentos"
     >
-      <div className="panel">
-        <span className="inline-status inline-status-info">Tela</span>
-        <p className="panel-copy">
-          O mapa de assentos usará estados visuais para disponível, selecionado,
-          reservado, comprado e acessível.
-        </p>
-      </div>
-      <StateMessage tone="loading" title="Mapa de assentos pendente">
-        A estrutura responsiva permite rolagem horizontal quando a sala for mais
-        larga que a tela do dispositivo.
-      </StateMessage>
-      <SeatSelectionActions />
+      <SeatMap sessionId={sessionId} />
     </PageSection>
   );
 }

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { getApiErrorUserMessage } from "@/api/client";
+import { reservationApi } from "@/api/reservation";
+import { StateMessage } from "@/components/ui/StateMessage";
+import type { SessionSeatMapItem } from "@/types/reservation";
+
+type SeatMapLoadState =
+  | { status: "error"; errorMessage?: string }
+  | { status: "loading" }
+  | { seats: SessionSeatMapItem[]; status: "success" };
+
+export type SeatMapRow = {
+  rowLabel: string;
+  seats: SessionSeatMapItem[];
+};
+
+export type SeatVisualState =
+  | "available"
+  | "purchased"
+  | "reserved"
+  | "selected";
+
+type SeatMapProps = {
+  sessionId: string;
+};
+
+type SeatMapViewProps = {
+  seats: SessionSeatMapItem[];
+};
+
+const seatStateLabels: Record<SeatVisualState, string> = {
+  available: "Disponível",
+  purchased: "Comprado",
+  reserved: "Reservado ou indisponível",
+  selected: "Selecionado",
+};
+
+const seatStateMarkers: Record<SeatVisualState, string> = {
+  available: "L",
+  purchased: "C",
+  reserved: "R",
+  selected: "S",
+};
+
+export function SeatMap({ sessionId }: SeatMapProps) {
+  const [state, setState] = useState<SeatMapLoadState>({ status: "loading" });
+
+  useEffect(() => {
+    let isActive = true;
+    const trimmedSessionId = sessionId.trim();
+
+    if (!trimmedSessionId) {
+      setState({ errorMessage: "Sessão inválida.", status: "error" });
+      return;
+    }
+
+    async function fetchSeatMap() {
+      setState({ status: "loading" });
+
+      try {
+        const seats = await reservationApi.getSeatMap(trimmedSessionId);
+
+        if (isActive) {
+          setState({ seats, status: "success" });
+        }
+      } catch (error) {
+        if (isActive) {
+          setState({
+            errorMessage: getApiErrorUserMessage(error),
+            status: "error",
+          });
+        }
+      }
+    }
+
+    void fetchSeatMap();
+
+    return () => {
+      isActive = false;
+    };
+  }, [sessionId]);
+
+  if (state.status === "loading") {
+    return (
+      <StateMessage tone="loading" title="Carregando mapa de assentos">
+        Buscando a disposição da sala para esta sessão.
+      </StateMessage>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <StateMessage title="Mapa indisponível" tone="error">
+        {state.errorMessage ??
+          "Não conseguimos carregar os assentos desta sessão agora."}
+      </StateMessage>
+    );
+  }
+
+  return <SeatMapView seats={state.seats} />;
+}
+
+export function SeatMapView({ seats }: SeatMapViewProps) {
+  const rows = useMemo(() => groupSeatMapRows(seats), [seats]);
+  const [selectedSeatIds, setSelectedSeatIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  function toggleSeat(seat: SessionSeatMapItem) {
+    if (seat.status !== "AVAILABLE") {
+      return;
+    }
+
+    setSelectedSeatIds((currentSelection) => {
+      const nextSelection = new Set(currentSelection);
+
+      if (nextSelection.has(seat.session_seat_id)) {
+        nextSelection.delete(seat.session_seat_id);
+      } else {
+        nextSelection.add(seat.session_seat_id);
+      }
+
+      return nextSelection;
+    });
+  }
+
+  if (rows.length === 0) {
+    return (
+      <StateMessage title="Sala sem assentos">
+        Ainda não há assentos cadastrados para esta sessão.
+      </StateMessage>
+    );
+  }
+
+  return (
+    <section aria-labelledby="mapa-assentos" className="seat-map-section">
+      <div className="seat-map-section__header">
+        <h2 id="mapa-assentos">Mapa de assentos</h2>
+        <p>
+          Visitantes podem consultar a sala. A seleção abaixo é local e não
+          reserva assentos.
+        </p>
+      </div>
+
+      <SeatMapLegend />
+
+      <div
+        aria-label="Área rolável do mapa de assentos"
+        className="seat-map-scroll"
+        tabIndex={0}
+      >
+        <div
+          aria-label="Mapa interativo de assentos da sessão"
+          className="seat-map"
+        >
+          <div className="seat-map__screen">Tela</div>
+
+          <div className="seat-map__rows">
+            {rows.map((row) => (
+              <div className="seat-map__row" key={row.rowLabel}>
+                <span
+                  aria-hidden="true"
+                  className="seat-map__row-label"
+                >
+                  {row.rowLabel}
+                </span>
+                <div
+                  aria-label={`Fileira ${row.rowLabel}`}
+                  className="seat-map__seat-list"
+                  role="group"
+                >
+                  {row.seats.map((seat, seatIndex) => {
+                    const visualState = getSeatVisualState(
+                      seat,
+                      selectedSeatIds
+                    );
+                    const isSelected = visualState === "selected";
+                    const isUnavailable =
+                      visualState === "reserved" ||
+                      visualState === "purchased";
+
+                    return (
+                      <button
+                        aria-disabled={isUnavailable}
+                        aria-label={getSeatAccessibleLabel(
+                          seat,
+                          visualState
+                        )}
+                        aria-pressed={isSelected}
+                        className={[
+                          "seat-map__seat",
+                          `seat-map__seat--${visualState}`,
+                          seat.is_accessible
+                            ? "seat-map__seat--accessible"
+                            : "",
+                          shouldAddCenterAisle(row.seats, seatIndex)
+                            ? "seat-map__seat--after-aisle"
+                            : "",
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                        data-state={visualState}
+                        key={seat.session_seat_id}
+                        onClick={() => toggleSeat(seat)}
+                        type="button"
+                      >
+                        <span className="seat-map__seat-number">
+                          {seat.number}
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          className="seat-map__seat-marker"
+                        >
+                          {seatStateMarkers[visualState]}
+                        </span>
+                        {seat.is_accessible ? (
+                          <span
+                            aria-hidden="true"
+                            className="seat-map__seat-accessible"
+                          >
+                            ♿
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+                <span
+                  aria-hidden="true"
+                  className="seat-map__row-label"
+                >
+                  {row.rowLabel}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div className="seat-map__back-label">Fundo da sala</div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function SeatMapLegend() {
+  const legendItems: Array<{
+    className: string;
+    label: string;
+    marker: string;
+  }> = [
+    {
+      className: "seat-map__legend-swatch--available",
+      label: "Disponível",
+      marker: seatStateMarkers.available,
+    },
+    {
+      className: "seat-map__legend-swatch--selected",
+      label: "Selecionado",
+      marker: seatStateMarkers.selected,
+    },
+    {
+      className: "seat-map__legend-swatch--reserved",
+      label: "Reservado ou indisponível",
+      marker: seatStateMarkers.reserved,
+    },
+    {
+      className: "seat-map__legend-swatch--purchased",
+      label: "Comprado",
+      marker: seatStateMarkers.purchased,
+    },
+    {
+      className: "seat-map__legend-swatch--accessible",
+      label: "Acessível",
+      marker: "♿",
+    },
+  ];
+
+  return (
+    <div aria-label="Legenda dos assentos" className="seat-map__legend">
+      {legendItems.map((item) => (
+        <div className="seat-map__legend-item" key={item.label}>
+          <span
+            aria-hidden="true"
+            className={[
+              "seat-map__legend-swatch",
+              item.className,
+            ].join(" ")}
+          >
+            {item.marker}
+          </span>
+          <span>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function groupSeatMapRows(
+  seats: SessionSeatMapItem[]
+): SeatMapRow[] {
+  const rowsByLabel = new Map<string, SessionSeatMapItem[]>();
+
+  for (const seat of seats) {
+    const existingSeats = rowsByLabel.get(seat.row) ?? [];
+    existingSeats.push(seat);
+    rowsByLabel.set(seat.row, existingSeats);
+  }
+
+  return Array.from(rowsByLabel.entries())
+    .sort(([leftRow], [rightRow]) => compareRowLabels(leftRow, rightRow))
+    .map(([rowLabel, rowSeats]) => ({
+      rowLabel,
+      seats: [...rowSeats].sort((leftSeat, rightSeat) => {
+        return leftSeat.number - rightSeat.number;
+      }),
+    }));
+}
+
+export function getSeatVisualState(
+  seat: SessionSeatMapItem,
+  selectedSeatIds: ReadonlySet<string>
+): SeatVisualState {
+  if (
+    selectedSeatIds.has(seat.session_seat_id) ||
+    (seat.status === "RESERVED" && seat.reserved_by_current_user === true)
+  ) {
+    return "selected";
+  }
+
+  if (seat.status === "PURCHASED") {
+    return "purchased";
+  }
+
+  if (seat.status === "RESERVED") {
+    return "reserved";
+  }
+
+  return "available";
+}
+
+export function getSeatAccessibleLabel(
+  seat: SessionSeatMapItem,
+  visualState: SeatVisualState
+) {
+  const identifier = `${seat.row}${seat.number}`;
+  const accessibleSuffix = seat.is_accessible ? ", assento acessível" : "";
+
+  return `Assento ${identifier}, fileira ${seat.row}, número ${seat.number}, ${seatStateLabels[visualState]}${accessibleSuffix}.`;
+}
+
+function shouldAddCenterAisle(seats: SessionSeatMapItem[], seatIndex: number) {
+  return seats.length > 4 && seatIndex === Math.ceil(seats.length / 2) - 1;
+}
+
+function compareRowLabels(leftRow: string, rightRow: string) {
+  return leftRow.localeCompare(rightRow, "pt-BR", {
+    numeric: true,
+    sensitivity: "base",
+  });
+}

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { SessionSeatMapItem } from "@/types/reservation";
+
+import {
+  getSeatAccessibleLabel,
+  getSeatVisualState,
+  groupSeatMapRows,
+  SeatMapLegend,
+  SeatMapView,
+} from "./SeatMap";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+function seat(
+  overrides: Partial<SessionSeatMapItem> = {}
+): SessionSeatMapItem {
+  const row = overrides.row ?? "A";
+  const number = overrides.number ?? 1;
+
+  return {
+    is_accessible: false,
+    number,
+    row,
+    seat_id: `seat-${row}-${number}`,
+    session_seat_id: `session-seat-${row}-${number}`,
+    status: "AVAILABLE",
+    ...overrides,
+  };
+}
+
+test("seat map groups seats by row and orders seats by number", () => {
+  const rows = groupSeatMapRows([
+    seat({ number: 2, row: "B" }),
+    seat({ number: 2, row: "A" }),
+    seat({ number: 1, row: "A" }),
+  ]);
+
+  assert.deepEqual(
+    rows.map((row) => ({
+      rowLabel: row.rowLabel,
+      seatNumbers: row.seats.map((rowSeat) => rowSeat.number),
+    })),
+    [
+      { rowLabel: "A", seatNumbers: [1, 2] },
+      { rowLabel: "B", seatNumbers: [2] },
+    ]
+  );
+});
+
+test("seat visual states distinguish available, selected, reserved, and purchased", () => {
+  assert.equal(getSeatVisualState(seat(), new Set()), "available");
+  assert.equal(
+    getSeatVisualState(seat({ session_seat_id: "selected-seat" }), new Set(["selected-seat"])),
+    "selected"
+  );
+  assert.equal(
+    getSeatVisualState(
+      seat({ reserved_by_current_user: true, status: "RESERVED" }),
+      new Set()
+    ),
+    "selected"
+  );
+  assert.equal(getSeatVisualState(seat({ status: "RESERVED" }), new Set()), "reserved");
+  assert.equal(getSeatVisualState(seat({ status: "PURCHASED" }), new Set()), "purchased");
+});
+
+test("seat map renders screen, row labels, seat numbers, and semantic states", () => {
+  const html = renderToStaticMarkup(
+    createElement(SeatMapView, {
+      seats: [
+        seat({ number: 1, row: "A" }),
+        seat({
+          is_accessible: true,
+          number: 2,
+          row: "A",
+          status: "AVAILABLE",
+        }),
+        seat({ number: 1, row: "B", status: "RESERVED" }),
+        seat({ number: 2, row: "B", status: "PURCHASED" }),
+        seat({
+          number: 3,
+          reserved_by_current_user: true,
+          row: "B",
+          status: "RESERVED",
+        }),
+      ],
+    })
+  );
+
+  assert.match(html, /Tela/);
+  assert.match(html, /Fundo da sala/);
+  assert.match(html, /Fileira A/);
+  assert.match(html, /Fileira B/);
+  assert.match(html, /seat-map__seat--available/);
+  assert.match(html, /seat-map__seat--accessible/);
+  assert.match(html, /seat-map__seat--reserved/);
+  assert.match(html, /seat-map__seat--purchased/);
+  assert.match(html, /seat-map__seat--selected/);
+  assert.match(html, /aria-disabled="true"/);
+  assert.match(html, /aria-pressed="true"/);
+});
+
+test("seat legend explains every state in pt-BR", () => {
+  const html = renderToStaticMarkup(createElement(SeatMapLegend));
+
+  assert.match(html, /Legenda dos assentos/);
+  assert.match(html, /Disponível/);
+  assert.match(html, /Selecionado/);
+  assert.match(html, /Reservado ou indisponível/);
+  assert.match(html, /Comprado/);
+  assert.match(html, /Acessível/);
+});
+
+test("seat accessible labels expose row, number, state, and accessible marker", () => {
+  assert.equal(
+    getSeatAccessibleLabel(seat({ number: 7, row: "C" }), "available"),
+    "Assento C7, fileira C, número 7, Disponível."
+  );
+  assert.equal(
+    getSeatAccessibleLabel(
+      seat({ is_accessible: true, number: 8, row: "C" }),
+      "selected"
+    ),
+    "Assento C8, fileira C, número 8, Selecionado, assento acessível."
+  );
+});


### PR DESCRIPTION
## Objective

Build the public, accessible interactive seat map experience for `/sessions/{sessionId}/seats`, using the current backend seat map contract without adding reservation mutations or ticket type flow.

## What was done

### 1. Public seat map route

Replaced the placeholder seat selection page with a session-aware route that reads the dynamic `sessionId` and renders the seat map UI for:

- `/sessions/{sessionId}/seats`

The route remains public for viewing and does not use protected route guards.

### 2. Seat map API fetch

Integrated the existing reservation API client with the seat map page through:

- `GET /api/v1/reservation/sessions/{sessionId}/seats/`

The fetch uses public `auth: "none"` behavior already defined in the reservation API layer.

### 3. Accessible interactive seat map component

Added a dedicated `SeatMap` component that renders:

- screen indicator above the first row
- alphabetical row labels on both sides of each row
- seat numbers inside seat controls
- grouped and ordered seat rows
- center aisle spacing for wider rows
- bottom room orientation label
- keyboard-reachable seat buttons
- accessible labels exposing row, number, status, and accessible-seat information

Seat selection is local UI state only. No reserve or release endpoints are called in this issue.

### 4. Seat state rendering

Implemented distinct visual and semantic rendering for:

- available seats
- selected seats
- reserved or unavailable seats
- purchased seats
- accessible seats

The UI does not rely on color alone: seats also expose text markers, accessible labels, ARIA state, and an accessible-seat icon marker.

### 5. Legend and pt-BR copy

Added the required legend in Brazilian Portuguese explaining every state:

- Disponível
- Selecionado
- Reservado ou indisponível
- Comprado
- Acessível

Loading, error, empty-state, and helper copy are also in pt-BR.

### 6. Responsive mobile behavior

Added a horizontally scrollable seat map container so wider room layouts remain usable on narrow screens such as 375px mobile width.

The scroll area is focusable and labelled for keyboard users.

### 7. Automated test coverage

Added focused frontend tests covering:

- seat grouping by row
- seat ordering by number
- state mapping for available, selected, reserved, and purchased seats
- legend output
- accessible labels
- rendered row labels, screen indicator, seat numbers, and ARIA state

## How to test

### Automated validation

Run the frontend validation from `frontend/`:

```bash
npm test
npm run lint
npm run build
```

### Manual validation

1. Start the frontend:

```bash
cd frontend
npm run dev
```

2. Start or point the frontend to a backend API with session seat map data.

3. Visit a session seat map route:

```text
http://127.0.0.1:3000/sessions/<sessionId>/seats
```

4. Validate the expected behavior:

- unauthenticated visitors can view the map
- the screen indicator appears above the grid
- row labels appear on both sides
- seat numbers are visible
- the legend explains all states in pt-BR
- available, selected, reserved, purchased, and accessible seats are distinct
- seats are keyboard reachable buttons with useful accessible labels
- wide layouts can be horizontally scrolled on mobile width
- no reserve or release endpoint is called

## Expected Result

- The seat map page loads backend seat map data for the route session.
- Visitors can inspect the room without authentication.
- Seat rows, numbers, screen orientation, legend, and states render clearly.
- Keyboard and assistive technology users receive useful labels and state information.
- Mobile users can navigate wide room layouts with horizontal scrolling.
- Reservation mutation and ticket type flows remain outside this issue.
- Frontend tests, lint, and production build pass.

closes #99
