### PR TITLE
feat: implement checkout review and payment submission

### DIFF
--- a/frontend/src/api/checkout.test.ts
+++ b/frontend/src/api/checkout.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiError, setApiAuthController } from "./client";
+import { checkoutApi } from "./checkout";
+
+const checkoutResponse = {
+  payment_method: "pix",
+  seats: [
+    {
+      amount_paid: "42.50",
+      number: 7,
+      row: "B",
+      seat_id: "seat-1",
+      session_seat_id: "session-seat-1",
+      status: "PURCHASED",
+      ticket_type: "inteira",
+    },
+  ],
+  status: "PURCHASED",
+  tickets: [
+    {
+      amount_paid: "42.50",
+      movie: {
+        id: "movie-1",
+        title: "O Filme",
+      },
+      payment_method: "pix",
+      room: {
+        id: "room-1",
+        name: "Sala 1",
+      },
+      seat: {
+        id: "seat-1",
+        identifier: "B7",
+        number: 7,
+        row: "B",
+      },
+      seat_id: "seat-1",
+      session: {
+        end_time: "2026-05-22T23:00:00-03:00",
+        id: "session-1",
+        start_time: "2026-05-22T21:00:00-03:00",
+      },
+      session_seat_id: "session-seat-1",
+      ticket_code: "ABC123",
+      ticket_id: "ticket-1",
+      ticket_type: "inteira",
+    },
+  ],
+  total_amount: "42.50",
+};
+
+test("checkoutApi posts the typed checkout payload to the authenticated endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "access-token",
+      refreshAccessToken: async () => null,
+    });
+
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/reservation/checkout/");
+      assert.equal(init?.method, "POST");
+      assert.equal(
+        init?.body,
+        JSON.stringify({
+          payment_method: "pix",
+          seats: [
+            {
+              session_seat_id: "session-seat-1",
+              ticket_type: "inteira",
+            },
+          ],
+        })
+      );
+      assert.equal(
+        Object.hasOwn(JSON.parse(String(init?.body)), "total_amount"),
+        false
+      );
+
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("Authorization"), "Bearer access-token");
+      assert.equal(headers.get("Content-Type"), "application/json");
+
+      return Response.json(checkoutResponse);
+    };
+
+    const response = await checkoutApi.checkout({
+      payment_method: "pix",
+      seats: [
+        {
+          session_seat_id: "session-seat-1",
+          ticket_type: "inteira",
+        },
+      ],
+    });
+
+    assert.deepEqual(response, checkoutResponse);
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("checkoutApi preserves backend error codes for friendly checkout errors", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "access-token",
+      refreshAccessToken: async () => null,
+    });
+
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          error: {
+            code: "INVALID_PAYMENT_METHOD",
+            details: {},
+            message: "Unrecognized payment_method value.",
+            status: 400,
+          },
+        },
+        { status: 400 }
+      );
+
+    await assert.rejects(
+      checkoutApi.checkout({
+        payment_method: "pix",
+        seats: [
+          {
+            session_seat_id: "session-seat-1",
+            ticket_type: "inteira",
+          },
+        ],
+      }),
+      (error) =>
+        error instanceof ApiError && error.code === "INVALID_PAYMENT_METHOD"
+    );
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("checkoutApi rejects unexpected checkout responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "access-token",
+      refreshAccessToken: async () => null,
+    });
+
+    globalThis.fetch = async () => Response.json({ status: "PURCHASED" });
+
+    await assert.rejects(
+      checkoutApi.checkout({
+        payment_method: "pix",
+        seats: [
+          {
+            session_seat_id: "session-seat-1",
+            ticket_type: "inteira",
+          },
+        ],
+      }),
+      /Unexpected checkout response/
+    );
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/checkout.ts
+++ b/frontend/src/api/checkout.ts
@@ -1,0 +1,105 @@
+import type {
+  CheckoutPayload,
+  CheckoutResponse,
+  CheckoutSeatResponse,
+  CheckoutTicketResponse,
+  PaymentMethod,
+  SessionSeatStatus,
+  TicketType,
+} from "@/types/reservation";
+
+import { apiRequest } from "./client";
+
+const CHECKOUT_PATH = "/api/v1/reservation/checkout/";
+
+export const checkoutApi = {
+  checkout(payload: CheckoutPayload) {
+    return checkout(payload);
+  },
+};
+
+async function checkout(payload: CheckoutPayload) {
+  const response = await apiRequest<unknown>(CHECKOUT_PATH, {
+    auth: "required",
+    json: payload,
+    method: "POST",
+  });
+
+  if (!isCheckoutResponse(response)) {
+    throw new Error("Unexpected checkout response.");
+  }
+
+  return response satisfies CheckoutResponse;
+}
+
+function isCheckoutResponse(value: unknown): value is CheckoutResponse {
+  return (
+    isRecord(value) &&
+    typeof value.status === "string" &&
+    isPaymentMethod(value.payment_method) &&
+    typeof value.total_amount === "string" &&
+    Array.isArray(value.seats) &&
+    value.seats.every(isCheckoutSeatResponse) &&
+    Array.isArray(value.tickets) &&
+    value.tickets.every(isCheckoutTicketResponse)
+  );
+}
+
+function isCheckoutSeatResponse(value: unknown): value is CheckoutSeatResponse {
+  return (
+    isRecord(value) &&
+    typeof value.session_seat_id === "string" &&
+    typeof value.seat_id === "string" &&
+    typeof value.row === "string" &&
+    typeof value.number === "number" &&
+    isSessionSeatStatus(value.status) &&
+    isTicketType(value.ticket_type) &&
+    typeof value.amount_paid === "string"
+  );
+}
+
+function isCheckoutTicketResponse(
+  value: unknown
+): value is CheckoutTicketResponse {
+  return (
+    isRecord(value) &&
+    typeof value.ticket_id === "string" &&
+    typeof value.ticket_code === "string" &&
+    typeof value.session_seat_id === "string" &&
+    typeof value.seat_id === "string" &&
+    isTicketType(value.ticket_type) &&
+    typeof value.amount_paid === "string" &&
+    isPaymentMethod(value.payment_method) &&
+    isRecord(value.movie) &&
+    typeof value.movie.id === "string" &&
+    typeof value.movie.title === "string" &&
+    isRecord(value.session) &&
+    typeof value.session.id === "string" &&
+    typeof value.session.start_time === "string" &&
+    typeof value.session.end_time === "string" &&
+    isRecord(value.room) &&
+    typeof value.room.id === "string" &&
+    typeof value.room.name === "string" &&
+    isRecord(value.seat) &&
+    typeof value.seat.id === "string" &&
+    typeof value.seat.row === "string" &&
+    typeof value.seat.number === "number" &&
+    typeof value.seat.identifier === "string"
+  );
+}
+
+function isTicketType(value: unknown): value is TicketType {
+  return value === "inteira" || value === "meia";
+}
+
+function isPaymentMethod(value: unknown): value is PaymentMethod {
+  return value === "cartao_credito" || value === "pix";
+}
+
+function isSessionSeatStatus(value: unknown): value is SessionSeatStatus {
+  return value === "AVAILABLE" || value === "RESERVED" || value === "PURCHASED";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -1,8 +1,8 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { CheckoutReview } from "@/components/reservations/CheckoutReview";
 import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PurchaseFlowGuard } from "@/components/reservations/PurchaseFlowGuard";
 import { PageSection } from "@/components/ui/PageSection";
