### PR TITLE
feat: add shared order summary panel and checkout steps

### DIFF
--- a/frontend/src/api/catalog.test.ts
+++ b/frontend/src/api/catalog.test.ts
@@ -91,6 +91,29 @@ test("catalogApi lists movies through the public catalog endpoint", async () => 
   }
 });
 
+test("catalogApi gets a session through the public catalog detail endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+  const sessionDetailResponse = sessionResponse.results[0];
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/session-123/"
+      );
+      assert.equal(init?.method, "GET");
+
+      return Response.json(sessionDetailResponse);
+    };
+
+    const response = await catalogApi.getSession("session-123");
+
+    assert.deepEqual(response, sessionDetailResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("catalogApi builds supported movie filters", async () => {
   const originalFetch = globalThis.fetch;
   const requestedUrls: string[] = [];
@@ -211,6 +234,21 @@ test("catalogApi rejects unexpected session responses", async () => {
     await assert.rejects(
       catalogApi.getSessions({ date: "2026-05-22", movie: "movie-123" }),
       /Unexpected catalog session list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi rejects unexpected session detail responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ id: "session-123" });
+
+    await assert.rejects(
+      catalogApi.getSession("session-123"),
+      /Unexpected catalog session detail response/
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -35,6 +35,10 @@ export const catalogApi = {
     return getMovie(movieId);
   },
 
+  getSession(sessionId: string) {
+    return getSession(sessionId);
+  },
+
   getSessions(params: GetSessionsParams = {}) {
     return getSessions(params);
   },
@@ -67,6 +71,19 @@ async function getMovie(movieId: string) {
   }
 
   return response satisfies CatalogMovieDetail;
+}
+
+async function getSession(sessionId: string) {
+  const response = await apiRequest<unknown>(`${SESSIONS_PATH}${sessionId}/`, {
+    auth: "none",
+    method: "GET",
+  });
+
+  if (!isCatalogSession(response)) {
+    throw new Error("Unexpected catalog session detail response.");
+  }
+
+  return response satisfies CatalogSession;
 }
 
 async function listMovies(params: ListMoviesParams) {

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -1,4 +1,5 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PurchaseFlowGuard } from "@/components/reservations/PurchaseFlowGuard";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
@@ -12,28 +13,32 @@ export default function CheckoutPage() {
           eyebrow="Pagamento"
           title="Finalizar compra"
         >
-          <div className="panel-grid">
-            <article className="panel">
-              <h2 className="panel-title">Cartão de crédito</h2>
-              <p className="panel-copy">
-                Opção preparada para pagamento com cartão.
-              </p>
-            </article>
-            <article className="panel">
-              <h2 className="panel-title">PIX</h2>
-              <p className="panel-copy">Opção preparada para pagamento via PIX.</p>
-            </article>
-            <article className="panel">
-              <h2 className="panel-title">Resumo</h2>
-              <p className="panel-copy">
-                Filme, sessão, assentos e total ficarão reunidos aqui.
-              </p>
-            </article>
-          </div>
-          <StateMessage tone="error" title="Compra não iniciada">
-            Se a reserva expirar ou o pedido não puder ser concluído, a mensagem
-            será apresentada em português do Brasil.
-          </StateMessage>
+          <PurchaseFlowLayout currentStep="checkout">
+            <div className="panel-grid">
+              <article className="panel">
+                <h2 className="panel-title">Cartão de crédito</h2>
+                <p className="panel-copy">
+                  Opção preparada para pagamento com cartão.
+                </p>
+              </article>
+              <article className="panel">
+                <h2 className="panel-title">PIX</h2>
+                <p className="panel-copy">
+                  Opção preparada para pagamento via PIX.
+                </p>
+              </article>
+              <article className="panel">
+                <h2 className="panel-title">Resumo</h2>
+                <p className="panel-copy">
+                  Revise assentos, tipos de ingresso e total antes de confirmar.
+                </p>
+              </article>
+            </div>
+            <StateMessage tone="error" title="Compra não iniciada">
+              Se a reserva expirar ou o pedido não puder ser concluído, a mensagem
+              será apresentada em português do Brasil.
+            </StateMessage>
+          </PurchaseFlowLayout>
         </PageSection>
       </PurchaseFlowGuard>
     </ProtectedRoute>

--- a/frontend/src/app/confirmation/page.tsx
+++ b/frontend/src/app/confirmation/page.tsx
@@ -1,4 +1,5 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
@@ -10,10 +11,12 @@ export default function ConfirmationPage() {
         eyebrow="Pedido"
         title="Confirmação"
       >
-        <StateMessage tone="success" title="Pronto para exibir ingressos">
-          Esta página receberá os dados da compra concluída e mostrará os
-          ingressos com identificação visual.
-        </StateMessage>
+        <PurchaseFlowLayout currentStep="confirmation">
+          <StateMessage tone="success" title="Pronto para exibir ingressos">
+            Esta página receberá os dados da compra concluída e mostrará os
+            ingressos com identificação visual.
+          </StateMessage>
+        </PurchaseFlowLayout>
       </PageSection>
     </ProtectedRoute>
   );

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -969,71 +969,226 @@ h1 {
   text-transform: uppercase;
 }
 
-.seat-reservation-summary {
-  align-items: center;
-  background: #f8fafc;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
+.purchase-flow {
   display: grid;
-  gap: 14px;
-  grid-template-columns: minmax(0, 1fr) auto;
-  padding: 16px;
+  gap: 18px;
 }
 
-.seat-reservation-summary h3,
-.seat-reservation-summary p {
+.purchase-flow__body {
+  align-items: start;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(0, 1fr) minmax(288px, 340px);
+}
+
+.purchase-flow__primary {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.purchase-flow__summary {
+  min-width: 0;
+  position: sticky;
+  top: 96px;
+}
+
+.checkout-steps {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  overflow-x: auto;
+  padding: 12px;
+}
+
+.checkout-steps__list {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, minmax(112px, 1fr));
+  list-style: none;
+  margin: 0;
+  min-width: 620px;
+  padding: 0;
+}
+
+.checkout-steps__item {
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-muted);
+  display: flex;
+  gap: 8px;
+  min-height: 44px;
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.checkout-steps__item--completed {
+  background: #e8f5ee;
+  border-color: #9fd5b8;
+  color: #0f5c38;
+}
+
+.checkout-steps__item--current {
+  background: #fff8df;
+  border-color: #d8a907;
+  color: var(--color-text);
+}
+
+.checkout-steps__marker {
+  align-items: center;
+  border: 2px solid currentColor;
+  border-radius: 999px;
+  display: inline-flex;
+  flex: 0 0 26px;
+  font-size: 13px;
+  font-weight: 900;
+  height: 26px;
+  justify-content: center;
+  line-height: 1;
+  width: 26px;
+}
+
+.checkout-steps__label {
+  font-size: 14px;
+  font-weight: 850;
+  overflow-wrap: anywhere;
+}
+
+.order-summary {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 14px;
+  min-height: 280px;
+  padding: 18px;
+}
+
+.order-summary__header {
+  align-items: start;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.order-summary__header h2,
+.order-summary__header p,
+.order-summary__empty,
+.order-summary__timer,
+.order-summary__details {
   margin: 0;
 }
 
-.seat-reservation-summary h3 {
-  font-size: 18px;
+.order-summary__header h2 {
+  font-size: 20px;
   line-height: 1.25;
 }
 
-.seat-reservation-summary p {
+.order-summary__header p,
+.order-summary__empty {
   color: var(--color-muted);
   line-height: 1.45;
 }
 
-.seat-reservation-summary__timer {
-  background: #fff8df;
-  border: 1px solid #e3bd34;
-  border-radius: 6px;
-  color: var(--color-text) !important;
-  font-size: 14px;
-  font-weight: 850;
-  padding: 9px 12px;
+.order-summary__total {
+  color: var(--color-brand);
+  font-size: 18px;
+  line-height: 1.25;
   white-space: nowrap;
 }
 
-.seat-reservation-summary__timer--warning {
-  background: #feeceb;
-  border-color: #d93025;
-  color: #9a1b13 !important;
+.order-summary__timer {
+  background: #fff8df;
+  border: 1px solid #e3bd34;
+  border-radius: 6px;
+  color: var(--color-text);
+  font-size: 14px;
+  font-weight: 850;
+  padding: 9px 12px;
 }
 
-.seat-reservation-summary__list {
-  display: flex;
-  flex-wrap: wrap;
+.order-summary__timer--warning,
+.order-summary__timer--expired {
+  background: #feeceb;
+  border-color: #d93025;
+  color: #9a1b13;
+}
+
+.order-summary__list {
+  display: grid;
   gap: 8px;
-  grid-column: 1 / -1;
   list-style: none;
   margin: 0;
+  min-height: 48px;
   padding: 0;
 }
 
-.seat-reservation-summary__list li {
-  background: #ffffff;
+.order-summary__item {
+  align-items: center;
+  background: #f8fafc;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  font-size: 14px;
-  font-weight: 850;
-  line-height: 1;
-  padding: 8px 10px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 58px;
+  padding: 10px 12px;
 }
 
-.seat-reservation-summary .button {
-  justify-self: end;
+.order-summary__item div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.order-summary__item strong,
+.order-summary__item span {
+  overflow-wrap: anywhere;
+}
+
+.order-summary__item strong {
+  font-size: 15px;
+  line-height: 1.25;
+}
+
+.order-summary__item span {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.order-summary__details {
+  border-top: 1px solid var(--color-border);
+  display: grid;
+  gap: 8px;
+  padding-top: 12px;
+}
+
+.order-summary__details div {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.order-summary__details dt {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.order-summary__details dd {
+  font-size: 15px;
+  font-weight: 850;
+  margin: 0;
+  text-align: right;
+}
+
+.order-summary__action {
+  width: 100%;
 }
 
 .movie-detail-loading__poster,
@@ -1146,14 +1301,21 @@ h1 {
     grid-template-columns: 1fr;
   }
 
-  .seat-reservation-summary {
-    align-items: stretch;
+  .purchase-flow__body {
     grid-template-columns: 1fr;
   }
 
-  .seat-reservation-summary .button {
-    justify-self: stretch;
-    width: 100%;
+  .purchase-flow__summary {
+    position: static;
+  }
+
+  .checkout-steps__list {
+    grid-template-columns: repeat(5, minmax(104px, 1fr));
+    min-width: 560px;
+  }
+
+  .order-summary {
+    min-height: 0;
   }
 
   .movie-detail__action-panel .button {

--- a/frontend/src/app/sessions/[sessionId]/seats/page.tsx
+++ b/frontend/src/app/sessions/[sessionId]/seats/page.tsx
@@ -1,4 +1,5 @@
 import { SeatMap } from "@/components/seats/SeatMap";
+import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PageSection } from "@/components/ui/PageSection";
 
 type SeatSelectionPageProps = {
@@ -18,7 +19,13 @@ export default async function SeatSelectionPage({
       eyebrow="Sessão"
       title="Mapa de assentos"
     >
-      <SeatMap sessionId={sessionId} />
+      <PurchaseFlowLayout
+        currentStep="seats"
+        summaryActionHref="/ticket-types"
+        summaryActionLabel="Continuar"
+      >
+        <SeatMap sessionId={sessionId} />
+      </PurchaseFlowLayout>
     </PageSection>
   );
 }

--- a/frontend/src/app/ticket-types/page.tsx
+++ b/frontend/src/app/ticket-types/page.tsx
@@ -1,4 +1,5 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PurchaseFlowGuard } from "@/components/reservations/PurchaseFlowGuard";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
@@ -13,28 +14,34 @@ export default function TicketTypeSelectionPage() {
           eyebrow="Ingressos"
           title="Tipos de ingresso"
         >
-          <div className="panel-grid">
-            <article className="panel">
-              <h2 className="panel-title">Inteira</h2>
-              <p className="panel-copy">Valor cheio da sessão selecionada.</p>
-            </article>
-            <article className="panel">
-              <h2 className="panel-title">Meia-entrada</h2>
-              <p className="panel-copy">
-                Metade do valor base, conforme regras aplicáveis.
-              </p>
-            </article>
-            <article className="panel">
-              <h2 className="panel-title">Cupom</h2>
-              <p className="panel-copy">
-                Campo preparado para validação em etapa futura.
-              </p>
-            </article>
-          </div>
-          <StateMessage tone="loading" title="Seleção de assentos necessária">
-            Os tipos de ingresso serão calculados depois que os assentos forem
-            reservados.
-          </StateMessage>
+          <PurchaseFlowLayout
+            currentStep="ticket-types"
+            summaryActionHref="/checkout"
+            summaryActionLabel="Ir para pagamento"
+          >
+            <div className="panel-grid">
+              <article className="panel">
+                <h2 className="panel-title">Inteira</h2>
+                <p className="panel-copy">Valor cheio da sessão selecionada.</p>
+              </article>
+              <article className="panel">
+                <h2 className="panel-title">Meia-entrada</h2>
+                <p className="panel-copy">
+                  Metade do valor base, conforme regras aplicáveis.
+                </p>
+              </article>
+              <article className="panel">
+                <h2 className="panel-title">Cupom</h2>
+                <p className="panel-copy">
+                  Campo preparado para validação em etapa futura.
+                </p>
+              </article>
+            </div>
+            <StateMessage tone="loading" title="Seleção de assentos necessária">
+              Os tipos de ingresso serão calculados depois que os assentos forem
+              reservados.
+            </StateMessage>
+          </PurchaseFlowLayout>
         </PageSection>
       </PurchaseFlowGuard>
     </ProtectedRoute>

--- a/frontend/src/components/reservations/CheckoutStepIndicator.tsx
+++ b/frontend/src/components/reservations/CheckoutStepIndicator.tsx
@@ -1,0 +1,37 @@
+import { getCheckoutStepStates, type CheckoutStepKey } from "./checkout-steps";
+
+type CheckoutStepIndicatorProps = {
+  currentStep: CheckoutStepKey;
+};
+
+const stepStatusLabels = {
+  completed: "concluída",
+  current: "atual",
+  upcoming: "pendente",
+} as const;
+
+export function CheckoutStepIndicator({
+  currentStep,
+}: CheckoutStepIndicatorProps) {
+  const steps = getCheckoutStepStates(currentStep);
+
+  return (
+    <nav aria-label="Etapas da compra" className="checkout-steps">
+      <ol className="checkout-steps__list">
+        {steps.map((step) => (
+          <li
+            aria-current={step.status === "current" ? "step" : undefined}
+            aria-label={`${step.label}, etapa ${step.position} de ${steps.length}, ${stepStatusLabels[step.status]}`}
+            className={`checkout-steps__item checkout-steps__item--${step.status}`}
+            key={step.key}
+          >
+            <span aria-hidden="true" className="checkout-steps__marker">
+              {step.status === "completed" ? "✓" : step.position}
+            </span>
+            <span className="checkout-steps__label">{step.label}</span>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/components/reservations/OrderSummaryPanel.tsx
+++ b/frontend/src/components/reservations/OrderSummaryPanel.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import Link from "next/link";
+
+import { useReservation } from "@/contexts/ReservationContext";
+import { useReservationCountdown } from "@/hooks/useReservationCountdown";
+import type {
+  PaymentMethod,
+  ReservedSeat,
+  TicketType,
+} from "@/types/reservation";
+import { formatCurrency } from "@/utils/formatters";
+
+import {
+  buildOrderSummaryItems,
+  calculateOrderTotal,
+  paymentMethodLabels,
+} from "./order-summary";
+
+type ReservationOrderSummaryProps = {
+  actionHref?: string;
+  actionLabel?: string;
+};
+
+export type OrderSummaryPanelProps = ReservationOrderSummaryProps & {
+  countdownExpired?: boolean;
+  countdownLabel?: string | null;
+  countdownWarning?: boolean;
+  paymentMethod?: PaymentMethod | null;
+  reservationExpiresAt?: Date | null;
+  reservedSeats: ReservedSeat[];
+  ticketTypes: Record<string, TicketType>;
+};
+
+export function ReservationOrderSummary({
+  actionHref,
+  actionLabel = "Continuar",
+}: ReservationOrderSummaryProps) {
+  const reservation = useReservation();
+  const countdown = useReservationCountdown(reservation.reservationExpiresAt);
+
+  return (
+    <OrderSummaryPanel
+      actionHref={actionHref}
+      actionLabel={actionLabel}
+      countdownExpired={countdown?.isExpired ?? false}
+      countdownLabel={countdown ? `Expira em ${countdown.displayValue}` : null}
+      countdownWarning={countdown?.isWarning ?? false}
+      paymentMethod={reservation.paymentMethod}
+      reservationExpiresAt={reservation.reservationExpiresAt}
+      reservedSeats={reservation.reservedSeats}
+      ticketTypes={reservation.ticketTypes}
+    />
+  );
+}
+
+export function OrderSummaryPanel({
+  actionHref,
+  actionLabel = "Continuar",
+  countdownExpired = false,
+  countdownLabel,
+  countdownWarning = false,
+  paymentMethod = null,
+  reservationExpiresAt = null,
+  reservedSeats,
+  ticketTypes,
+}: OrderSummaryPanelProps) {
+  const items = buildOrderSummaryItems(
+    reservedSeats,
+    ticketTypes
+  );
+  const total = calculateOrderTotal(items);
+  const hasSeats = items.length > 0;
+  const paymentLabel = paymentMethod
+    ? paymentMethodLabels[paymentMethod]
+    : null;
+
+  return (
+    <aside aria-label="Resumo do pedido" className="order-summary">
+      <div className="order-summary__header">
+        <div>
+          <h2>Resumo do pedido</h2>
+          <p>
+            {hasSeats
+              ? `${items.length} assento${items.length === 1 ? "" : "s"} selecionado${items.length === 1 ? "" : "s"}`
+              : "Nenhum assento selecionado"}
+          </p>
+        </div>
+        <strong className="order-summary__total">{formatCurrency(total)}</strong>
+      </div>
+
+      {reservationExpiresAt ? (
+        <p
+          className={[
+            "order-summary__timer",
+            countdownWarning ? "order-summary__timer--warning" : "",
+            countdownExpired ? "order-summary__timer--expired" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          role="timer"
+        >
+          {countdownExpired
+            ? "Reserva expirada"
+            : countdownLabel
+              ? countdownLabel
+              : "Reserva temporária ativa"}
+        </p>
+      ) : null}
+
+      {hasSeats ? (
+        <ul className="order-summary__list">
+          {items.map((item) => (
+            <li className="order-summary__item" key={item.seat.sessionSeatId}>
+              <div>
+                <strong>Assento {item.seatLabel}</strong>
+                <span>{item.ticketTypeLabel}</span>
+              </div>
+              <span>{formatCurrency(item.unitPrice)}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="order-summary__empty">
+          Escolha os assentos para ver valores e tipos de ingresso.
+        </p>
+      )}
+
+      <dl className="order-summary__details">
+        <div>
+          <dt>Subtotal</dt>
+          <dd>{formatCurrency(total)}</dd>
+        </div>
+        <div>
+          <dt>Pagamento</dt>
+          <dd>{paymentLabel ?? "A definir"}</dd>
+        </div>
+      </dl>
+
+      {actionHref && hasSeats ? (
+        <Link className="button button-primary order-summary__action" href={actionHref}>
+          {actionLabel}
+        </Link>
+      ) : null}
+    </aside>
+  );
+}

--- a/frontend/src/components/reservations/PurchaseFlowLayout.tsx
+++ b/frontend/src/components/reservations/PurchaseFlowLayout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+import { CheckoutStepIndicator } from "./CheckoutStepIndicator";
+import { ReservationOrderSummary } from "./OrderSummaryPanel";
+import type { CheckoutStepKey } from "./checkout-steps";
+
+type PurchaseFlowLayoutProps = {
+  children: ReactNode;
+  currentStep: CheckoutStepKey;
+  summaryActionHref?: string;
+  summaryActionLabel?: string;
+};
+
+export function PurchaseFlowLayout({
+  children,
+  currentStep,
+  summaryActionHref,
+  summaryActionLabel,
+}: PurchaseFlowLayoutProps) {
+  return (
+    <div className="purchase-flow">
+      <CheckoutStepIndicator currentStep={currentStep} />
+      <div className="purchase-flow__body">
+        <div className="purchase-flow__primary">{children}</div>
+        <div className="purchase-flow__summary">
+          <ReservationOrderSummary
+            actionHref={summaryActionHref}
+            actionLabel={summaryActionLabel}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reservations/checkout-steps.ts
+++ b/frontend/src/components/reservations/checkout-steps.ts
@@ -1,0 +1,33 @@
+export const checkoutSteps = [
+  { key: "session", label: "Sessão" },
+  { key: "seats", label: "Assentos" },
+  { key: "ticket-types", label: "Ingressos" },
+  { key: "checkout", label: "Pagamento" },
+  { key: "confirmation", label: "Confirmação" },
+] as const;
+
+export type CheckoutStepKey = (typeof checkoutSteps)[number]["key"];
+
+export type CheckoutStepStatus = "completed" | "current" | "upcoming";
+
+export type CheckoutStepState = (typeof checkoutSteps)[number] & {
+  position: number;
+  status: CheckoutStepStatus;
+};
+
+export function getCheckoutStepStates(
+  currentStep: CheckoutStepKey
+): CheckoutStepState[] {
+  const currentIndex = checkoutSteps.findIndex((step) => step.key === currentStep);
+
+  return checkoutSteps.map((step, index) => ({
+    ...step,
+    position: index + 1,
+    status:
+      index < currentIndex
+        ? "completed"
+        : index === currentIndex
+          ? "current"
+          : "upcoming",
+  }));
+}

--- a/frontend/src/components/reservations/order-summary.test.ts
+++ b/frontend/src/components/reservations/order-summary.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { ReservedSeat } from "@/types/reservation";
+import { formatCurrency } from "@/utils/formatters";
+
+import { CheckoutStepIndicator } from "./CheckoutStepIndicator";
+import { OrderSummaryPanel } from "./OrderSummaryPanel";
+import { getCheckoutStepStates } from "./checkout-steps";
+import {
+  buildOrderSummaryItems,
+  calculateOrderTotal,
+  calculateTicketUnitPrice,
+} from "./order-summary";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const firstSeat: ReservedSeat = {
+  basePrice: 42.5,
+  expiresAt: new Date("2026-05-22T21:40:00.000Z"),
+  isAccessible: false,
+  number: 7,
+  row: "B",
+  seatId: "seat-1",
+  sessionSeatId: "session-seat-1",
+};
+
+const secondSeat: ReservedSeat = {
+  ...firstSeat,
+  isAccessible: true,
+  number: 8,
+  seatId: "seat-2",
+  sessionSeatId: "session-seat-2",
+};
+
+test("order summary helpers calculate full, half, and total values", () => {
+  assert.equal(calculateTicketUnitPrice(42.5, "inteira"), 42.5);
+  assert.equal(calculateTicketUnitPrice(42.5, "meia"), 21.25);
+
+  const items = buildOrderSummaryItems(
+    [firstSeat, secondSeat],
+    {
+      "session-seat-1": "inteira",
+      "session-seat-2": "meia",
+    }
+  );
+
+  assert.deepEqual(
+    items.map((item) => ({
+      seatLabel: item.seatLabel,
+      ticketTypeLabel: item.ticketTypeLabel,
+      unitPrice: item.unitPrice,
+    })),
+    [
+      { seatLabel: "B7", ticketTypeLabel: "Inteira", unitPrice: 42.5 },
+      { seatLabel: "B8", ticketTypeLabel: "Meia-entrada", unitPrice: 21.25 },
+    ]
+  );
+  assert.equal(calculateOrderTotal(items), 63.75);
+});
+
+test("checkout step states mark completed, current, and upcoming steps", () => {
+  const states = getCheckoutStepStates("ticket-types");
+
+  assert.deepEqual(
+    states.map((step) => [step.key, step.status]),
+    [
+      ["session", "completed"],
+      ["seats", "completed"],
+      ["ticket-types", "current"],
+      ["checkout", "upcoming"],
+      ["confirmation", "upcoming"],
+    ]
+  );
+});
+
+test("checkout step indicator identifies the current step semantically", () => {
+  const html = renderToStaticMarkup(
+    createElement(CheckoutStepIndicator, { currentStep: "checkout" })
+  );
+
+  assert.match(html, /Etapas da compra/);
+  assert.match(html, /Sessão/);
+  assert.match(html, /Pagamento/);
+  assert.match(html, /aria-current="step"/);
+  assert.match(html, /Pagamento, etapa 4 de 5, atual/);
+});
+
+test("order summary renders seats, ticket types, prices, total, and expiration", () => {
+  const html = renderToStaticMarkup(
+    createElement(OrderSummaryPanel, {
+      actionHref: "/checkout",
+      actionLabel: "Ir para pagamento",
+      countdownLabel: "Expira em 04:30",
+      countdownWarning: true,
+      paymentMethod: "pix",
+      reservationExpiresAt: firstSeat.expiresAt,
+      reservedSeats: [firstSeat, secondSeat],
+      ticketTypes: {
+        "session-seat-1": "inteira",
+        "session-seat-2": "meia",
+      },
+    })
+  );
+
+  assert.match(html, /Resumo do pedido/);
+  assert.match(html, /Assento B7/);
+  assert.match(html, /Inteira/);
+  assert.match(html, /Assento B8/);
+  assert.match(html, /Meia-entrada/);
+  assert.match(html, /PIX/);
+  assert.match(html, /Expira em 04:30/);
+  assert.match(html, /order-summary__timer--warning/);
+  assert.match(html, new RegExp(escapeRegExp(formatCurrency(63.75))));
+  assert.match(html, /Ir para pagamento/);
+});
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/frontend/src/components/reservations/order-summary.ts
+++ b/frontend/src/components/reservations/order-summary.ts
@@ -1,0 +1,65 @@
+import type {
+  PaymentMethod,
+  ReservedSeat,
+  TicketType,
+} from "@/types/reservation";
+
+export type OrderSummaryItem = {
+  seat: ReservedSeat;
+  seatLabel: string;
+  ticketType: TicketType | null;
+  ticketTypeLabel: string;
+  unitPrice: number;
+};
+
+export const ticketTypeLabels: Record<TicketType, string> = {
+  inteira: "Inteira",
+  meia: "Meia-entrada",
+};
+
+export const paymentMethodLabels: Record<PaymentMethod, string> = {
+  cartao_credito: "Cartão de crédito",
+  pix: "PIX",
+};
+
+export function formatSeatLabel(seat: Pick<ReservedSeat, "number" | "row">) {
+  return `${seat.row}${seat.number}`;
+}
+
+export function calculateTicketUnitPrice(
+  basePrice: number,
+  ticketType?: TicketType | null
+) {
+  if (ticketType === "meia") {
+    return roundCurrency(basePrice * 0.5);
+  }
+
+  return roundCurrency(basePrice);
+}
+
+export function buildOrderSummaryItems(
+  reservedSeats: ReservedSeat[],
+  ticketTypes: Record<string, TicketType>
+): OrderSummaryItem[] {
+  return reservedSeats.map((seat) => {
+    const ticketType = ticketTypes[seat.sessionSeatId] ?? null;
+
+    return {
+      seat,
+      seatLabel: formatSeatLabel(seat),
+      ticketType,
+      ticketTypeLabel: ticketType ? ticketTypeLabels[ticketType] : "A definir",
+      unitPrice: calculateTicketUnitPrice(seat.basePrice, ticketType),
+    };
+  });
+}
+
+export function calculateOrderTotal(items: Pick<OrderSummaryItem, "unitPrice">[]) {
+  return roundCurrency(
+    items.reduce((total, item) => total + item.unitPrice, 0)
+  );
+}
+
+function roundCurrency(value: number) {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 
 import { ApiError, getApiErrorUserMessage } from "@/api/client";
+import { catalogApi } from "@/api/catalog";
 import { reservationApi } from "@/api/reservation";
 import { useGuardedAction } from "@/components/auth/useGuardedAction";
 import { StateMessage } from "@/components/ui/StateMessage";
@@ -18,7 +18,7 @@ import type {
 type SeatMapLoadState =
   | { status: "error"; errorMessage?: string }
   | { status: "loading" }
-  | { seats: SessionSeatMapItem[]; status: "success" };
+  | { seats: SessionSeatMapItem[]; sessionBasePrice: number; status: "success" };
 
 export type SeatMapRow = {
   rowLabel: string;
@@ -36,17 +36,15 @@ type SeatMapProps = {
 };
 
 type SeatMapViewProps = {
+  sessionBasePrice: number;
   sessionId: string;
   seats: SessionSeatMapItem[];
 };
 
 type SeatMapLayoutProps = {
-  countdownLabel: string | null;
-  countdownWarning?: boolean;
   errorMessage?: string | null;
   onSeatToggle?: (seat: SessionSeatMapItem) => void;
   pendingSeatIds?: ReadonlySet<string>;
-  reservedSeats?: ReservedSeat[];
   seats: SessionSeatMapItem[];
   selectedSeatIds?: ReadonlySet<string>;
 };
@@ -65,8 +63,6 @@ const seatStateMarkers: Record<SeatVisualState, string> = {
   selected: "S",
 };
 
-const SESSION_BASE_PRICE_PLACEHOLDER = 0;
-
 export function SeatMap({ sessionId }: SeatMapProps) {
   const [state, setState] = useState<SeatMapLoadState>({ status: "loading" });
 
@@ -83,10 +79,20 @@ export function SeatMap({ sessionId }: SeatMapProps) {
       setState({ status: "loading" });
 
       try {
-        const seats = await reservationApi.getSeatMap(trimmedSessionId);
+        const [seats, session] = await Promise.all([
+          reservationApi.getSeatMap(trimmedSessionId),
+          catalogApi.getSession(trimmedSessionId),
+        ]);
+        const sessionBasePrice = Number(session.base_price);
 
         if (isActive) {
-          setState({ seats, status: "success" });
+          setState({
+            seats,
+            sessionBasePrice: Number.isFinite(sessionBasePrice)
+              ? sessionBasePrice
+              : 0,
+            status: "success",
+          });
         }
       } catch (error) {
         if (isActive) {
@@ -122,10 +128,20 @@ export function SeatMap({ sessionId }: SeatMapProps) {
     );
   }
 
-  return <SeatMapView seats={state.seats} sessionId={sessionId.trim()} />;
+  return (
+    <SeatMapView
+      seats={state.seats}
+      sessionBasePrice={state.sessionBasePrice}
+      sessionId={sessionId.trim()}
+    />
+  );
 }
 
-export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
+export function SeatMapView({
+  seats,
+  sessionBasePrice,
+  sessionId,
+}: SeatMapViewProps) {
   const guardAction = useGuardedAction();
   const reservation = useReservation();
   const [currentSeats, setCurrentSeats] = useState(seats);
@@ -234,6 +250,7 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
       const nextSeats = buildReservedSeatsFromReservation(
         response,
         currentSeats,
+        sessionBasePrice,
         response.expires_at
       );
 
@@ -299,12 +316,9 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
 
   return (
     <SeatMapLayout
-      countdownLabel={countdown ? `Expira em ${countdown.displayValue}` : null}
-      countdownWarning={countdown?.isWarning ?? false}
       errorMessage={errorMessage}
       onSeatToggle={toggleSeat}
       pendingSeatIds={pendingSeatIds}
-      reservedSeats={reservedSeatsForSession}
       seats={currentSeats}
       selectedSeatIds={selectedSeatIds}
     />
@@ -312,17 +326,13 @@ export function SeatMapView({ seats, sessionId }: SeatMapViewProps) {
 }
 
 export function SeatMapLayout({
-  countdownLabel,
-  countdownWarning = false,
   errorMessage,
   onSeatToggle,
   pendingSeatIds = new Set(),
-  reservedSeats = [],
   seats,
   selectedSeatIds = new Set(),
 }: SeatMapLayoutProps) {
   const rows = useMemo(() => groupSeatMapRows(seats), [seats]);
-  const hasReservedSeats = reservedSeats.length > 0;
 
   if (rows.length === 0) {
     return (
@@ -449,45 +459,6 @@ export function SeatMapLayout({
           <div className="seat-map__back-label">Fundo da sala</div>
         </div>
       </div>
-
-      <aside aria-label="Resumo da reserva" className="seat-reservation-summary">
-        <div>
-          <h3>Reserva temporária</h3>
-          <p>
-            {hasReservedSeats
-              ? `${reservedSeats.length} assento${reservedSeats.length === 1 ? "" : "s"} reservado${reservedSeats.length === 1 ? "" : "s"}.`
-              : "Nenhum assento reservado nesta sessão."}
-          </p>
-        </div>
-        {countdownLabel ? (
-          <p
-            className={[
-              "seat-reservation-summary__timer",
-              countdownWarning ? "seat-reservation-summary__timer--warning" : "",
-            ]
-              .filter(Boolean)
-              .join(" ")}
-            role="timer"
-          >
-            {countdownLabel}
-          </p>
-        ) : null}
-        {hasReservedSeats ? (
-          <>
-            <ul className="seat-reservation-summary__list">
-              {reservedSeats.map((seat) => (
-                <li key={seat.sessionSeatId}>
-                  {seat.row}
-                  {seat.number}
-                </li>
-              ))}
-            </ul>
-            <Link className="button button-primary" href="/ticket-types">
-              Continuar
-            </Link>
-          </>
-        ) : null}
-      </aside>
     </section>
   );
 }
@@ -601,6 +572,7 @@ export function getSeatAccessibleLabel(
 export function buildReservedSeatsFromReservation(
   response: TemporaryReservationResponse,
   seatMap: SessionSeatMapItem[],
+  basePrice: number,
   expiresAtValue = response.expires_at
 ): ReservedSeat[] {
   const expiresAt = new Date(expiresAtValue);
@@ -614,7 +586,7 @@ export function buildReservedSeatsFromReservation(
     }
 
     return {
-      basePrice: SESSION_BASE_PRICE_PLACEHOLDER,
+      basePrice,
       expiresAt,
       isAccessible: originalSeat.is_accessible,
       number: reservedSeat.number,

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -79,7 +79,6 @@ test("seat visual states distinguish available, selected, reserved, and purchase
 test("seat map renders screen, row labels, seat numbers, and semantic states", () => {
   const html = renderToStaticMarkup(
     createElement(SeatMapLayout, {
-      countdownLabel: null,
       seats: [
         seat({ number: 1, row: "A" }),
         seat({
@@ -111,35 +110,6 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, /seat-map__seat--selected/);
   assert.match(html, /aria-disabled="true"/);
   assert.match(html, /aria-pressed="true"/);
-});
-
-test("seat map layout renders reservation summary and countdown", () => {
-  const expiresAt = new Date("2026-05-22T21:40:00.000Z");
-  const html = renderToStaticMarkup(
-    createElement(SeatMapLayout, {
-      countdownLabel: "Expira em 04:30",
-      countdownWarning: true,
-      reservedSeats: [
-        {
-          basePrice: 0,
-          expiresAt,
-          isAccessible: false,
-          number: 7,
-          row: "B",
-          seatId: "seat-1",
-          sessionSeatId: "session-seat-1",
-        },
-      ],
-      seats: [seat({ number: 7, row: "B", session_seat_id: "session-seat-1" })],
-    })
-  );
-
-  assert.match(html, /Reserva temporária/);
-  assert.match(html, /1 assento reservado/);
-  assert.match(html, /Expira em 04:30/);
-  assert.match(html, /seat-reservation-summary__timer--warning/);
-  assert.match(html, /B7/);
-  assert.match(html, /Continuar/);
 });
 
 test("seat legend explains every state in pt-BR", () => {
@@ -191,9 +161,11 @@ test("reserved seats built from reservation response preserve original session s
         seat_id: "seat-1",
         session_seat_id: "session-seat-original",
       }),
-    ]
+    ],
+    42.5
   );
 
+  assert.equal(reservedSeats[0].basePrice, 42.5);
   assert.equal(reservedSeats[0].seatId, "seat-1");
   assert.equal(reservedSeats[0].sessionSeatId, "session-seat-original");
   assert.equal(reservedSeats[0].isAccessible, true);


### PR DESCRIPTION
## Objective

Build the shared frontend purchase-flow summary surface used across seat selection, ticket type selection, checkout, and confirmation preparation, while keeping totals informational and synchronized with the existing reservation state.

## What was done

### 1. Shared order summary panel

Added a reusable reservation order summary component under `frontend/src/components/reservations/`.

The panel displays:

- selected seats using row and number identifiers
- ticket type per seat when available
- unit price per seat
- subtotal/total using Brazilian currency formatting
- reservation expiration countdown state when available
- selected payment method when available

### 2. Checkout step indicator

Added a shared purchase-flow step indicator covering:

- Sessão
- Assentos
- Ingressos
- Pagamento
- Confirmação

The indicator marks completed, current, and upcoming steps, and exposes the current step semantically with `aria-current="step"`.

### 3. Responsive purchase-flow layout

Added a shared purchase-flow layout that combines the step indicator, primary page content, and order summary panel.

On desktop, the summary renders as a sticky sidebar. On smaller screens, the layout stacks into a mobile-friendly anchored panel without overlapping the primary content.

### 4. Reservation state integration

Connected the summary to the existing shared reservation state:

- `reservedSeats`
- `ticketTypes`
- `paymentMethod`
- `reservationExpiresAt`

Also added pure helpers for seat labels, ticket price calculation, order summary item generation, and total calculation.

### 5. Session pricing integration

Extended the frontend catalog API with `catalogApi.getSession()` so the seat selection flow can fetch the selected session's `base_price`.

The reserved seat state now carries the session base price instead of using a placeholder, allowing the summary to show informative per-seat values.

### 6. Page integration

Integrated the shared purchase-flow layout into:

- seat selection
- ticket type selection
- checkout
- confirmation preparation

The former seat-map-local reservation summary was removed so the shared component is the single summary surface for the purchase flow.

### 7. Automated test coverage

Added and updated frontend tests for:

- full and half ticket price calculation
- order total calculation
- checkout step state generation
- semantic current-step rendering
- order summary rendering with seats, ticket types, BRL prices, payment method, and expiration state
- catalog session detail API support
- seat reservation state preserving the fetched session base price

## Acceptance criteria confirmation

- Shared Component: satisfied by `ReservationOrderSummary` and `OrderSummaryPanel`.
- Seat Display: satisfied with row/number labels such as `B7`.
- Ticket Type Display: satisfied with `Inteira`, `Meia-entrada`, or `A definir`.
- Price Display: satisfied with `Intl.NumberFormat("pt-BR", { currency: "BRL" })`.
- Responsive Behavior: satisfied by desktop sidebar and stacked mobile panel styles.
- Step Indicator: satisfied for Session, Seats, Ticket Types, Checkout, and Confirmation.
- Current Step: satisfied visually and semantically with `aria-current="step"`.
- State Sync: satisfied through `useReservation()` and reservation countdown state.
- Automated Tests: satisfied with focused helper and rendering coverage.

## How to test

### Automated validation

Run the frontend checks:

```bash
cd frontend
npm run test
npm run lint
npm run build
```

### Manual validation

1. Start the frontend:

```bash
cd frontend
npm run dev
```

2. Visit the purchase flow pages:

- `/sessions/{sessionId}/seats`
- `/ticket-types`
- `/checkout`
- `/confirmation`

3. Validate the main expected behaviors:

- the step indicator shows the correct current step
- selected seats appear in the summary as row/number labels
- ticket types appear when present in reservation state
- unit prices and totals render in Brazilian currency format
- reservation countdown appears when `reservationExpiresAt` exists
- desktop uses sidebar layout
- mobile stacks the summary without overlapping the main content

## Expected Result

- Purchase-flow pages share one reusable summary panel.
- Users can track seats, ticket types, prices, total, payment method, and reservation expiration consistently.
- The checkout step indicator gives clear progress feedback across the purchase flow.
- Totals remain client-side informational while backend pricing remains authoritative.
- Frontend automated validation passes successfully.

closes #108 