### PR TITLE
feat: add live reservation countdown and expiration reset

### DIFF
--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -1,34 +1,41 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PurchaseFlowGuard } from "@/components/reservations/PurchaseFlowGuard";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function CheckoutPage() {
   return (
     <ProtectedRoute>
-      <PageSection
-        description="Revise a compra, escolha a forma de pagamento e finalize seu pedido com mensagens claras de carregamento e erro."
-        eyebrow="Pagamento"
-        title="Finalizar compra"
-      >
-        <div className="panel-grid">
-          <article className="panel">
-            <h2 className="panel-title">Cartão de crédito</h2>
-            <p className="panel-copy">Opção preparada para pagamento com cartão.</p>
-          </article>
-          <article className="panel">
-            <h2 className="panel-title">PIX</h2>
-            <p className="panel-copy">Opção preparada para pagamento via PIX.</p>
-          </article>
-          <article className="panel">
-            <h2 className="panel-title">Resumo</h2>
-            <p className="panel-copy">Filme, sessão, assentos e total ficarão reunidos aqui.</p>
-          </article>
-        </div>
-        <StateMessage tone="error" title="Compra não iniciada">
-          Se a reserva expirar ou o pedido não puder ser concluído, a mensagem será
-          apresentada em português do Brasil.
-        </StateMessage>
-      </PageSection>
+      <PurchaseFlowGuard>
+        <PageSection
+          description="Revise a compra, escolha a forma de pagamento e finalize seu pedido com mensagens claras de carregamento e erro."
+          eyebrow="Pagamento"
+          title="Finalizar compra"
+        >
+          <div className="panel-grid">
+            <article className="panel">
+              <h2 className="panel-title">Cartão de crédito</h2>
+              <p className="panel-copy">
+                Opção preparada para pagamento com cartão.
+              </p>
+            </article>
+            <article className="panel">
+              <h2 className="panel-title">PIX</h2>
+              <p className="panel-copy">Opção preparada para pagamento via PIX.</p>
+            </article>
+            <article className="panel">
+              <h2 className="panel-title">Resumo</h2>
+              <p className="panel-copy">
+                Filme, sessão, assentos e total ficarão reunidos aqui.
+              </p>
+            </article>
+          </div>
+          <StateMessage tone="error" title="Compra não iniciada">
+            Se a reserva expirar ou o pedido não puder ser concluído, a mensagem
+            será apresentada em português do Brasil.
+          </StateMessage>
+        </PageSection>
+      </PurchaseFlowGuard>
     </ProtectedRoute>
   );
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1006,6 +1006,12 @@ h1 {
   white-space: nowrap;
 }
 
+.seat-reservation-summary__timer--warning {
+  background: #feeceb;
+  border-color: #d93025;
+  color: #9a1b13 !important;
+}
+
 .seat-reservation-summary__list {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/app/ticket-types/page.tsx
+++ b/frontend/src/app/ticket-types/page.tsx
@@ -1,4 +1,5 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PurchaseFlowGuard } from "@/components/reservations/PurchaseFlowGuard";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 import { formatCurrency } from "@/utils/formatters";
@@ -6,30 +7,36 @@ import { formatCurrency } from "@/utils/formatters";
 export default function TicketTypeSelectionPage() {
   return (
     <ProtectedRoute>
-      <PageSection
-        description={`Escolha entre inteira e meia-entrada. A exibição de valores já usa o padrão ${formatCurrency(42.5)}.`}
-        eyebrow="Ingressos"
-        title="Tipos de ingresso"
-      >
-        <div className="panel-grid">
-          <article className="panel">
-            <h2 className="panel-title">Inteira</h2>
-            <p className="panel-copy">Valor cheio da sessão selecionada.</p>
-          </article>
-          <article className="panel">
-            <h2 className="panel-title">Meia-entrada</h2>
-            <p className="panel-copy">Metade do valor base, conforme regras aplicáveis.</p>
-          </article>
-          <article className="panel">
-            <h2 className="panel-title">Cupom</h2>
-            <p className="panel-copy">Campo preparado para validação em etapa futura.</p>
-          </article>
-        </div>
-        <StateMessage tone="loading" title="Seleção de assentos necessária">
-          Os tipos de ingresso serão calculados depois que os assentos forem
-          reservados.
-        </StateMessage>
-      </PageSection>
+      <PurchaseFlowGuard>
+        <PageSection
+          description={`Escolha entre inteira e meia-entrada. A exibição de valores já usa o padrão ${formatCurrency(42.5)}.`}
+          eyebrow="Ingressos"
+          title="Tipos de ingresso"
+        >
+          <div className="panel-grid">
+            <article className="panel">
+              <h2 className="panel-title">Inteira</h2>
+              <p className="panel-copy">Valor cheio da sessão selecionada.</p>
+            </article>
+            <article className="panel">
+              <h2 className="panel-title">Meia-entrada</h2>
+              <p className="panel-copy">
+                Metade do valor base, conforme regras aplicáveis.
+              </p>
+            </article>
+            <article className="panel">
+              <h2 className="panel-title">Cupom</h2>
+              <p className="panel-copy">
+                Campo preparado para validação em etapa futura.
+              </p>
+            </article>
+          </div>
+          <StateMessage tone="loading" title="Seleção de assentos necessária">
+            Os tipos de ingresso serão calculados depois que os assentos forem
+            reservados.
+          </StateMessage>
+        </PageSection>
+      </PurchaseFlowGuard>
     </ProtectedRoute>
   );
 }

--- a/frontend/src/components/reservations/PurchaseFlowGuard.tsx
+++ b/frontend/src/components/reservations/PurchaseFlowGuard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { StateMessage } from "@/components/ui/StateMessage";
+import { useReservation } from "@/contexts/ReservationContext";
+import { useReservationCountdown } from "@/hooks/useReservationCountdown";
+import {
+  getPurchaseFlowGuardDecision,
+  PURCHASE_FLOW_MISSING_RESERVATION_MESSAGE,
+} from "./purchase-flow-guards";
+
+type PurchaseFlowGuardProps = {
+  children: ReactNode;
+};
+
+export function PurchaseFlowGuard({ children }: PurchaseFlowGuardProps) {
+  const router = useRouter();
+  const reservation = useReservation();
+  const countdown = useReservationCountdown(reservation.reservationExpiresAt);
+  const hasReservedSeats = reservation.reservedSeats.length > 0;
+  const decision = getPurchaseFlowGuardDecision({
+    hasReservedSeats,
+    isExpired: countdown?.isExpired ?? false,
+    sessionId: reservation.sessionId,
+  });
+
+  useEffect(() => {
+    if (!decision.shouldResetExpiredReservation) {
+      return;
+    }
+
+    reservation.expireReservation(decision.message ?? undefined);
+
+    if (decision.redirectPath) {
+      router.replace(decision.redirectPath);
+    }
+  }, [
+    decision.message,
+    decision.redirectPath,
+    decision.shouldResetExpiredReservation,
+    reservation,
+    router,
+  ]);
+
+  if (decision.renderContent) {
+    return children;
+  }
+
+  const recoveryPath = reservation.expiredSessionId
+    ? `/sessions/${encodeURIComponent(reservation.expiredSessionId)}/seats`
+    : "/";
+  const message = reservation.expirationNotice ?? decision.message;
+  const tone =
+    reservation.expirationNotice ||
+    decision.message !== PURCHASE_FLOW_MISSING_RESERVATION_MESSAGE
+      ? "error"
+      : "empty";
+
+  return (
+    <StateMessage
+      action={
+        <Link className="button button-primary" href={recoveryPath}>
+          {reservation.expiredSessionId
+            ? "Escolher assentos"
+            : "Voltar ao catálogo"}
+        </Link>
+      }
+      tone={tone}
+      title={decision.title ?? "Reserva indisponível"}
+    >
+      {message}
+    </StateMessage>
+  );
+}

--- a/frontend/src/components/reservations/purchase-flow-guards.test.ts
+++ b/frontend/src/components/reservations/purchase-flow-guards.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getPurchaseFlowGuardDecision,
+  PURCHASE_FLOW_EXPIRED_MESSAGE,
+  PURCHASE_FLOW_MISSING_RESERVATION_MESSAGE,
+} from "./purchase-flow-guards";
+
+test("purchase flow guard renders content while a reservation is active", () => {
+  assert.deepEqual(
+    getPurchaseFlowGuardDecision({
+      hasReservedSeats: true,
+      isExpired: false,
+      sessionId: "session-1",
+    }),
+    {
+      message: null,
+      redirectPath: null,
+      renderContent: true,
+      shouldResetExpiredReservation: false,
+      title: null,
+    }
+  );
+});
+
+test("purchase flow guard resets and redirects expired reservations", () => {
+  assert.deepEqual(
+    getPurchaseFlowGuardDecision({
+      hasReservedSeats: true,
+      isExpired: true,
+      sessionId: "session-1",
+    }),
+    {
+      message: PURCHASE_FLOW_EXPIRED_MESSAGE,
+      redirectPath: "/sessions/session-1/seats",
+      renderContent: false,
+      shouldResetExpiredReservation: true,
+      title: "Reserva expirada",
+    }
+  );
+});
+
+test("purchase flow guard blocks ticket and checkout steps without reserved seats", () => {
+  assert.deepEqual(
+    getPurchaseFlowGuardDecision({
+      hasReservedSeats: false,
+      isExpired: false,
+      sessionId: null,
+    }),
+    {
+      message: PURCHASE_FLOW_MISSING_RESERVATION_MESSAGE,
+      redirectPath: null,
+      renderContent: false,
+      shouldResetExpiredReservation: false,
+      title: "Reserva necessária",
+    }
+  );
+});

