### PR TITLE
feat: implement ticket type selection flow

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1191,6 +1191,182 @@ h1 {
   width: 100%;
 }
 
+.ticket-types {
+  display: grid;
+  gap: 18px;
+}
+
+.ticket-types__panel {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.ticket-types__heading {
+  align-items: start;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.ticket-types__heading h2,
+.ticket-types__heading p {
+  margin: 0;
+}
+
+.ticket-types__heading h2 {
+  font-size: 21px;
+  line-height: 1.25;
+}
+
+.ticket-types__heading p {
+  color: var(--color-muted);
+  line-height: 1.5;
+  margin-top: 6px;
+}
+
+.ticket-types__heading > strong {
+  color: var(--color-brand);
+  font-size: 20px;
+  white-space: nowrap;
+}
+
+.ticket-types__list {
+  display: grid;
+  gap: 12px;
+}
+
+.ticket-types__seat {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  min-width: 0;
+  padding: 14px;
+}
+
+.ticket-types__seat legend {
+  display: grid;
+  gap: 3px;
+  margin: 0 0 10px;
+  padding: 0;
+}
+
+.ticket-types__seat legend span,
+.ticket-types__seat legend small,
+.ticket-types__voucher span {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.ticket-types__seat legend strong {
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.ticket-types__options {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ticket-types__option {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  min-height: 74px;
+  padding: 12px;
+}
+
+.ticket-types__option:has(input:checked) {
+  background: #fff8df;
+  border-color: #d8a907;
+}
+
+.ticket-types__option input {
+  height: 18px;
+  width: 18px;
+}
+
+.ticket-types__option span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ticket-types__option strong,
+.ticket-types__option small {
+  overflow-wrap: anywhere;
+}
+
+.ticket-types__option small {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.ticket-types__option b {
+  font-size: 15px;
+  white-space: nowrap;
+}
+
+.ticket-types__voucher {
+  display: grid;
+  gap: 8px;
+}
+
+.ticket-types__voucher input {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  min-height: 46px;
+  padding: 10px 12px;
+  width: 100%;
+}
+
+.ticket-types__footer {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 16px 20px;
+}
+
+.ticket-types__footer div {
+  display: grid;
+  gap: 4px;
+}
+
+.ticket-types__footer span {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.ticket-types__footer strong {
+  color: var(--color-brand);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
 .checkout-review {
   display: grid;
   gap: 18px;
@@ -1527,6 +1703,7 @@ h1 {
   }
 
   .checkout-review__heading,
+  .ticket-types__heading,
   .confirmation-tickets__heading,
   .confirmation-ticket__header {
     grid-template-columns: 1fr;
@@ -1536,8 +1713,17 @@ h1 {
     grid-template-columns: 1fr;
   }
 
+  .ticket-types__options,
+  .ticket-types__footer {
+    grid-template-columns: 1fr;
+  }
+
   .checkout-review__submit {
     justify-self: stretch;
+  }
+
+  .ticket-types__continue {
+    width: 100%;
   }
 
   .movie-detail__action-panel .button {

--- a/frontend/src/app/ticket-types/page.tsx
+++ b/frontend/src/app/ticket-types/page.tsx
@@ -1,16 +1,15 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PurchaseFlowLayout } from "@/components/reservations/PurchaseFlowLayout";
 import { PurchaseFlowGuard } from "@/components/reservations/PurchaseFlowGuard";
+import { TicketTypeSelection } from "@/components/reservations/TicketTypeSelection";
 import { PageSection } from "@/components/ui/PageSection";
-import { StateMessage } from "@/components/ui/StateMessage";
-import { formatCurrency } from "@/utils/formatters";
 
 export default function TicketTypeSelectionPage() {
   return (
     <ProtectedRoute>
       <PurchaseFlowGuard>
         <PageSection
-          description={`Escolha entre inteira e meia-entrada. A exibição de valores já usa o padrão ${formatCurrency(42.5)}.`}
+          description="Defina o tipo de ingresso para cada assento reservado e acompanhe o subtotal antes do pagamento."
           eyebrow="Ingressos"
           title="Tipos de ingresso"
         >
@@ -19,28 +18,7 @@ export default function TicketTypeSelectionPage() {
             summaryActionHref="/checkout"
             summaryActionLabel="Ir para pagamento"
           >
-            <div className="panel-grid">
-              <article className="panel">
-                <h2 className="panel-title">Inteira</h2>
-                <p className="panel-copy">Valor cheio da sessão selecionada.</p>
-              </article>
-              <article className="panel">
-                <h2 className="panel-title">Meia-entrada</h2>
-                <p className="panel-copy">
-                  Metade do valor base, conforme regras aplicáveis.
-                </p>
-              </article>
-              <article className="panel">
-                <h2 className="panel-title">Cupom</h2>
-                <p className="panel-copy">
-                  Campo preparado para validação em etapa futura.
-                </p>
-              </article>
-            </div>
-            <StateMessage tone="loading" title="Seleção de assentos necessária">
-              Os tipos de ingresso serão calculados depois que os assentos forem
-              reservados.
-            </StateMessage>
+            <TicketTypeSelection />
           </PurchaseFlowLayout>
         </PageSection>
       </PurchaseFlowGuard>

--- a/frontend/src/components/movies/movie-detail.test.ts
+++ b/frontend/src/components/movies/movie-detail.test.ts
@@ -29,7 +29,6 @@ const movie: CatalogMovieDetail = {
 test("movie detail renders backend movie fields with accessible media", () => {
   const html = renderToStaticMarkup(
     createElement(MovieDetailView, {
-      movieId: movie.id,
       state: {
         movie,
         status: "success",

--- a/frontend/src/components/reservations/TicketTypeSelection.tsx
+++ b/frontend/src/components/reservations/TicketTypeSelection.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { useReservation } from "@/contexts/ReservationContext";
+import type { ReservedSeat, TicketType } from "@/types/reservation";
+import { formatCurrency } from "@/utils/formatters";
+
+import {
+  buildTicketTypeSelectionRows,
+  calculateTicketTypeSubtotal,
+  ticketTypeOptions,
+} from "./ticket-type-selection";
+
+type TicketTypeSelectionFormProps = {
+  onTicketTypeChange: (sessionSeatId: string, type: TicketType) => void;
+  reservedSeats: ReservedSeat[];
+  ticketTypes: Record<string, TicketType>;
+};
+
+export function TicketTypeSelection() {
+  const reservation = useReservation();
+
+  return (
+    <TicketTypeSelectionForm
+      onTicketTypeChange={reservation.setTicketType}
+      reservedSeats={reservation.reservedSeats}
+      ticketTypes={reservation.ticketTypes}
+    />
+  );
+}
+
+export function TicketTypeSelectionForm({
+  onTicketTypeChange,
+  reservedSeats,
+  ticketTypes,
+}: TicketTypeSelectionFormProps) {
+  const [voucherCode, setVoucherCode] = useState("");
+  const rows = useMemo(
+    () => buildTicketTypeSelectionRows(reservedSeats, ticketTypes),
+    [reservedSeats, ticketTypes]
+  );
+  const subtotal = calculateTicketTypeSubtotal(rows);
+
+  return (
+    <div className="ticket-types">
+      <section
+        aria-labelledby="ticket-types-heading"
+        className="ticket-types__panel"
+      >
+        <div className="ticket-types__heading">
+          <div>
+            <h2 id="ticket-types-heading">Ingressos por assento</h2>
+            <p>
+              Escolha inteira ou meia-entrada para cada lugar reservado antes de
+              avançar ao pagamento.
+            </p>
+          </div>
+          <strong>{formatCurrency(subtotal)}</strong>
+        </div>
+
+        <div className="ticket-types__list" role="list">
+          {rows.map((row) => (
+            <fieldset
+              className="ticket-types__seat"
+              key={row.seat.sessionSeatId}
+              role="listitem"
+            >
+              <legend>
+                <span>Assento</span>
+                <strong>{row.seatLabel}</strong>
+                <small>
+                  Fileira {row.seat.row}, assento {row.seat.number}
+                </small>
+              </legend>
+
+              <div className="ticket-types__options" role="radiogroup">
+                {ticketTypeOptions.map((option) => {
+                  const optionPrice =
+                    option.value === "meia" ? row.halfPrice : row.fullPrice;
+
+                  return (
+                    <label className="ticket-types__option" key={option.value}>
+                      <input
+                        checked={row.selectedTicketType === option.value}
+                        name={`ticket-type-${row.seat.sessionSeatId}`}
+                        onChange={() =>
+                          onTicketTypeChange(
+                            row.seat.sessionSeatId,
+                            option.value
+                          )
+                        }
+                        type="radio"
+                        value={option.value}
+                      />
+                      <span>
+                        <strong>{option.label}</strong>
+                        <small>{option.description}</small>
+                      </span>
+                      <b>{formatCurrency(optionPrice)}</b>
+                    </label>
+                  );
+                })}
+              </div>
+            </fieldset>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="voucher-heading" className="ticket-types__panel">
+        <div className="ticket-types__heading">
+          <div>
+            <h2 id="voucher-heading">Cupom</h2>
+            <p id="voucher-helper">
+              O cupom não altera o subtotal nesta versão.
+            </p>
+          </div>
+        </div>
+
+        <label className="ticket-types__voucher">
+          <span>Código promocional</span>
+          <input
+            aria-describedby="voucher-helper"
+            autoComplete="off"
+            name="voucher"
+            onChange={(event) => setVoucherCode(event.target.value)}
+            placeholder="Digite o cupom"
+            type="text"
+            value={voucherCode}
+          />
+        </label>
+      </section>
+
+      <div className="ticket-types__footer">
+        <div>
+          <span>Subtotal</span>
+          <strong>{formatCurrency(subtotal)}</strong>
+        </div>
+        <Link className="button button-primary ticket-types__continue" href="/checkout">
+          Continuar para pagamento
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reservations/ticket-type-selection.test.ts
+++ b/frontend/src/components/reservations/ticket-type-selection.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { ReservedSeat } from "@/types/reservation";
+import { formatCurrency } from "@/utils/formatters";
+
+import { TicketTypeSelectionForm } from "./TicketTypeSelection";
+import {
+  buildTicketTypeSelectionRows,
+  calculateTicketTypeSubtotal,
+} from "./ticket-type-selection";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const firstSeat: ReservedSeat = {
+  basePrice: 42.5,
+  expiresAt: new Date("2026-05-22T21:40:00.000Z"),
+  isAccessible: false,
+  number: 7,
+  row: "B",
+  seatId: "seat-1",
+  sessionSeatId: "session-seat-1",
+};
+
+const secondSeat: ReservedSeat = {
+  ...firstSeat,
+  number: 8,
+  seatId: "seat-2",
+  sessionSeatId: "session-seat-2",
+};
+
+test("ticket type selection rows list seats and calculate full and half prices", () => {
+  const rows = buildTicketTypeSelectionRows(
+    [firstSeat, secondSeat],
+    {
+      "session-seat-1": "inteira",
+      "session-seat-2": "meia",
+    }
+  );
+
+  assert.deepEqual(
+    rows.map((row) => ({
+      fullPrice: row.fullPrice,
+      halfPrice: row.halfPrice,
+      seatLabel: row.seatLabel,
+      selectedTicketType: row.selectedTicketType,
+      unitPrice: row.unitPrice,
+    })),
+    [
+      {
+        fullPrice: 42.5,
+        halfPrice: 21.25,
+        seatLabel: "B7",
+        selectedTicketType: "inteira",
+        unitPrice: 42.5,
+      },
+      {
+        fullPrice: 42.5,
+        halfPrice: 21.25,
+        seatLabel: "B8",
+        selectedTicketType: "meia",
+        unitPrice: 21.25,
+      },
+    ]
+  );
+  assert.equal(calculateTicketTypeSubtotal(rows), 63.75);
+});
+
+test("ticket type selection defaults missing state to full price", () => {
+  const rows = buildTicketTypeSelectionRows([firstSeat], {});
+
+  assert.equal(rows[0].selectedTicketType, "inteira");
+  assert.equal(calculateTicketTypeSubtotal(rows), 42.5);
+});
+
+test("ticket type selection form renders seats, options, voucher field, and subtotal", () => {
+  const html = renderToStaticMarkup(
+    createElement(TicketTypeSelectionForm, {
+      onTicketTypeChange: () => undefined,
+      reservedSeats: [firstSeat, secondSeat],
+      ticketTypes: {
+        "session-seat-1": "inteira",
+        "session-seat-2": "meia",
+      },
+    })
+  );
+
+  assert.match(html, /Ingressos por assento/);
+  assert.match(html, /Assento/);
+  assert.match(html, /B7/);
+  assert.match(html, /Fileira B, assento 7/);
+  assert.match(html, /B8/);
+  assert.match(html, /Inteira/);
+  assert.match(html, /Meia-entrada/);
+  assert.match(html, /Código promocional/);
+  assert.match(html, /O cupom não altera o subtotal nesta versão/);
+  assert.match(html, /Continuar para pagamento/);
+  assert.match(html, new RegExp(escapeRegExp(formatCurrency(63.75))));
+});
+
+test("voucher input is present without validation or discount controls", () => {
+  const html = renderToStaticMarkup(
+    createElement(TicketTypeSelectionForm, {
+      onTicketTypeChange: () => undefined,
+      reservedSeats: [firstSeat],
+      ticketTypes: {
+        "session-seat-1": "inteira",
+      },
+    })
+  );
+
+  assert.match(html, /name="voucher"/);
+  assert.match(html, new RegExp(escapeRegExp(formatCurrency(42.5))));
+  assert.doesNotMatch(html, /Aplicar cupom|Validar cupom|Desconto/);
+});
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/frontend/src/components/reservations/ticket-type-selection.ts
+++ b/frontend/src/components/reservations/ticket-type-selection.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_TICKET_TYPE } from "@/contexts/reservation-state";
+import type { ReservedSeat, TicketType } from "@/types/reservation";
+
+import {
+  calculateOrderTotal,
+  calculateTicketUnitPrice,
+  formatSeatLabel,
+  ticketTypeLabels,
+} from "./order-summary";
+
+export type TicketTypeOption = {
+  description: string;
+  label: string;
+  value: TicketType;
+};
+
+export type TicketTypeSelectionRow = {
+  fullPrice: number;
+  halfPrice: number;
+  seat: ReservedSeat;
+  seatLabel: string;
+  selectedTicketType: TicketType;
+  unitPrice: number;
+};
+
+export const ticketTypeOptions: TicketTypeOption[] = [
+  {
+    description: "Valor integral da sessão",
+    label: ticketTypeLabels.inteira,
+    value: "inteira",
+  },
+  {
+    description: "50% do valor integral",
+    label: ticketTypeLabels.meia,
+    value: "meia",
+  },
+];
+
+export function buildTicketTypeSelectionRows(
+  reservedSeats: ReservedSeat[],
+  ticketTypes: Record<string, TicketType>
+): TicketTypeSelectionRow[] {
+  return reservedSeats.map((seat) => {
+    const selectedTicketType =
+      ticketTypes[seat.sessionSeatId] ?? DEFAULT_TICKET_TYPE;
+
+    return {
+      fullPrice: calculateTicketUnitPrice(seat.basePrice, "inteira"),
+      halfPrice: calculateTicketUnitPrice(seat.basePrice, "meia"),
+      seat,
+      seatLabel: formatSeatLabel(seat),
+      selectedTicketType,
+      unitPrice: calculateTicketUnitPrice(seat.basePrice, selectedTicketType),
+    };
+  });
+}
+
+export function calculateTicketTypeSubtotal(
+  rows: Pick<TicketTypeSelectionRow, "unitPrice">[]
+) {
+  return calculateOrderTotal(rows);
+}


### PR DESCRIPTION
## Objective

Implement the frontend ticket type selection flow so authenticated users with active reserved seats can choose full price or half price per seat, see subtotal updates immediately, and continue to checkout.

## What was done

### 1. Functional ticket type page

Replaced the placeholder `/ticket-types` content with a real selection experience:

- Lists every currently reserved seat.
- Shows row and seat number for each seat.
- Shows the selected seat identifier.
- Keeps the existing protected route and purchase flow guard wrappers.
- Provides a continue action to `/checkout`.

### 2. Ticket type options

Added support for the API ticket type values required by checkout:

- Full price: `inteira`
- Half price: `meia`

Half price is calculated as 50% of each reserved seat's `basePrice`, which is sourced from the session reservation state.

### 3. Shared reservation state updates

Changing a ticket type calls the shared reservation context update flow:

- `reservation.setTicketType(sessionSeatId, type)`
- `ticketTypes` remains keyed by `sessionSeatId`
- checkout payload generation continues to consume the same shared state

### 4. Immediate subtotal updates

Added ticket type selection helpers that calculate:

- full price per seat
- half price per seat
- selected unit price per seat
- subtotal for the current ticket type selection

The visible page subtotal and existing order summary update as soon as the user changes a ticket type.

### 5. Voucher input

Added a coupon/voucher input to the UI.

This version intentionally does not:

- validate coupons
- apply discounts
- alter totals
- alter the checkout payload

### 6. Flow guard behavior

The route continues to use the existing flow protections:

- authentication through `ProtectedRoute`
- active reservation requirement through `PurchaseFlowGuard`
- at least one reserved seat requirement
- expired reservation blocking/reset behavior with a clear Portuguese message

### 7. Styling

Added responsive styles for the ticket type selection experience:

- seat-level option groups
- selected radio option states
- voucher input
- subtotal footer
- mobile-friendly one-column layout

### 8. Automated test coverage

Added test coverage for the new ticket type flow:

- seat rows are built from reserved seats
- `inteira` and `meia` prices are calculated correctly
- subtotal calculation updates based on selected ticket types
- missing ticket type state defaults safely to `inteira`
- voucher input is present and does not expose validation/discount behavior
- rendered UI includes seats, options, subtotal, voucher field, and continue action

Also fixed an existing TypeScript test issue in `movie-detail.test.ts`, where `MovieDetailView` was receiving an unsupported `movieId` prop.

## Acceptance Criteria

- Protected Route: `/ticket-types` remains wrapped by `ProtectedRoute`.
- Reservation Required: users without active reserved seats are blocked by `PurchaseFlowGuard`.
- Seat List: each reserved seat is listed with row and number.
- Ticket Options: each seat supports `inteira` and `meia`.
- State Update: changing a ticket type updates shared reservation state.
- Subtotal Update: subtotal updates immediately from shared ticket type state.
- Voucher Field: coupon input is present and non-validating.
- Continue Action: valid selections can navigate to `/checkout`.
- Expiration Safety: expired reservations are reset/blocked by the existing guard with a clear pt-BR message.
- Automated Tests: tests cover selection rows, subtotal calculation, guard behavior through existing guard tests, and voucher non-validation.

## How to test

### Automated validation

Run the frontend validation suite:

```bash
cd frontend
npm run lint
npx tsc --noEmit
npm test
npm run build
```

### Manual validation

1. Start the frontend and backend normally.
2. Log in with an authenticated user.
3. Select a movie session.
4. Reserve one or more seats.
5. Navigate to `/ticket-types`.
6. Validate the main expected behaviors:

- all reserved seats appear with row and number
- each seat offers `Inteira` and `Meia-entrada`
- selecting `Meia-entrada` changes that seat to 50% of the session base price
- subtotal updates immediately
- coupon input accepts text but does not validate or discount
- continue action navigates to `/checkout`
- opening `/ticket-types` without reserved seats shows the safe reservation-required state
- expired reservations are blocked/reset with the existing pt-BR message

## Expected Result

- Authenticated users with active reserved seats can choose ticket types per seat.
- Frontend subtotals update immediately and remain informational only.
- Coupon UI is present without backend validation or checkout payload changes.
- The checkout flow receives the selected ticket types through existing shared reservation state.
- Invalid or expired reservation access is safely blocked.
- Frontend lint, typecheck, tests, and production build pass.

closes #109
