### PR TITLE
feat: implement seat reservation interactions

### DIFF
--- a/frontend/src/api/reservation.ts
+++ b/frontend/src/api/reservation.ts
@@ -36,7 +36,7 @@ export const reservationApi = {
 
 async function getSeatMap(sessionId: string) {
   const response = await apiRequest<unknown>(buildSessionSeatMapPath(sessionId), {
-    auth: "none",
+    auth: "optional",
     method: "GET",
   });
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -933,6 +933,10 @@ h1 {
   color: #ffffff;
 }
 
+.seat-map__seat--pending {
+  opacity: 0.72;
+}
+
 .seat-map__seat--accessible {
   box-shadow: inset 0 -4px 0 #1f6feb;
 }
@@ -963,6 +967,67 @@ h1 {
   font-weight: 900;
   text-align: center;
   text-transform: uppercase;
+}
+
+.seat-reservation-summary {
+  align-items: center;
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 16px;
+}
+
+.seat-reservation-summary h3,
+.seat-reservation-summary p {
+  margin: 0;
+}
+
+.seat-reservation-summary h3 {
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.seat-reservation-summary p {
+  color: var(--color-muted);
+  line-height: 1.45;
+}
+
+.seat-reservation-summary__timer {
+  background: #fff8df;
+  border: 1px solid #e3bd34;
+  border-radius: 6px;
+  color: var(--color-text) !important;
+  font-size: 14px;
+  font-weight: 850;
+  padding: 9px 12px;
+  white-space: nowrap;
+}
+
+.seat-reservation-summary__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  grid-column: 1 / -1;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.seat-reservation-summary__list li {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 850;
+  line-height: 1;
+  padding: 8px 10px;
+}
+
+.seat-reservation-summary .button {
+  justify-self: end;
 }
 
 .movie-detail-loading__poster,
@@ -1073,6 +1138,16 @@ h1 {
   .movie-detail__metadata,
   .movie-detail__sessions-header {
     grid-template-columns: 1fr;
+  }
+
+  .seat-reservation-summary {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .seat-reservation-summary .button {
+    justify-self: stretch;
+    width: 100%;
   }
 
   .movie-detail__action-panel .button {

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
-import { getApiErrorUserMessage } from "@/api/client";
+import { ApiError, getApiErrorUserMessage } from "@/api/client";
 import { reservationApi } from "@/api/reservation";
+import { useGuardedAction } from "@/components/auth/useGuardedAction";
 import { StateMessage } from "@/components/ui/StateMessage";
-import type { SessionSeatMapItem } from "@/types/reservation";
+import { useReservation } from "@/contexts/ReservationContext";
+import type {
+  ReservedSeat,
+  SessionSeatMapItem,
+  TemporaryReservationResponse,
+} from "@/types/reservation";
 
 type SeatMapLoadState =
   | { status: "error"; errorMessage?: string }
@@ -28,7 +35,18 @@ type SeatMapProps = {
 };
 
 type SeatMapViewProps = {
+  sessionId: string;
   seats: SessionSeatMapItem[];
+};
+
+type SeatMapLayoutProps = {
+  countdownLabel: string | null;
+  errorMessage?: string | null;
+  onSeatToggle?: (seat: SessionSeatMapItem) => void;
+  pendingSeatIds?: ReadonlySet<string>;
+  reservedSeats?: ReservedSeat[];
+  seats: SessionSeatMapItem[];
+  selectedSeatIds?: ReadonlySet<string>;
 };
 
 const seatStateLabels: Record<SeatVisualState, string> = {
@@ -44,6 +62,8 @@ const seatStateMarkers: Record<SeatVisualState, string> = {
   reserved: "R",
   selected: "S",
 };
+
+const SESSION_BASE_PRICE_PLACEHOLDER = 0;
 
 export function SeatMap({ sessionId }: SeatMapProps) {
   const [state, setState] = useState<SeatMapLoadState>({ status: "loading" });
@@ -100,32 +120,173 @@ export function SeatMap({ sessionId }: SeatMapProps) {
     );
   }
 
-  return <SeatMapView seats={state.seats} />;
+  return <SeatMapView seats={state.seats} sessionId={sessionId.trim()} />;
 }
 
-export function SeatMapView({ seats }: SeatMapViewProps) {
-  const rows = useMemo(() => groupSeatMapRows(seats), [seats]);
-  const [selectedSeatIds, setSelectedSeatIds] = useState<Set<string>>(
+export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
+  const guardAction = useGuardedAction();
+  const reservation = useReservation();
+  const [currentSeats, setCurrentSeats] = useState(seats);
+  const [pendingSeatIds, setPendingSeatIds] = useState<Set<string>>(
     () => new Set()
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCurrentSeats(seats);
+  }, [seats]);
+
+  const reservedSeatsForSession = useMemo(() => {
+    if (reservation.sessionId !== sessionId) {
+      return [];
+    }
+
+    return reservation.reservedSeats;
+  }, [reservation.reservedSeats, reservation.sessionId, sessionId]);
+
+  const selectedSeatIds = useMemo(
+    () =>
+      new Set([
+        ...reservedSeatsForSession.map((seat) => seat.sessionSeatId),
+        ...currentSeats
+          .filter(
+            (seat) =>
+              seat.status === "RESERVED" &&
+              seat.reserved_by_current_user === true
+          )
+          .map((seat) => seat.session_seat_id),
+      ]),
+    [currentSeats, reservedSeatsForSession]
   );
 
   function toggleSeat(seat: SessionSeatMapItem) {
-    if (seat.status !== "AVAILABLE") {
+    if (pendingSeatIds.has(seat.session_seat_id)) {
       return;
     }
 
-    setSelectedSeatIds((currentSelection) => {
-      const nextSelection = new Set(currentSelection);
+    const visualState = getSeatVisualState(seat, selectedSeatIds);
 
-      if (nextSelection.has(seat.session_seat_id)) {
-        nextSelection.delete(seat.session_seat_id);
-      } else {
-        nextSelection.add(seat.session_seat_id);
-      }
+    if (visualState === "selected") {
+      guardAction(() => {
+        void releaseSeat(seat);
+      });
+      return;
+    }
 
-      return nextSelection;
+    if (visualState !== "available") {
+      return;
+    }
+
+    guardAction(() => {
+      void reserveSeat(seat);
     });
   }
+
+  async function reserveSeat(seat: SessionSeatMapItem) {
+    setErrorMessage(null);
+    setPendingSeatIds((current) => addToSet(current, seat.session_seat_id));
+    setCurrentSeats((current) =>
+      markSeatsAsReservedBySeatIds(current, [seat.seat_id])
+    );
+
+    try {
+      const response = await reservationApi.reserveSeats(sessionId, [
+        seat.seat_id,
+      ]);
+      const nextSeats = buildReservedSeatsFromReservation(
+        response,
+        currentSeats,
+        response.expires_at
+      );
+
+      reservation.addSeats(nextSeats, { sessionId });
+      setCurrentSeats((current) =>
+        markSeatsAsReservedBySeatIds(
+          current,
+          response.seats.map((responseSeat) => responseSeat.seat_id),
+          response.expires_at
+        )
+      );
+    } catch (error) {
+      setCurrentSeats((current) =>
+        restoreSeatSnapshots(current, [seat])
+      );
+      setErrorMessage(getSeatInteractionErrorMessage(error));
+    } finally {
+      setPendingSeatIds((current) =>
+        removeFromSet(current, seat.session_seat_id)
+      );
+    }
+  }
+
+  async function releaseSeat(seat: SessionSeatMapItem) {
+    const reservedSeat = reservedSeatsForSession.find(
+      (currentSeat) => currentSeat.sessionSeatId === seat.session_seat_id
+    );
+
+    setErrorMessage(null);
+    setPendingSeatIds((current) => addToSet(current, seat.session_seat_id));
+    reservation.removeSeat(seat.session_seat_id);
+    setCurrentSeats((current) =>
+      markSeatsAsAvailableBySessionSeatIds(current, [seat.session_seat_id])
+    );
+
+    try {
+      const response = await reservationApi.releaseReservations(sessionId, [
+        seat.session_seat_id,
+      ]);
+      const releasedSessionSeatIds = response.seats.map(
+        (responseSeat) => responseSeat.session_seat_id
+      );
+
+      setCurrentSeats((current) =>
+        markSeatsAsAvailableBySessionSeatIds(current, releasedSessionSeatIds)
+      );
+    } catch (error) {
+      setCurrentSeats((current) =>
+        restoreSeatSnapshots(current, [seat])
+      );
+
+      if (reservedSeat) {
+        reservation.addSeats([reservedSeat], { sessionId });
+      }
+
+      setErrorMessage(getSeatInteractionErrorMessage(error));
+    } finally {
+      setPendingSeatIds((current) =>
+        removeFromSet(current, seat.session_seat_id)
+      );
+    }
+  }
+
+  return (
+    <SeatMapLayout
+      countdownLabel={formatCountdownLabel(
+        reservation.sessionId === sessionId
+          ? reservation.reservationExpiresAt
+          : null
+      )}
+      errorMessage={errorMessage}
+      onSeatToggle={toggleSeat}
+      pendingSeatIds={pendingSeatIds}
+      reservedSeats={reservedSeatsForSession}
+      seats={currentSeats}
+      selectedSeatIds={selectedSeatIds}
+    />
+  );
+}
+
+export function SeatMapLayout({
+  countdownLabel,
+  errorMessage,
+  onSeatToggle,
+  pendingSeatIds = new Set(),
+  reservedSeats = [],
+  seats,
+  selectedSeatIds = new Set(),
+}: SeatMapLayoutProps) {
+  const rows = useMemo(() => groupSeatMapRows(seats), [seats]);
+  const hasReservedSeats = reservedSeats.length > 0;
 
   if (rows.length === 0) {
     return (
@@ -140,12 +301,18 @@ export function SeatMapView({ seats }: SeatMapViewProps) {
       <div className="seat-map-section__header">
         <h2 id="mapa-assentos">Mapa de assentos</h2>
         <p>
-          Visitantes podem consultar a sala. A seleção abaixo é local e não
-          reserva assentos.
+          Visitantes podem consultar a sala. Para reservar ou liberar assentos,
+          entre na sua conta.
         </p>
       </div>
 
       <SeatMapLegend />
+
+      {errorMessage ? (
+        <p className="inline-status inline-status-error" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
 
       <div
         aria-label="Área rolável do mapa de assentos"
@@ -181,10 +348,14 @@ export function SeatMapView({ seats }: SeatMapViewProps) {
                     const isUnavailable =
                       visualState === "reserved" ||
                       visualState === "purchased";
+                    const isPending = pendingSeatIds.has(
+                      seat.session_seat_id
+                    );
 
                     return (
                       <button
-                        aria-disabled={isUnavailable}
+                        aria-busy={isPending}
+                        aria-disabled={isUnavailable || isPending}
                         aria-label={getSeatAccessibleLabel(
                           seat,
                           visualState
@@ -196,6 +367,7 @@ export function SeatMapView({ seats }: SeatMapViewProps) {
                           seat.is_accessible
                             ? "seat-map__seat--accessible"
                             : "",
+                          isPending ? "seat-map__seat--pending" : "",
                           shouldAddCenterAisle(row.seats, seatIndex)
                             ? "seat-map__seat--after-aisle"
                             : "",
@@ -204,7 +376,7 @@ export function SeatMapView({ seats }: SeatMapViewProps) {
                           .join(" ")}
                         data-state={visualState}
                         key={seat.session_seat_id}
-                        onClick={() => toggleSeat(seat)}
+                        onClick={() => onSeatToggle?.(seat)}
                         type="button"
                       >
                         <span className="seat-map__seat-number">
@@ -241,6 +413,37 @@ export function SeatMapView({ seats }: SeatMapViewProps) {
           <div className="seat-map__back-label">Fundo da sala</div>
         </div>
       </div>
+
+      <aside aria-label="Resumo da reserva" className="seat-reservation-summary">
+        <div>
+          <h3>Reserva temporária</h3>
+          <p>
+            {hasReservedSeats
+              ? `${reservedSeats.length} assento${reservedSeats.length === 1 ? "" : "s"} reservado${reservedSeats.length === 1 ? "" : "s"}.`
+              : "Nenhum assento reservado nesta sessão."}
+          </p>
+        </div>
+        {countdownLabel ? (
+          <p className="seat-reservation-summary__timer" role="timer">
+            {countdownLabel}
+          </p>
+        ) : null}
+        {hasReservedSeats ? (
+          <>
+            <ul className="seat-reservation-summary__list">
+              {reservedSeats.map((seat) => (
+                <li key={seat.sessionSeatId}>
+                  {seat.row}
+                  {seat.number}
+                </li>
+              ))}
+            </ul>
+            <Link className="button button-primary" href="/ticket-types">
+              Continuar
+            </Link>
+          </>
+        ) : null}
+      </aside>
     </section>
   );
 }
@@ -349,6 +552,120 @@ export function getSeatAccessibleLabel(
   const accessibleSuffix = seat.is_accessible ? ", assento acessível" : "";
 
   return `Assento ${identifier}, fileira ${seat.row}, número ${seat.number}, ${seatStateLabels[visualState]}${accessibleSuffix}.`;
+}
+
+export function buildReservedSeatsFromReservation(
+  response: TemporaryReservationResponse,
+  seatMap: SessionSeatMapItem[],
+  expiresAtValue = response.expires_at
+): ReservedSeat[] {
+  const expiresAt = new Date(expiresAtValue);
+  const seatsBySeatId = new Map(seatMap.map((seat) => [seat.seat_id, seat]));
+
+  return response.seats.map((reservedSeat) => {
+    const originalSeat = seatsBySeatId.get(reservedSeat.seat_id);
+
+    if (!originalSeat) {
+      throw new Error("Reserved seat was not present in the loaded seat map.");
+    }
+
+    return {
+      basePrice: SESSION_BASE_PRICE_PLACEHOLDER,
+      expiresAt,
+      isAccessible: originalSeat.is_accessible,
+      number: reservedSeat.number,
+      row: reservedSeat.row,
+      seatId: reservedSeat.seat_id,
+      sessionSeatId: originalSeat.session_seat_id,
+    };
+  });
+}
+
+export function markSeatsAsReservedBySeatIds(
+  seats: SessionSeatMapItem[],
+  seatIds: string[],
+  lockExpiresAt: string | null = null
+) {
+  const seatIdsToReserve = new Set(seatIds);
+
+  return seats.map((seat) =>
+    seatIdsToReserve.has(seat.seat_id)
+      ? {
+          ...seat,
+          lock_expires_at: lockExpiresAt,
+          reserved_by_current_user: true,
+          status: "RESERVED" as const,
+        }
+      : seat
+  );
+}
+
+export function markSeatsAsAvailableBySessionSeatIds(
+  seats: SessionSeatMapItem[],
+  sessionSeatIds: string[]
+) {
+  const sessionSeatIdsToRelease = new Set(sessionSeatIds);
+
+  return seats.map((seat) =>
+    sessionSeatIdsToRelease.has(seat.session_seat_id)
+      ? {
+          ...seat,
+          lock_expires_at: null,
+          reserved_by_current_user: false,
+          status: "AVAILABLE" as const,
+        }
+      : seat
+  );
+}
+
+export function restoreSeatSnapshots(
+  seats: SessionSeatMapItem[],
+  snapshots: SessionSeatMapItem[]
+) {
+  const snapshotsBySessionSeatId = new Map(
+    snapshots.map((seat) => [seat.session_seat_id, seat])
+  );
+
+  return seats.map(
+    (seat) => snapshotsBySessionSeatId.get(seat.session_seat_id) ?? seat
+  );
+}
+
+export function formatCountdownLabel(expiresAt: Date | null, now = new Date()) {
+  if (!expiresAt) {
+    return null;
+  }
+
+  const remainingSeconds = Math.max(
+    0,
+    Math.ceil((expiresAt.getTime() - now.getTime()) / 1000)
+  );
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+
+  return `Expira em ${String(minutes).padStart(2, "0")}:${String(
+    seconds
+  ).padStart(2, "0")}`;
+}
+
+export function getSeatInteractionErrorMessage(error: unknown) {
+  if (error instanceof ApiError && error.code === "SEAT_ALREADY_RESERVED") {
+    return "Esse assento acabou de ser reservado por outra pessoa. Escolha outro lugar.";
+  }
+
+  return getApiErrorUserMessage(error);
+}
+
+function addToSet<T>(set: ReadonlySet<T>, value: T) {
+  const nextSet = new Set(set);
+  nextSet.add(value);
+  return nextSet;
+}
+
+function removeFromSet<T>(set: ReadonlySet<T>, value: T) {
+  const nextSet = new Set(set);
+  nextSet.delete(value);
+  return nextSet;
 }
 
 function shouldAddCenterAisle(seats: SessionSeatMapItem[], seatIndex: number) {

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -5,14 +5,21 @@ import { createElement } from "react";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { ApiError } from "@/api/client";
 import type { SessionSeatMapItem } from "@/types/reservation";
 
 import {
+  buildReservedSeatsFromReservation,
+  formatCountdownLabel,
   getSeatAccessibleLabel,
+  getSeatInteractionErrorMessage,
   getSeatVisualState,
   groupSeatMapRows,
+  markSeatsAsAvailableBySessionSeatIds,
+  markSeatsAsReservedBySeatIds,
+  restoreSeatSnapshots,
   SeatMapLegend,
-  SeatMapView,
+  SeatMapLayout,
 } from "./SeatMap";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
@@ -72,7 +79,8 @@ test("seat visual states distinguish available, selected, reserved, and purchase
 
 test("seat map renders screen, row labels, seat numbers, and semantic states", () => {
   const html = renderToStaticMarkup(
-    createElement(SeatMapView, {
+    createElement(SeatMapLayout, {
+      countdownLabel: null,
       seats: [
         seat({ number: 1, row: "A" }),
         seat({
@@ -106,6 +114,36 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, /aria-pressed="true"/);
 });
 
+test("seat map layout renders reservation summary and countdown", () => {
+  const expiresAt = new Date("2026-05-22T21:40:00.000Z");
+  const html = renderToStaticMarkup(
+    createElement(SeatMapLayout, {
+      countdownLabel: formatCountdownLabel(
+        expiresAt,
+        new Date("2026-05-22T21:35:30.000Z")
+      ),
+      reservedSeats: [
+        {
+          basePrice: 0,
+          expiresAt,
+          isAccessible: false,
+          number: 7,
+          row: "B",
+          seatId: "seat-1",
+          sessionSeatId: "session-seat-1",
+        },
+      ],
+      seats: [seat({ number: 7, row: "B", session_seat_id: "session-seat-1" })],
+    })
+  );
+
+  assert.match(html, /Reserva temporária/);
+  assert.match(html, /1 assento reservado/);
+  assert.match(html, /Expira em 04:30/);
+  assert.match(html, /B7/);
+  assert.match(html, /Continuar/);
+});
+
 test("seat legend explains every state in pt-BR", () => {
   const html = renderToStaticMarkup(createElement(SeatMapLegend));
 
@@ -129,4 +167,101 @@ test("seat accessible labels expose row, number, state, and accessible marker", 
     ),
     "Assento C8, fileira C, número 8, Selecionado, assento acessível."
   );
+});
+
+test("reserved seats built from reservation response preserve original session seat identifiers", () => {
+  const expiresAt = "2026-05-22T18:40:00-03:00";
+  const reservedSeats = buildReservedSeatsFromReservation(
+    {
+      expires_at: expiresAt,
+      seats: [
+        {
+          number: 7,
+          row: "B",
+          seat_id: "seat-1",
+          status: "RESERVED",
+        },
+      ],
+      session_id: "session-1",
+      status: "TEMPORARILY_RESERVED",
+    },
+    [
+      seat({
+        is_accessible: true,
+        number: 7,
+        row: "B",
+        seat_id: "seat-1",
+        session_seat_id: "session-seat-original",
+      }),
+    ]
+  );
+
+  assert.equal(reservedSeats[0].seatId, "seat-1");
+  assert.equal(reservedSeats[0].sessionSeatId, "session-seat-original");
+  assert.equal(reservedSeats[0].isAccessible, true);
+  assert.equal(reservedSeats[0].expiresAt.toISOString(), "2026-05-22T21:40:00.000Z");
+});
+
+test("optimistic reservation and rollback only affect targeted seats", () => {
+  const originalSeat = seat({
+    number: 1,
+    seat_id: "seat-1",
+    session_seat_id: "session-seat-1",
+  });
+  const unrelatedSeat = seat({
+    number: 2,
+    seat_id: "seat-2",
+    session_seat_id: "session-seat-2",
+  });
+
+  const optimisticSeats = markSeatsAsReservedBySeatIds(
+    [originalSeat, unrelatedSeat],
+    ["seat-1"],
+    "2026-05-22T18:40:00-03:00"
+  );
+
+  assert.equal(optimisticSeats[0].status, "RESERVED");
+  assert.equal(optimisticSeats[0].reserved_by_current_user, true);
+  assert.equal(optimisticSeats[1], unrelatedSeat);
+
+  const rolledBackSeats = restoreSeatSnapshots(optimisticSeats, [originalSeat]);
+
+  assert.deepEqual(rolledBackSeats, [originalSeat, unrelatedSeat]);
+});
+
+test("release updates only released session seat identifiers", () => {
+  const ownReservation = seat({
+    reserved_by_current_user: true,
+    seat_id: "seat-1",
+    session_seat_id: "session-seat-1",
+    status: "RESERVED",
+  });
+  const unrelatedReservation = seat({
+    reserved_by_current_user: true,
+    seat_id: "seat-2",
+    session_seat_id: "session-seat-2",
+    status: "RESERVED",
+  });
+
+  const updatedSeats = markSeatsAsAvailableBySessionSeatIds(
+    [ownReservation, unrelatedReservation],
+    ["session-seat-1"]
+  );
+
+  assert.equal(updatedSeats[0].status, "AVAILABLE");
+  assert.equal(updatedSeats[0].reserved_by_current_user, false);
+  assert.equal(updatedSeats[1], unrelatedReservation);
+});
+
+test("seat conflict errors use a friendly pt-BR message", () => {
+  const message = getSeatInteractionErrorMessage(
+    new ApiError("Conflict", 409, {
+      code: "SEAT_ALREADY_RESERVED",
+      details: {},
+    })
+  );
+
+  assert.match(message, /assento/);
+  assert.match(message, /reservado/);
+  assert.doesNotMatch(message, /Conflict/);
 });


### PR DESCRIPTION
## Objective

Implement authenticated seat reservation and release interactions on the frontend seat selection page, keeping visitors able to inspect the seat map while requiring login for protected reservation actions.

## What was done

### 1. Guarded seat interactions

Connected seat clicks to the existing guarded action flow:

- Visitors can still view the seat map.
- Unauthenticated reservation/release attempts redirect through the login redirect guard.
- Authenticated users can reserve available seats.
- Authenticated users can release their own temporary reservations.

### 2. Reservation API integration

Connected temporary reservation creation to:

- `POST /api/v1/reservation/sessions/{sessionId}/reservations/`
- payload shape `{ "seat_ids": [...] }`

The seat map request now uses optional authentication, so the backend can mark seats reserved by the current user when a token is available without blocking visitors.

### 3. Release API integration

Connected temporary reservation release to:

- `DELETE /api/v1/reservation/sessions/{sessionId}/reservations/`
- payload shape `{ "session_seat_ids": [...] }`

This preserves the backend contract where reservation creation receives `seat_id`, while release and checkout keep using the original `session_seat_id`.

### 4. Optimistic UI and conflict recovery

Added optimistic updates for seat interactions:

- reserving a seat immediately marks it as selected while the request is pending
- releasing a seat immediately restores it visually while the request is pending
- failed reservation requests restore only the affected seat snapshot
- `SEAT_ALREADY_RESERVED` conflicts show a friendly pt-BR message without clearing unrelated selected seats

### 5. Shared reservation state synchronization

Successful reservation responses now update shared reservation state with:

- selected seat data
- original `session_seat_id` from the loaded seat map
- backend `seat_id`
- accessibility metadata
- backend `expires_at`

Successful release responses remove the released seats from shared reservation state and update the seat map.

### 6. Countdown-ready reservation summary

Added a minimal reservation summary under the seat map:

- shows selected seat identifiers
- shows a visible countdown label based on backend `expires_at`
- links the user forward to `/ticket-types` once at least one seat is reserved

### 7. Frontend tests

Expanded seat map test coverage for the critical reservation behavior:

- countdown summary rendering
- preservation of original `session_seat_id`
- optimistic reservation update
- targeted rollback without clearing unrelated seats
- release update by `session_seat_id`
- friendly conflict message for `SEAT_ALREADY_RESERVED`

Existing reservation API tests already cover the reserve and release payload shapes.

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm run test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

## Expected Result

- Visitors can view the seat map without logging in.
- Unauthenticated reserve attempts redirect to `/login?redirect=<current_url>`.
- Authenticated reservation uses `seat_ids`.
- Authenticated release uses `session_seat_ids`.
- Seat selection responds immediately while requests are pending.
- Reservation conflicts rollback only affected seats and show a friendly pt-BR message.
- Successful reservations update shared reservation state with preserved identifiers.
- Successful reservations store backend `expires_at` for countdown behavior.
- Successful releases remove seats from shared reservation state and update the map.
- Frontend tests, lint, and build pass.

closes #100