--- a/frontend/src/components/reservations/purchase-flow-guards.ts
+++ b/frontend/src/components/reservations/purchase-flow-guards.ts
@@ -1,0 +1,57 @@
+export const PURCHASE_FLOW_EXPIRED_MESSAGE =
+  "Sua reserva temporária expirou. Os assentos foram liberados; escolha seus lugares novamente para continuar a compra.";
+
+export const PURCHASE_FLOW_MISSING_RESERVATION_MESSAGE =
+  "Selecione seus assentos antes de continuar a compra.";
+
+export type PurchaseFlowGuardDecision = {
+  message: string | null;
+  redirectPath: string | null;
+  renderContent: boolean;
+  shouldResetExpiredReservation: boolean;
+  title: string | null;
+};
+
+type PurchaseFlowGuardInput = {
+  hasReservedSeats: boolean;
+  isExpired: boolean;
+  sessionId: string | null;
+};
+
+export function getPurchaseFlowGuardDecision({
+  hasReservedSeats,
+  isExpired,
+  sessionId,
+}: PurchaseFlowGuardInput): PurchaseFlowGuardDecision {
+  if (hasReservedSeats && isExpired) {
+    return {
+      message: PURCHASE_FLOW_EXPIRED_MESSAGE,
+      redirectPath: buildSeatSelectionPath(sessionId),
+      renderContent: false,
+      shouldResetExpiredReservation: true,
+      title: "Reserva expirada",
+    };
+  }
+
+  if (!hasReservedSeats) {
+    return {
+      message: PURCHASE_FLOW_MISSING_RESERVATION_MESSAGE,
+      redirectPath: null,
+      renderContent: false,
+      shouldResetExpiredReservation: false,
+      title: "Reserva necessária",
+    };
+  }
+
+  return {
+    message: null,
+    redirectPath: null,
+    renderContent: true,
+    shouldResetExpiredReservation: false,
+    title: null,
+  };
+}
+
+function buildSeatSelectionPath(sessionId: string | null) {
+  return sessionId ? `/sessions/${encodeURIComponent(sessionId)}/seats` : "/";
+}

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -8,6 +8,7 @@ import { reservationApi } from "@/api/reservation";
 import { useGuardedAction } from "@/components/auth/useGuardedAction";
 import { StateMessage } from "@/components/ui/StateMessage";
 import { useReservation } from "@/contexts/ReservationContext";