-import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function CheckoutPage() {
   return (
@@ -14,30 +14,7 @@ export default function CheckoutPage() {
           title="Finalizar compra"
         >
           <PurchaseFlowLayout currentStep="checkout">
-            <div className="panel-grid">
-              <article className="panel">
-                <h2 className="panel-title">Cartão de crédito</h2>
-                <p className="panel-copy">
-                  Opção preparada para pagamento com cartão.
-                </p>
-              </article>
-              <article className="panel">
-                <h2 className="panel-title">PIX</h2>
-                <p className="panel-copy">
-                  Opção preparada para pagamento via PIX.
-                </p>
-              </article>
-              <article className="panel">
-                <h2 className="panel-title">Resumo</h2>
-                <p className="panel-copy">
-                  Revise assentos, tipos de ingresso e total antes de confirmar.
-                </p>
-              </article>
-            </div>
-            <StateMessage tone="error" title="Compra não iniciada">
-              Se a reserva expirar ou o pedido não puder ser concluído, a mensagem
-              será apresentada em português do Brasil.
-            </StateMessage>
+            <CheckoutReview />
           </PurchaseFlowLayout>
         </PageSection>
       </PurchaseFlowGuard>

--- a/frontend/src/app/confirmation/page.tsx
+++ b/frontend/src/app/confirmation/page.tsx
@@ -1,7 +1,7 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { CheckoutConfirmation } from "@/components/reservations/CheckoutConfirmation";
 import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PageSection } from "@/components/ui/PageSection";
-import { StateMessage } from "@/components/ui/StateMessage";
 
 export default function ConfirmationPage() {
   return (
@@ -12,10 +12,7 @@ export default function ConfirmationPage() {
         title="Confirmação"
       >
         <PurchaseFlowLayout currentStep="confirmation">
-          <StateMessage tone="success" title="Pronto para exibir ingressos">
-            Esta página receberá os dados da compra concluída e mostrará os
-            ingressos com identificação visual.
-          </StateMessage>
+          <CheckoutConfirmation />
         </PurchaseFlowLayout>
       </PageSection>
     </ProtectedRoute>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1191,6 +1191,214 @@ h1 {
   width: 100%;
 }
 
+.checkout-review {
+  display: grid;
+  gap: 18px;
+}
+
+.checkout-review__panel,
+.confirmation-tickets {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+}
+
+.checkout-review__heading,
+.confirmation-tickets__heading {
+  align-items: start;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.checkout-review__heading h2,
+.checkout-review__heading p,
+.checkout-review__session,
+.confirmation-tickets__heading h2,
+.confirmation-tickets__heading p {
+  margin: 0;
+}
+
+.checkout-review__heading h2,
+.confirmation-tickets__heading h2 {
+  font-size: 21px;
+  line-height: 1.25;
+}
+
+.checkout-review__heading p,
+.confirmation-tickets__heading p {
+  color: var(--color-muted);
+  line-height: 1.5;
+  margin-top: 6px;
+}
+
+.checkout-review__heading strong,
+.confirmation-tickets__heading strong {
+  color: var(--color-brand);
+  font-size: 20px;
+  white-space: nowrap;
+}
+
+.checkout-review__session,
+.confirmation-ticket__details {
+  display: grid;
+  gap: 10px;
+}
+
+.checkout-review__session div,
+.confirmation-ticket__details div {
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  padding-bottom: 10px;
+}
+
+.checkout-review__session dt,
+.confirmation-ticket__details dt {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.checkout-review__session dd,
+.confirmation-ticket__details dd {
+  font-weight: 850;
+  margin: 0;
+  text-align: right;
+}
+
+.checkout-review__items,
+.confirmation-tickets__list {
+  display: grid;
+  gap: 10px;
+}
+
+.checkout-review__item {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(88px, 0.8fr) minmax(120px, 1fr) auto;
+  min-height: 66px;
+  padding: 12px;
+}
+
+.checkout-review__item div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.checkout-review__item span {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.checkout-review__item strong {
+  font-size: 15px;
+  overflow-wrap: anywhere;
+}
+
+.payment-methods {
+  display: grid;
+  gap: 10px;
+}
+
+.payment-methods__option {
+  align-items: center;
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 72px;
+  padding: 12px;
+}
+
+.payment-methods__option:has(input:checked) {
+  background: #fff8df;
+  border-color: #d8a907;
+}
+
+.payment-methods__option input {
+  height: 18px;
+  width: 18px;
+}
+
+.payment-methods__option span {
+  display: grid;
+  gap: 4px;
+}
+
+.payment-methods__option strong {
+  font-size: 16px;
+}
+
+.payment-methods__option small {
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.checkout-review__submit {
+  justify-self: end;
+  min-width: 190px;
+}
+
+.confirmation-ticket {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.confirmation-ticket__header {
+  align-items: start;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.confirmation-ticket__header h3,
+.confirmation-ticket__header p {
+  margin: 0;
+}
+
+.confirmation-ticket__header h3 {
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.confirmation-ticket__header p {
+  color: var(--color-muted);
+  font-weight: 750;
+  margin-top: 4px;
+}
+
+.confirmation-ticket__header span {
+  background: #ffffff;
+  border: 1px dashed var(--color-border);
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 13px;
+  font-weight: 850;
+  padding: 8px 10px;
+  white-space: nowrap;
+}
+
 .movie-detail-loading__poster,
 .movie-detail-loading .skeleton-line {
   animation: skeleton-pulse 1300ms ease-in-out infinite;
@@ -1316,6 +1524,20 @@ h1 {
 
   .order-summary {
     min-height: 0;
+  }
+
+  .checkout-review__heading,
+  .confirmation-tickets__heading,
+  .confirmation-ticket__header {
+    grid-template-columns: 1fr;
+  }
+
+  .checkout-review__item {
+    grid-template-columns: 1fr;
+  }
+
+  .checkout-review__submit {
+    justify-self: stretch;
   }
 
   .movie-detail__action-panel .button {

--- a/frontend/src/components/reservations/CheckoutConfirmation.tsx
+++ b/frontend/src/components/reservations/CheckoutConfirmation.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+
+import { StateMessage } from "@/components/ui/StateMessage";
+import { useReservation } from "@/contexts/ReservationContext";
+import { formatCurrency, formatDateTime } from "@/utils/formatters";
+
+import {
+  paymentMethodLabels,
+  ticketTypeLabels,
+} from "./order-summary";
+
+export function CheckoutConfirmation() {
+  const { checkoutResult } = useReservation();
+
+  if (!checkoutResult || checkoutResult.tickets.length === 0) {
+    return (
+      <StateMessage
+        action={
+          <Link className="button button-primary" href="/">
+            Voltar ao catálogo
+          </Link>
+        }
+        title="Nenhum ingresso em memória"
+      >
+        Finalize uma compra para visualizar a confirmação nesta sessão.
+      </StateMessage>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="ingressos-gerados"
+      className="confirmation-tickets"
+    >
+      <div className="confirmation-tickets__heading">
+        <div>
+          <h2 id="ingressos-gerados">Compra confirmada</h2>
+          <p>
+            {checkoutResult.tickets.length} ingresso
+            {checkoutResult.tickets.length === 1 ? "" : "s"} gerado
+            {checkoutResult.tickets.length === 1 ? "" : "s"} com pagamento em{" "}
+            {paymentMethodLabels[checkoutResult.payment_method]}.
+          </p>
+        </div>
+        <strong>{formatCurrency(Number(checkoutResult.total_amount))}</strong>
+      </div>
+
+      <div className="confirmation-tickets__list">
+        {checkoutResult.tickets.map((ticket) => (
+          <article className="confirmation-ticket" key={ticket.ticket_id}>
+            <div className="confirmation-ticket__header">
+              <div>
+                <h3>{ticket.movie.title}</h3>
+                <p>{formatDateTime(ticket.session.start_time)}</p>
+              </div>
+              <span>{ticket.ticket_code}</span>
+            </div>
+
+            <dl className="confirmation-ticket__details">
+              <div>
+                <dt>Sala</dt>
+                <dd>{ticket.room.name}</dd>
+              </div>
+              <div>
+                <dt>Assento</dt>
+                <dd>{ticket.seat.identifier}</dd>
+              </div>
+              <div>
+                <dt>Ingresso</dt>
+                <dd>{ticketTypeLabels[ticket.ticket_type]}</dd>
+              </div>
+              <div>
+                <dt>Valor</dt>
+                <dd>{formatCurrency(Number(ticket.amount_paid))}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/reservations/CheckoutReview.tsx
+++ b/frontend/src/components/reservations/CheckoutReview.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { checkoutApi } from "@/api/checkout";
+import { catalogApi } from "@/api/catalog";
+import { StateMessage } from "@/components/ui/StateMessage";
+import { useReservation } from "@/contexts/ReservationContext";
+import type { CatalogSession } from "@/types/catalog";
+import type { PaymentMethod } from "@/types/reservation";
+import { formatCurrency, formatDateTime } from "@/utils/formatters";
+
+import {
+  buildCheckoutPayload,
+  getCheckoutErrorMessage,
+  getCheckoutSubmitBlocker,
+} from "./checkout-flow";
+import {
+  buildOrderSummaryItems,
+  calculateOrderTotal,
+  paymentMethodLabels,
+} from "./order-summary";
+
+type SessionDetailState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { errorMessage: string; status: "error" }
+  | { session: CatalogSession; status: "success" };
+
+const paymentMethods: PaymentMethod[] = ["cartao_credito", "pix"];
+
+export function CheckoutReview() {
+  const router = useRouter();
+  const reservation = useReservation();
+  const [sessionState, setSessionState] = useState<SessionDetailState>({
+    status: reservation.sessionId ? "loading" : "idle",
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const items = useMemo(
+    () =>
+      buildOrderSummaryItems(
+        reservation.reservedSeats,
+        reservation.ticketTypes
+      ),
+    [reservation.reservedSeats, reservation.ticketTypes]
+  );
+  const total = calculateOrderTotal(items);
+  const session =
+    sessionState.status === "success" ? sessionState.session : null;
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadSession(sessionId: string) {
+      setSessionState({ status: "loading" });
+
+      try {
+        const loadedSession = await catalogApi.getSession(sessionId);
+
+        if (isActive) {
+          setSessionState({ session: loadedSession, status: "success" });
+        }
+      } catch {
+        if (isActive) {
+          setSessionState({
+            errorMessage:
+              "Não conseguimos carregar os detalhes da sessão. Você ainda pode revisar os assentos selecionados.",
+            status: "error",
+          });
+        }
+      }
+    }
+
+    if (reservation.sessionId) {
+      void loadSession(reservation.sessionId);
+    } else {
+      setSessionState({ status: "idle" });
+    }
+
+    return () => {
+      isActive = false;
+    };
+  }, [reservation.sessionId]);
+
+  async function submitCheckout(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const blocker = getCheckoutSubmitBlocker({
+      paymentMethod: reservation.paymentMethod,
+      reservedSeats: reservation.reservedSeats,
+    });
+
+    if (blocker) {
+      setErrorMessage(blocker);
+      return;
+    }
+
+    const paymentMethod = reservation.paymentMethod;
+
+    if (!paymentMethod) {
+      setErrorMessage("Escolha uma forma de pagamento para finalizar a compra.");
+      return;
+    }
+
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      const payload = buildCheckoutPayload({
+        paymentMethod,
+        reservedSeats: reservation.reservedSeats,
+        ticketTypes: reservation.ticketTypes,
+      });
+      const checkoutResult = await checkoutApi.checkout(payload);
+
+      reservation.storeCheckoutResult(checkoutResult);
+      router.push("/confirmation");
+    } catch (error) {
+      setErrorMessage(getCheckoutErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="checkout-review" onSubmit={submitCheckout}>
+      <section aria-labelledby="revisao-pedido" className="checkout-review__panel">
+        <div className="checkout-review__heading">
+          <div>
+            <h2 id="revisao-pedido">Revise seu pedido</h2>
+            <p>
+              O total abaixo é informativo. A cobrança final é calculada pelo
+              sistema no momento da confirmação.
+            </p>
+          </div>
+          <strong>{formatCurrency(total)}</strong>
+        </div>
+
+        <dl className="checkout-review__session">
+          <div>
+            <dt>Filme</dt>
+            <dd>{session?.movie.title ?? "Filme indisponível"}</dd>
+          </div>
+          <div>
+            <dt>Sessão</dt>
+            <dd>
+              {session
+                ? formatDateTime(session.start_time)
+                : "Data e horário indisponíveis"}
+            </dd>
+          </div>
+          <div>
+            <dt>Sala</dt>
+            <dd>{session?.room.name ?? "Sala indisponível"}</dd>
+          </div>
+        </dl>
+
+        {sessionState.status === "loading" ? (
+          <p className="inline-status inline-status-info" role="status">
+            Carregando detalhes da sessão...
+          </p>
+        ) : null}
+
+        {sessionState.status === "error" ? (
+          <p className="inline-status inline-status-error" role="status">
+            {sessionState.errorMessage}
+          </p>
+        ) : null}
+
+        <div className="checkout-review__items" role="list">
+          {items.map((item) => (
+            <div
+              className="checkout-review__item"
+              key={item.seat.sessionSeatId}
+              role="listitem"
+            >
+              <div>
+                <span>Assento</span>
+                <strong>{item.seatLabel}</strong>
+              </div>
+              <div>
+                <span>Ingresso</span>
+                <strong>{item.ticketTypeLabel}</strong>
+              </div>
+              <div>
+                <span>Valor unitário</span>
+                <strong>{formatCurrency(item.unitPrice)}</strong>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="forma-pagamento"
+        className="checkout-review__panel"
+      >
+        <div className="checkout-review__heading">
+          <div>
+            <h2 id="forma-pagamento">Forma de pagamento</h2>
+            <p>Escolha como deseja concluir este pedido.</p>
+          </div>
+        </div>
+
+        <div className="payment-methods" role="radiogroup">
+          {paymentMethods.map((method) => (
+            <label className="payment-methods__option" key={method}>
+              <input
+                checked={reservation.paymentMethod === method}
+                disabled={isSubmitting}
+                name="payment_method"
+                onChange={() => {
+                  reservation.setPaymentMethod(method);
+                  setErrorMessage(null);
+                }}
+                type="radio"
+                value={method}
+              />
+              <span>
+                <strong>{paymentMethodLabels[method]}</strong>
+                <small>
+                  {method === "cartao_credito"
+                    ? "Finalize com cartão de crédito."
+                    : "Finalize com pagamento via PIX."}
+                </small>
+              </span>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      {errorMessage ? (
+        <StateMessage tone="error" title="Não foi possível finalizar">
+          {errorMessage}
+        </StateMessage>
+      ) : null}
+
+      <button
+        className="button button-primary checkout-review__submit"
+        disabled={isSubmitting}
+        type="submit"
+      >
+        {isSubmitting ? "Finalizando..." : "Confirmar compra"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/reservations/checkout-flow.test.ts
+++ b/frontend/src/components/reservations/checkout-flow.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ReservedSeat } from "@/types/reservation";
+
+import {
+  CHECKOUT_EMPTY_ORDER_MESSAGE,
+  CHECKOUT_PAYMENT_REQUIRED_MESSAGE,
+  buildCheckoutPayload,
+  getCheckoutSubmitBlocker,
+} from "./checkout-flow";
+
+const seats: ReservedSeat[] = [
+  {
+    basePrice: 42.5,
+    expiresAt: new Date("2026-05-22T21:40:00.000Z"),
+    isAccessible: false,
+    number: 7,
+    row: "B",
+    seatId: "seat-1",
+    sessionSeatId: "session-seat-1",
+  },
+  {
+    basePrice: 42.5,
+    expiresAt: new Date("2026-05-22T21:40:00.000Z"),
+    isAccessible: false,
+    number: 8,
+    row: "B",
+    seatId: "seat-2",
+    sessionSeatId: "session-seat-2",
+  },
+];
+
+test("buildCheckoutPayload submits only session seat IDs, ticket types, and payment method", () => {
+  const payload = buildCheckoutPayload({
+    paymentMethod: "pix",
+    reservedSeats: seats,
+    ticketTypes: {
+      "session-seat-1": "inteira",
+      "session-seat-2": "meia",
+    },
+  });
+
+  assert.deepEqual(payload, {
+    payment_method: "pix",
+    seats: [
+      {
+        session_seat_id: "session-seat-1",
+        ticket_type: "inteira",
+      },
+      {
+        session_seat_id: "session-seat-2",
+        ticket_type: "meia",
+      },
+    ],
+  });
+  assert.equal(Object.hasOwn(payload, "total_amount"), false);
+});
+
+test("buildCheckoutPayload falls back to inteira for missing ticket type state", () => {
+  const payload = buildCheckoutPayload({
+    paymentMethod: "cartao_credito",
+    reservedSeats: [seats[0]],
+    ticketTypes: {},
+  });
+
+  assert.deepEqual(payload.seats, [
+    {
+      session_seat_id: "session-seat-1",
+      ticket_type: "inteira",
+    },
+  ]);
+});
+
+test("getCheckoutSubmitBlocker requires seats and a selected payment method", () => {
+  assert.equal(
+    getCheckoutSubmitBlocker({
+      paymentMethod: "pix",
+      reservedSeats: [],
+    }),
+    CHECKOUT_EMPTY_ORDER_MESSAGE
+  );
+  assert.equal(
+    getCheckoutSubmitBlocker({
+      paymentMethod: null,
+      reservedSeats: [seats[0]],
+    }),
+    CHECKOUT_PAYMENT_REQUIRED_MESSAGE
+  );
+  assert.equal(
+    getCheckoutSubmitBlocker({
+      paymentMethod: "cartao_credito",
+      reservedSeats: [seats[0]],
+    }),
+    null
+  );
+});

--- a/frontend/src/components/reservations/checkout-flow.ts
+++ b/frontend/src/components/reservations/checkout-flow.ts
@@ -1,0 +1,54 @@
+import { getApiErrorUserMessage } from "@/api/client";
+import { DEFAULT_TICKET_TYPE } from "@/contexts/reservation-state";
+import type {
+  CheckoutPayload,
+  PaymentMethod,
+  ReservedSeat,
+  TicketType,
+} from "@/types/reservation";
+
+export const CHECKOUT_PAYMENT_REQUIRED_MESSAGE =
+  "Escolha uma forma de pagamento para finalizar a compra.";
+
+export const CHECKOUT_EMPTY_ORDER_MESSAGE =
+  "Selecione ao menos um assento antes de finalizar a compra.";
+
+export function buildCheckoutPayload({
+  paymentMethod,
+  reservedSeats,
+  ticketTypes,
+}: {
+  paymentMethod: PaymentMethod;
+  reservedSeats: ReservedSeat[];
+  ticketTypes: Record<string, TicketType>;
+}): CheckoutPayload {
+  return {
+    payment_method: paymentMethod,
+    seats: reservedSeats.map((seat) => ({
+      session_seat_id: seat.sessionSeatId,
+      ticket_type: ticketTypes[seat.sessionSeatId] ?? DEFAULT_TICKET_TYPE,
+    })),
+  };
+}
+
+export function getCheckoutSubmitBlocker({
+  paymentMethod,
+  reservedSeats,
+}: {
+  paymentMethod: PaymentMethod | null;
+  reservedSeats: ReservedSeat[];
+}) {
+  if (reservedSeats.length === 0) {
+    return CHECKOUT_EMPTY_ORDER_MESSAGE;
+  }
+
+  if (!paymentMethod) {
+    return CHECKOUT_PAYMENT_REQUIRED_MESSAGE;
+  }
+
+  return null;
+}
+
+export function getCheckoutErrorMessage(error: unknown) {
+  return getApiErrorUserMessage(error);
+}

--- a/frontend/src/contexts/ReservationContext.tsx
+++ b/frontend/src/contexts/ReservationContext.tsx
@@ -20,9 +20,11 @@ import {
   resetReservation as getResetReservationState,
   setReservationPaymentMethod,
   setReservationTicketType,
+  storeCheckoutResult as getStoredCheckoutResultState,
   type ReservationState,
 } from "./reservation-state";
 import type {
+  CheckoutResponse,
   PaymentMethod,
   ReservedSeat,
   TicketType,
@@ -39,6 +41,7 @@ type ReservationContextValue = ReservationState & {
   resetReservation: () => void;
   setPaymentMethod: (method: PaymentMethod) => void;
   setTicketType: (sessionSeatId: string, type: TicketType) => void;
+  storeCheckoutResult: (checkoutResult: CheckoutResponse) => void;
 };
 
 const ReservationContext = createContext<ReservationContextValue | null>(null);
@@ -96,6 +99,10 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
     setState(getResetReservationState());
   }, []);
 
+  const storeCheckoutResult = useCallback((checkoutResult: CheckoutResponse) => {
+    setState(getStoredCheckoutResultState(checkoutResult));
+  }, []);
+
   const expireReservation = useCallback(
     (message = RESERVATION_EXPIRED_MESSAGE) => {
       setState((currentState) => getExpiredReservationState(currentState, message));
@@ -128,6 +135,7 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
       resetReservation,
       setPaymentMethod,
       setTicketType,
+      storeCheckoutResult,
     }),
     [
       addSeats,
@@ -137,6 +145,7 @@ export function ReservationProvider({ children }: { children: ReactNode }) {
       resetReservation,
       setPaymentMethod,
       setTicketType,
+      storeCheckoutResult,
       state,
     ]
   );

--- a/frontend/src/contexts/reservation-state.test.ts
+++ b/frontend/src/contexts/reservation-state.test.ts
@@ -12,6 +12,7 @@ import {
   resetReservation,
   setReservationPaymentMethod,
   setReservationTicketType,
+  storeCheckoutResult,
 } from "./reservation-state";
 
 const firstSeat: ReservedSeat = {
@@ -36,6 +37,7 @@ const secondSeat: ReservedSeat = {
 
 test("reservation state starts without persisted purchase data", () => {
   assert.deepEqual(initialReservationState, {
+    checkoutResult: null,
     expirationNotice: null,
     expiredSessionId: null,
     paymentMethod: null,
@@ -59,6 +61,20 @@ test("addSeats preserves seat identifiers and applies default ticket types", () 
   assert.equal(state.reservedSeats[0].seatId, "seat-1");
   assert.equal(state.ticketTypes["session-seat-1"], "inteira");
   assert.equal(state.reservationExpiresAt, firstSeat.expiresAt);
+});
+
+test("addSeats clears a previous in-memory checkout confirmation", () => {
+  const checkedOut = storeCheckoutResult({
+    payment_method: "pix",
+    seats: [],
+    status: "PURCHASED",
+    tickets: [],
+    total_amount: "0.00",
+  });
+  const state = addSeatsToReservation(checkedOut, [firstSeat], "session-1");
+
+  assert.equal(state.checkoutResult, null);
+  assert.deepEqual(state.reservedSeats, [firstSeat]);
 });
 
 test("addSeats can use a custom default ticket type and keeps the earliest expiration", () => {
@@ -154,6 +170,54 @@ test("resetReservation clears selected seats, ticket types, payment method, and 
 
   assert.notDeepEqual(state, initialReservationState);
   assert.deepEqual(resetReservation(), initialReservationState);
+});
+
+test("storeCheckoutResult keeps generated tickets in memory and clears active order state", () => {
+  const checkoutResult = {
+    payment_method: "pix" as const,
+    seats: [
+      {
+        amount_paid: "42.50",
+        number: 7,
+        row: "B",
+        seat_id: "seat-1",
+        session_seat_id: "session-seat-1",
+        status: "PURCHASED" as const,
+        ticket_type: "inteira" as const,
+      },
+    ],
+    status: "PURCHASED",
+    tickets: [
+      {
+        amount_paid: "42.50",
+        movie: { id: "movie-1", title: "O Filme" },
+        payment_method: "pix" as const,
+        room: { id: "room-1", name: "Sala 1" },
+        seat: {
+          id: "seat-1",
+          identifier: "B7",
+          number: 7,
+          row: "B",
+        },
+        seat_id: "seat-1",
+        session: {
+          end_time: "2026-05-22T23:00:00-03:00",
+          id: "session-1",
+          start_time: "2026-05-22T21:00:00-03:00",
+        },
+        session_seat_id: "session-seat-1",
+        ticket_code: "ABC123",
+        ticket_id: "ticket-1",
+        ticket_type: "inteira" as const,
+      },
+    ],
+    total_amount: "42.50",
+  };
+
+  assert.deepEqual(storeCheckoutResult(checkoutResult), {
+    ...initialReservationState,
+    checkoutResult,
+  });
 });
 
 test("expireReservation clears purchase flow data and keeps a transient notice", () => {

--- a/frontend/src/contexts/reservation-state.ts
+++ b/frontend/src/contexts/reservation-state.ts
@@ -1,10 +1,12 @@
 import type {
+  CheckoutResponse,
   PaymentMethod,
   ReservedSeat,
   TicketType,
 } from "@/types/reservation";
 
 export type ReservationState = {
+  checkoutResult: CheckoutResponse | null;
   expirationNotice: string | null;
   expiredSessionId: string | null;
   sessionId: string | null;
@@ -17,6 +19,7 @@ export type ReservationState = {
 export const DEFAULT_TICKET_TYPE: TicketType = "inteira";
 
 export const initialReservationState: ReservationState = {
+  checkoutResult: null,
   expirationNotice: null,
   expiredSessionId: null,
   paymentMethod: null,
@@ -49,6 +52,7 @@ export function addSeatsToReservation(
 
   return {
     ...state,
+    checkoutResult: null,
     expirationNotice: null,
     expiredSessionId: null,
     reservationExpiresAt: nextExpiresAt,
@@ -104,6 +108,15 @@ export function setReservationPaymentMethod(
   return {
     ...state,
     paymentMethod: method,
+  };
+}
+
+export function storeCheckoutResult(
+  checkoutResult: CheckoutResponse
+): ReservationState {
+  return {
+    ...initialReservationState,
+    checkoutResult,
   };
 }
 

--- a/frontend/src/types/reservation.ts
+++ b/frontend/src/types/reservation.ts
@@ -4,6 +4,63 @@ export type TicketType = "inteira" | "meia";
 
 export type PaymentMethod = "cartao_credito" | "pix";
 
+export type CheckoutSeatPayload = {
+  session_seat_id: string;
+  ticket_type: TicketType;
+};
+
+export type CheckoutPayload = {
+  seats: CheckoutSeatPayload[];
+  payment_method: PaymentMethod;
+};
+
+export type CheckoutSeatResponse = {
+  session_seat_id: string;
+  seat_id: string;
+  row: string;
+  number: number;
+  status: SessionSeatStatus;
+  ticket_type: TicketType;
+  amount_paid: string;
+};
+
+export type CheckoutTicketResponse = {
+  ticket_id: string;
+  ticket_code: string;
+  session_seat_id: string;
+  seat_id: string;
+  ticket_type: TicketType;
+  amount_paid: string;
+  payment_method: PaymentMethod;
+  movie: {
+    id: string;
+    title: string;
+  };
+  session: {
+    id: string;
+    start_time: string;
+    end_time: string;
+  };
+  room: {
+    id: string;
+    name: string;
+  };
+  seat: {
+    id: string;
+    row: string;
+    number: number;
+    identifier: string;
+  };
+};
+
+export type CheckoutResponse = {
+  status: string;
+  payment_method: PaymentMethod;
+  total_amount: string;
+  seats: CheckoutSeatResponse[];
+  tickets: CheckoutTicketResponse[];
+};
+
 export type SessionSeatMapItem = {
   session_seat_id: string;
   seat_id: string;


### PR DESCRIPTION
## Objective

Implement the authenticated checkout review and payment submission flow so users can review their reserved seats, select the API-supported payment method, submit the checkout payload, and land on confirmation with generated tickets kept in memory.

## What was done

### 1. Checkout API module

Added a typed checkout API module for `POST /api/v1/reservation/checkout/`:

- Added `checkoutApi.checkout()`.
- Added typed checkout payload and response models.
- Validated the response shape before returning it to the UI.

### 2. Checkout payload construction

Added a testable checkout payload builder that submits only API-authoritative fields:

- `session_seat_id`
- `ticket_type`
- `payment_method`

The frontend does not send `total_amount` by default.

### 3. Checkout review page

Replaced the placeholder `/checkout` content with a full pt-BR review flow:

- movie title when session details are available
- session date/time when available
- room when available
- selected seats
- ticket type per seat
- unit price per seat
- informational total amount

### 4. Payment method selection

Added payment selection for the backend-supported methods:

- `cartao_credito`
- `pix`

The selected payment method is stored in shared reservation state.

### 5. Checkout submission flow

Implemented confirmation behavior:

- disables the submit action while pending
- shows loading text while submitting
- derives friendly pt-BR messages from API error codes
- preserves recoverable reservation state after failures
- stores generated tickets in memory after success
- redirects to `/confirmation` on success

### 6. Confirmation memory state

Extended shared reservation state to keep the latest checkout result in memory only.

The confirmation page now renders generated ticket details from that in-memory result, including movie, session, room, seat, ticket type, amount paid, payment method, and ticket code.

### 7. Styling and responsive layout

Added checkout and confirmation styles that match the existing frontend patterns:

- review panels
- payment method radio options
- selected-ticket rows
- confirmation ticket cards
- responsive stacking for smaller viewports

### 8. Automated test coverage

Added and updated frontend tests for:

- checkout API endpoint and authenticated request
- payload shape
- no-total rule
- payment method validation/blocking
- backend error code preservation for friendly messages
- in-memory checkout result storage
- generated ticket state after success

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

## Acceptance Criteria

- Checkout API: typed checkout API posts to `/api/v1/reservation/checkout/`.
- Payload Shape: payload includes `seats[].session_seat_id`, `seats[].ticket_type`, and `payment_method`.
- No Total Amount: frontend does not send `total_amount` by default.
- Review Details: checkout displays selected seats, ticket types, unit prices, and total.
- Payment Methods: users can select `cartao_credito` or `pix`.
- Submit Loading: confirmation action is disabled and shows loading while submitting.
- Success Redirect: successful checkout stores generated tickets in memory and redirects to `/confirmation`.
- Friendly Errors: API failures display pt-BR messages derived from `error.code`.
- State Preservation: recoverable checkout errors do not clear the current reservation state.
- Automated Tests: tests cover payload construction, no-total rule, payment method selection, success redirect state, and error behavior where practical.

## Expected Result

- Authenticated users can review a reserved order before checkout.
- The frontend submits the backend-authoritative checkout payload without client-side total manipulation.
- Recoverable checkout failures keep the current order intact.
- Successful checkout shows the generated tickets in memory on the confirmation page.
- Frontend automated validation passes.

closes #110