+import { useReservationCountdown } from "@/hooks/useReservationCountdown";
 import type {
   ReservedSeat,
   SessionSeatMapItem,
@@ -41,6 +42,7 @@ type SeatMapViewProps = {
 
 type SeatMapLayoutProps = {
   countdownLabel: string | null;
+  countdownWarning?: boolean;
   errorMessage?: string | null;
   onSeatToggle?: (seat: SessionSeatMapItem) => void;
   pendingSeatIds?: ReadonlySet<string>;
@@ -131,6 +133,11 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
     () => new Set()
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const reservationExpiresAt =
+    reservation.sessionId === sessionId
+      ? reservation.reservationExpiresAt
+      : null;
+  const countdown = useReservationCountdown(reservationExpiresAt);
 
   useEffect(() => {
     setCurrentSeats(seats);
@@ -158,6 +165,37 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
       ]),
     [currentSeats, reservedSeatsForSession]
   );
+
+  useEffect(() => {
+    if (!reservation.expirationNotice) {
+      return;
+    }
+
+    if (
+      reservation.expiredSessionId &&
+      reservation.expiredSessionId !== sessionId
+    ) {
+      return;
+    }
+
+    setErrorMessage(reservation.expirationNotice);
+    reservation.clearExpirationNotice();
+  }, [reservation, sessionId]);
+
+  useEffect(() => {
+    if (!countdown?.isExpired || reservedSeatsForSession.length === 0) {
+      return;
+    }
+
+    const expiredSessionSeatIds = reservedSeatsForSession.map(
+      (seat) => seat.sessionSeatId
+    );
+
+    reservation.expireReservation();
+    setCurrentSeats((current) =>
+      markSeatsAsAvailableBySessionSeatIds(current, expiredSessionSeatIds)
+    );
+  }, [countdown?.isExpired, reservation, reservedSeatsForSession]);
 
   function toggleSeat(seat: SessionSeatMapItem) {
     if (pendingSeatIds.has(seat.session_seat_id)) {
@@ -261,11 +299,8 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
 
   return (
     <SeatMapLayout
-      countdownLabel={formatCountdownLabel(
-        reservation.sessionId === sessionId
-          ? reservation.reservationExpiresAt
-          : null
-      )}
+      countdownLabel={countdown ? `Expira em ${countdown.displayValue}` : null}
+      countdownWarning={countdown?.isWarning ?? false}
       errorMessage={errorMessage}
       onSeatToggle={toggleSeat}
       pendingSeatIds={pendingSeatIds}
@@ -278,6 +313,7 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
 
 export function SeatMapLayout({
   countdownLabel,
+  countdownWarning = false,
   errorMessage,
   onSeatToggle,
   pendingSeatIds = new Set(),
@@ -424,7 +460,15 @@ export function SeatMapLayout({
           </p>
         </div>
         {countdownLabel ? (
-          <p className="seat-reservation-summary__timer" role="timer">
+          <p
+            className={[
+              "seat-reservation-summary__timer",
+              countdownWarning ? "seat-reservation-summary__timer--warning" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            role="timer"
+          >
             {countdownLabel}
           </p>
         ) : null}
@@ -629,23 +673,6 @@ export function restoreSeatSnapshots(
   return seats.map(
     (seat) => snapshotsBySessionSeatId.get(seat.session_seat_id) ?? seat
   );
-}
-
-export function formatCountdownLabel(expiresAt: Date | null, now = new Date()) {
-  if (!expiresAt) {
-    return null;
-  }
-
-  const remainingSeconds = Math.max(
-    0,
-    Math.ceil((expiresAt.getTime() - now.getTime()) / 1000)
-  );
-  const minutes = Math.floor(remainingSeconds / 60);
-  const seconds = remainingSeconds % 60;
-
-  return `Expira em ${String(minutes).padStart(2, "0")}:${String(
-    seconds
-  ).padStart(2, "0")}`;
 }
 
 export function getSeatInteractionErrorMessage(error: unknown) {

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -10,7 +10,6 @@ import type { SessionSeatMapItem } from "@/types/reservation";
 
 import {
   buildReservedSeatsFromReservation,
-  formatCountdownLabel,
   getSeatAccessibleLabel,
   getSeatInteractionErrorMessage,
   getSeatVisualState,
@@ -118,10 +117,8 @@ test("seat map layout renders reservation summary and countdown", () => {
   const expiresAt = new Date("2026-05-22T21:40:00.000Z");
   const html = renderToStaticMarkup(
     createElement(SeatMapLayout, {
-      countdownLabel: formatCountdownLabel(
-        expiresAt,
-        new Date("2026-05-22T21:35:30.000Z")
-      ),
+      countdownLabel: "Expira em 04:30",
+      countdownWarning: true,
       reservedSeats: [
         {
           basePrice: 0,
@@ -140,6 +137,7 @@ test("seat map layout renders reservation summary and countdown", () => {
   assert.match(html, /Reserva temporária/);
   assert.match(html, /1 assento reservado/);
   assert.match(html, /Expira em 04:30/);
+  assert.match(html, /seat-reservation-summary__timer--warning/);
   assert.match(html, /B7/);
   assert.match(html, /Continuar/);
 });

--- a/frontend/src/contexts/ReservationContext.tsx
+++ b/frontend/src/contexts/ReservationContext.tsx
@@ -13,6 +13,8 @@ import {
 import { AUTH_PROTECTED_STATE_RESET_EVENT } from "./AuthContext";
 import {
   addSeatsToReservation,
+  clearReservationExpirationNotice,
+  expireReservation as getExpiredReservationState,
   initialReservationState,
   removeSeatFromReservation,
   resetReservation as getResetReservationState,
@@ -31,6 +33,8 @@ type ReservationContextValue = ReservationState & {
     seats: ReservedSeat[],
     options?: { defaultTicketType?: TicketType; sessionId?: string }
   ) => void;
+  clearExpirationNotice: () => void;
+  expireReservation: (message?: string) => void;
   removeSeat: (sessionSeatId: string) => void;
   resetReservation: () => void;
   setPaymentMethod: (method: PaymentMethod) => void;
@@ -38,6 +42,9 @@ type ReservationContextValue = ReservationState & {
 };
 
 const ReservationContext = createContext<ReservationContextValue | null>(null);
+
+export const RESERVATION_EXPIRED_MESSAGE =
+  "Sua reserva temporária expirou. Os assentos foram liberados; escolha seus lugares novamente para continuar a compra.";
 
 export function ReservationProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<ReservationState>(initialReservationState);
@@ -68,6 +75,10 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
     );
   }, []);
 
+  const clearExpirationNotice = useCallback(() => {
+    setState((currentState) => clearReservationExpirationNotice(currentState));
+  }, []);
+
   const setTicketType = useCallback(
     (sessionSeatId: string, type: TicketType) => {
       setState((currentState) =>
@@ -84,6 +95,13 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
   const resetReservation = useCallback(() => {
     setState(getResetReservationState());
   }, []);
+
+  const expireReservation = useCallback(
+    (message = RESERVATION_EXPIRED_MESSAGE) => {
+      setState((currentState) => getExpiredReservationState(currentState, message));
+    },
+    []
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -104,6 +122,8 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
     () => ({
       ...state,
       addSeats,
+      clearExpirationNotice,
+      expireReservation,
       removeSeat,
       resetReservation,
       setPaymentMethod,
@@ -111,6 +131,8 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
     }),
     [
       addSeats,
+      clearExpirationNotice,
+      expireReservation,
       removeSeat,
       resetReservation,
       setPaymentMethod,

--- a/frontend/src/contexts/reservation-state.test.ts
+++ b/frontend/src/contexts/reservation-state.test.ts
@@ -5,6 +5,8 @@ import type { ReservedSeat } from "@/types/reservation";
 
 import {
   addSeatsToReservation,
+  clearReservationExpirationNotice,
+  expireReservation,
   initialReservationState,
   removeSeatFromReservation,
   resetReservation,
@@ -34,6 +36,8 @@ const secondSeat: ReservedSeat = {
 
 test("reservation state starts without persisted purchase data", () => {
   assert.deepEqual(initialReservationState, {
+    expirationNotice: null,
+    expiredSessionId: null,
     paymentMethod: null,
     reservationExpiresAt: null,
     reservedSeats: [],
@@ -150,4 +154,31 @@ test("resetReservation clears selected seats, ticket types, payment method, and 
 
   assert.notDeepEqual(state, initialReservationState);
   assert.deepEqual(resetReservation(), initialReservationState);
+});
+
+test("expireReservation clears purchase flow data and keeps a transient notice", () => {
+  const state = setReservationPaymentMethod(
+    addSeatsToReservation(initialReservationState, [firstSeat], "session-1"),
+    "pix"
+  );
+  const expired = expireReservation(state, "Reserva expirada.");
+
+  assert.deepEqual(expired, {
+    ...initialReservationState,
+    expirationNotice: "Reserva expirada.",
+    expiredSessionId: "session-1",
+  });
+});
+
+test("clearReservationExpirationNotice removes only transient expiration feedback", () => {
+  const expired = {
+    ...initialReservationState,
+    expirationNotice: "Reserva expirada.",
+    expiredSessionId: "session-1",
+  };
+
+  assert.deepEqual(
+    clearReservationExpirationNotice(expired),
+    initialReservationState
+  );
 });

--- a/frontend/src/contexts/reservation-state.ts
+++ b/frontend/src/contexts/reservation-state.ts
@@ -5,6 +5,8 @@ import type {
 } from "@/types/reservation";
 
 export type ReservationState = {
+  expirationNotice: string | null;
+  expiredSessionId: string | null;
   sessionId: string | null;
   reservedSeats: ReservedSeat[];
   ticketTypes: Record<string, TicketType>;
@@ -15,6 +17,8 @@ export type ReservationState = {
 export const DEFAULT_TICKET_TYPE: TicketType = "inteira";
 
 export const initialReservationState: ReservationState = {
+  expirationNotice: null,
+  expiredSessionId: null,
   paymentMethod: null,
   reservationExpiresAt: null,
   reservedSeats: [],
@@ -45,6 +49,8 @@ export function addSeatsToReservation(
 
   return {
     ...state,
+    expirationNotice: null,
+    expiredSessionId: null,
     reservationExpiresAt: nextExpiresAt,
     reservedSeats: Array.from(nextSeatsById.values()),
     sessionId: sessionId ?? state.sessionId,
@@ -103,6 +109,31 @@ export function setReservationPaymentMethod(
 
 export function resetReservation(): ReservationState {
   return { ...initialReservationState };
+}
+
+export function expireReservation(
+  state: ReservationState,
+  message: string
+): ReservationState {
+  return {
+    ...initialReservationState,
+    expirationNotice: message,
+    expiredSessionId: state.sessionId,
+  };
+}
+
+export function clearReservationExpirationNotice(
+  state: ReservationState
+): ReservationState {
+  if (!state.expirationNotice && !state.expiredSessionId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    expirationNotice: null,
+    expiredSessionId: null,
+  };
 }
 
 function getEarliestExpiration(seats: ReservedSeat[]) {

--- a/frontend/src/hooks/useReservationCountdown.ts
+++ b/frontend/src/hooks/useReservationCountdown.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  getReservationCountdownState,
+  type ReservationCountdownState,
+} from "@/utils/reservation-countdown";
+
+export function useReservationCountdown(
+  expiresAt: Date | string | null
+): ReservationCountdownState | null {
+  const [countdown, setCountdown] = useState(() =>
+    getReservationCountdownState(expiresAt)
+  );
+
+  useEffect(() => {
+    function updateCountdown() {
+      setCountdown(getReservationCountdownState(expiresAt));
+    }
+
+    updateCountdown();
+
+    if (!expiresAt) {
+      return;
+    }
+
+    const intervalId = window.setInterval(updateCountdown, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [expiresAt]);
+
+  return countdown;
+}

--- a/frontend/src/utils/reservation-countdown.test.ts
+++ b/frontend/src/utils/reservation-countdown.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatReservationCountdown,
+  getReservationCountdownState,
+} from "./reservation-countdown";
+
+test("formatReservationCountdown displays remaining time as mm:ss", () => {
+  assert.equal(formatReservationCountdown(0), "00:00");
+  assert.equal(formatReservationCountdown(7), "00:07");
+  assert.equal(formatReservationCountdown(65), "01:05");
+  assert.equal(formatReservationCountdown(600), "10:00");
+});
+
+test("getReservationCountdownState calculates remaining time from expires_at", () => {
+  const countdown = getReservationCountdownState(
+    "2026-05-22T21:40:30.000Z",
+    new Date("2026-05-22T21:39:00.000Z")
+  );
+
+  assert.deepEqual(countdown, {
+    displayValue: "01:30",
+    isExpired: false,
+    isWarning: false,
+    remainingSeconds: 90,
+  });
+});
+
+test("getReservationCountdownState warns at 60 seconds or less", () => {
+  assert.equal(
+    getReservationCountdownState(
+      new Date("2026-05-22T21:40:00.000Z"),
+      new Date("2026-05-22T21:39:00.000Z")
+    )?.isWarning,
+    true
+  );
+  assert.equal(
+    getReservationCountdownState(
+      new Date("2026-05-22T21:40:01.000Z"),
+      new Date("2026-05-22T21:39:00.000Z")
+    )?.isWarning,
+    false
+  );
+});
+
+test("getReservationCountdownState detects expiration at zero", () => {
+  assert.deepEqual(
+    getReservationCountdownState(
+      new Date("2026-05-22T21:40:00.000Z"),
+      new Date("2026-05-22T21:41:00.000Z")
+    ),
+    {
+      displayValue: "00:00",
+      isExpired: true,
+      isWarning: true,
+      remainingSeconds: 0,
+    }
+  );
+});
+
+test("getReservationCountdownState ignores missing or invalid expiration values", () => {
+  assert.equal(getReservationCountdownState(null), null);
+  assert.equal(getReservationCountdownState("not-a-date"), null);
+});

--- a/frontend/src/utils/reservation-countdown.ts
+++ b/frontend/src/utils/reservation-countdown.ts
@@ -1,0 +1,48 @@
+export const RESERVATION_COUNTDOWN_WARNING_SECONDS = 60;
+
+export type ReservationCountdownState = {
+  displayValue: string;
+  isExpired: boolean;
+  isWarning: boolean;
+  remainingSeconds: number;
+};
+
+export function getReservationCountdownState(
+  expiresAt: Date | string | null,
+  now: Date | number = new Date()
+): ReservationCountdownState | null {
+  if (!expiresAt) {
+    return null;
+  }
+
+  const expiresAtTime =
+    expiresAt instanceof Date ? expiresAt.getTime() : new Date(expiresAt).getTime();
+  const nowTime = now instanceof Date ? now.getTime() : now;
+
+  if (!Number.isFinite(expiresAtTime) || !Number.isFinite(nowTime)) {
+    return null;
+  }
+
+  const remainingSeconds = Math.max(
+    0,
+    Math.ceil((expiresAtTime - nowTime) / 1000)
+  );
+
+  return {
+    displayValue: formatReservationCountdown(remainingSeconds),
+    isExpired: remainingSeconds === 0,
+    isWarning: remainingSeconds <= RESERVATION_COUNTDOWN_WARNING_SECONDS,
+    remainingSeconds,
+  };
+}
+
+export function formatReservationCountdown(totalSeconds: number) {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(
+    2,
+    "0"
+  )}`;
+}


### PR DESCRIPTION
## Objective

Implement a frontend live reservation countdown that stays aligned with the backend `expires_at` timestamp, warns users near expiration, and safely resets the purchase flow when a temporary reservation expires.

## What was done

### 1. Countdown hook and utilities

Added reusable countdown behavior for reservation expiration:

- Calculates remaining time from the backend `expires_at` value stored in reservation state.
- Formats the remaining time as `mm:ss`.
- Marks warning state when 60 seconds or less remain.
- Detects expiration when the countdown reaches zero.

### 2. Reservation expiration state reset

Expanded the shared reservation state with explicit expiration handling:

- Clears reserved seats.
- Clears selected ticket types.
- Clears selected payment method.
- Clears the active session reservation state.
- Keeps a transient pt-BR explanation so the user understands why the flow was reset.

### 3. Seat selection integration

Updated the seat selection flow so the countdown:

- Updates live every second while a reservation exists.
- Uses `reservationExpiresAt` from shared reservation state.
- Applies warning styling near expiration.
- Resets selected seats when the backend-sourced expiration time reaches zero.
- Shows a clear pt-BR expiration message on the seat selection page.

### 4. Purchase flow guard integration

Added a reservation-aware guard for protected purchase steps:

- `/ticket-types` no longer remains usable without an active reservation.
- `/checkout` no longer remains usable without an active reservation.
- Expired reservations are reset and redirected back to a safe seat-selection page when possible.
- Missing reservation state guides the user back to a safe starting point.

### 5. Styling

Added countdown warning styling for the final 60 seconds of the temporary reservation window.

### 6. Automated test coverage

Added and updated frontend tests covering:

- Countdown formatting and remaining-time calculation.
- Warning threshold behavior.
- Expired countdown detection.
- Reservation expiration reset behavior.
- Purchase flow guard decisions for active, missing, and expired reservations.
- Seat map rendering of warning countdown state.

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

## Acceptance criteria confirmation

- Live Countdown: implemented with `useReservationCountdown`, updating every second while an active reservation exists.
- Backend Source: countdown uses `reservationExpiresAt`, derived from backend `expires_at` stored in reservation state.
- Format: remaining time displays as `mm:ss`.
- Warning State: warning state and styling apply at 60 seconds or less.
- Expiration Reset: when time reaches zero, reservation state is reset.
- Protected Step Behavior: `/ticket-types` and `/checkout` are guarded against missing or expired reservations.
- User Feedback: expiration messages are clear and written in Brazilian Portuguese.
- No Persistent Storage: no `localStorage` or `sessionStorage` was added.
- Automated Tests: tests cover countdown calculation, warning threshold, expiration reset, and guard behavior.

## Expected Result

- Users see a live, backend-aligned countdown during temporary seat reservation.
- The UI warns users in the final 60 seconds.
- Expired reservations cannot continue through ticket type selection or checkout.
- The purchase flow resets safely and explains the expiration in pt-BR.
- Frontend validation passes through tests, lint, and production build.

closes #107
