### PR TITLE
feat: implement my tickets list and filters

### DIFF
--- a/frontend/src/api/tickets.test.ts
+++ b/frontend/src/api/tickets.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiError } from "./client";
+import { ticketsApi } from "./tickets";
+
+const ticketsResponse = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [
+    {
+      amount_paid: "21.25",
+      created_at: "2026-05-22T20:20:00-03:00",
+      movie: {
+        id: "movie-1",
+        poster_url: "https://cdn.example.com/movie.jpg",
+        title: "A Jornada",
+      },
+      payment_method: "pix",
+      room: {
+        id: "room-1",
+        name: "Sala 1",
+      },
+      seat: {
+        id: "seat-1",
+        identifier: "A1",
+        number: 1,
+        row: "A",
+      },
+      session: {
+        end_time: "2026-05-22T20:30:00-03:00",
+        id: "session-1",
+        start_time: "2026-05-22T18:30:00-03:00",
+      },
+      ticket_code: "ABC123",
+      ticket_id: "ticket-1",
+      ticket_type: "meia",
+    },
+  ],
+};
+
+test("ticketsApi lists authenticated user tickets through the canonical endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/users/me/tickets/");
+      assert.equal(init?.method, "GET");
+
+      return Response.json(ticketsResponse);
+    };
+
+    const response = await ticketsApi.listMyTickets();
+
+    assert.deepEqual(response, ticketsResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ticketsApi builds upcoming and past ticket filters", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  try {
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return Response.json({ ...ticketsResponse, results: [] });
+    };
+
+    await ticketsApi.listMyTickets({ type: "upcoming" });
+    await ticketsApi.listMyTickets({ type: "past" });
+
+    assert.deepEqual(requestedUrls, [
+      "http://localhost:8000/api/v1/users/me/tickets/?type=upcoming",
+      "http://localhost:8000/api/v1/users/me/tickets/?type=past",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ticketsApi surfaces backend error codes through ApiError", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          error: {
+            code: "NOT_AUTHENTICATED",
+            details: {},
+            message: "Authentication credentials were not provided.",
+            status: 401,
+          },
+        },
+        { status: 401 }
+      );
+
+    await assert.rejects(ticketsApi.listMyTickets(), (error) => {
+      assert.ok(error instanceof ApiError);
+      assert.equal(error.code, "NOT_AUTHENTICATED");
+      return true;
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ticketsApi rejects unexpected ticket list responses", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json({ ...ticketsResponse, results: [{ ticket_id: "ticket-1" }] });
+
+    await assert.rejects(
+      ticketsApi.listMyTickets(),
+      /Unexpected my tickets response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/tickets.ts
+++ b/frontend/src/api/tickets.ts
@@ -1,0 +1,114 @@
+import type { TicketFilterType, UserTicket } from "@/types/ticket";
+
+import {
+  apiRequest,
+  isPaginatedResponse,
+  type PaginatedResponse,
+} from "./client";
+
+export type ListMyTicketsParams = {
+  type?: TicketFilterType;
+};
+
+const MY_TICKETS_PATH = "/api/v1/users/me/tickets/";
+
+export const ticketsApi = {
+  listMyTickets(params: ListMyTicketsParams = {}, options: RequestInit = {}) {
+    return listMyTickets(params, options);
+  },
+};
+
+async function listMyTickets(
+  params: ListMyTicketsParams,
+  options: RequestInit
+) {
+  const response = await apiRequest<unknown>(buildMyTicketsPath(params), {
+    ...options,
+    auth: "required",
+    method: "GET",
+  });
+
+  if (
+    !isPaginatedResponse<UserTicket>(response) ||
+    !response.results.every(isUserTicket)
+  ) {
+    throw new Error("Unexpected my tickets response.");
+  }
+
+  return response satisfies PaginatedResponse<UserTicket>;
+}
+
+function buildMyTicketsPath({ type }: ListMyTicketsParams) {
+  const searchParams = new URLSearchParams();
+
+  if (type) {
+    searchParams.set("type", type);
+  }
+
+  const query = searchParams.toString();
+  return query ? `${MY_TICKETS_PATH}?${query}` : MY_TICKETS_PATH;
+}
+
+function isUserTicket(value: unknown): value is UserTicket {
+  return (
+    isRecord(value) &&
+    typeof value.ticket_id === "string" &&
+    typeof value.ticket_code === "string" &&
+    isTicketType(value.ticket_type) &&
+    typeof value.amount_paid === "string" &&
+    isPaymentMethod(value.payment_method) &&
+    typeof value.created_at === "string" &&
+    isTicketMovie(value.movie) &&
+    isTicketSession(value.session) &&
+    isTicketRoom(value.room) &&
+    isTicketSeat(value.seat)
+  );
+}
+
+function isTicketMovie(value: unknown): value is UserTicket["movie"] {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    (typeof value.poster_url === "string" || value.poster_url === null)
+  );
+}
+
+function isTicketSession(value: unknown): value is UserTicket["session"] {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.start_time === "string" &&
+    typeof value.end_time === "string"
+  );
+}
+
+function isTicketRoom(value: unknown): value is UserTicket["room"] {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string"
+  );
+}
+
+function isTicketSeat(value: unknown): value is UserTicket["seat"] {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.row === "string" &&
+    typeof value.number === "number" &&
+    typeof value.identifier === "string"
+  );
+}
+
+function isTicketType(value: unknown): value is UserTicket["ticket_type"] {
+  return value === "inteira" || value === "meia";
+}
+
+function isPaymentMethod(value: unknown): value is UserTicket["payment_method"] {
+  return value === "cartao_credito" || value === "pix";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1575,6 +1575,126 @@ h1 {
   white-space: nowrap;
 }
 
+.my-tickets {
+  display: grid;
+  gap: 16px;
+}
+
+.my-tickets__toolbar {
+  align-items: start;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 20px;
+}
+
+.my-tickets__toolbar h2,
+.my-tickets__toolbar p {
+  margin: 0;
+}
+
+.my-tickets__toolbar h2 {
+  font-size: 21px;
+  line-height: 1.25;
+}
+
+.my-tickets__toolbar p {
+  color: var(--color-muted);
+  line-height: 1.5;
+  margin-top: 6px;
+}
+
+.my-tickets__filters {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.my-tickets__list {
+  display: grid;
+  gap: 12px;
+}
+
+.my-ticket {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.my-ticket__header {
+  align-items: start;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.my-ticket__header h3,
+.my-ticket__header p {
+  margin: 0;
+}
+
+.my-ticket__header h3 {
+  font-size: 19px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.my-ticket__header p {
+  color: var(--color-muted);
+  font-weight: 750;
+  margin-top: 4px;
+}
+
+.my-ticket__header span {
+  background: #f8fafc;
+  border: 1px dashed var(--color-border);
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 13px;
+  font-weight: 850;
+  padding: 8px 10px;
+  white-space: nowrap;
+}
+
+.my-ticket__details {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin: 0;
+}
+
+.my-ticket__details div {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  display: grid;
+  gap: 4px;
+  min-height: 70px;
+  padding: 10px;
+}
+
+.my-ticket__details dt {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.my-ticket__details dd {
+  font-weight: 850;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 .movie-detail-loading__poster,
 .movie-detail-loading .skeleton-line {
   animation: skeleton-pulse 1300ms ease-in-out infinite;
@@ -1705,8 +1825,18 @@ h1 {
   .checkout-review__heading,
   .ticket-types__heading,
   .confirmation-tickets__heading,
-  .confirmation-ticket__header {
+  .confirmation-ticket__header,
+  .my-tickets__toolbar,
+  .my-ticket__header {
     grid-template-columns: 1fr;
+  }
+
+  .my-tickets__filters {
+    justify-content: flex-start;
+  }
+
+  .my-ticket__details {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .checkout-review__item {
@@ -1769,5 +1899,9 @@ h1 {
   .movie-detail__synopsis,
   .movie-detail__action-panel {
     padding: 18px;
+  }
+
+  .my-ticket__details {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/app/my-tickets/page.tsx
+++ b/frontend/src/app/my-tickets/page.tsx
@@ -1,4 +1,7 @@
+import { Suspense } from "react";
+
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { MyTicketsClient } from "@/components/tickets/MyTicketsClient";
 import { PageSection } from "@/components/ui/PageSection";
 import { StateMessage } from "@/components/ui/StateMessage";
 
@@ -10,9 +13,15 @@ export default function MyTicketsPage() {
         eyebrow="Conta"
         title="Meus ingressos"
       >
-        <StateMessage title="Nenhum ingresso carregado">
-          A lista de ingressos será conectada à conta do usuário.
-        </StateMessage>
+        <Suspense
+          fallback={
+            <StateMessage tone="loading" title="Carregando ingressos">
+              Aguarde enquanto preparamos seus filtros.
+            </StateMessage>
+          }
+        >
+          <MyTicketsClient />
+        </Suspense>
       </PageSection>
     </ProtectedRoute>
   );

--- a/frontend/src/components/tickets/MyTicketsClient.tsx
+++ b/frontend/src/components/tickets/MyTicketsClient.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useSearchParams } from "next/navigation";
+
+import { getApiErrorUserMessage } from "@/api/client";
+import { ticketsApi } from "@/api/tickets";
+import type { UserTicket } from "@/types/ticket";
+
+import {
+  getTicketFilterFromSearchParams,
+  MyTicketsContent,
+  type MyTicketsStatus,
+} from "./my-tickets";
+
+type MyTicketsState = {
+  errorMessage?: string;
+  status: MyTicketsStatus;
+  tickets: UserTicket[];
+};
+
+export function MyTicketsClient() {
+  const searchParams = useSearchParams();
+  const activeFilter = useMemo(
+    () => getTicketFilterFromSearchParams(searchParams),
+    [searchParams]
+  );
+  const [retryCount, setRetryCount] = useState(0);
+  const [state, setState] = useState<MyTicketsState>({
+    status: "loading",
+    tickets: [],
+  });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    setState({ status: "loading", tickets: [] });
+
+    ticketsApi
+      .listMyTickets(
+        activeFilter ? { type: activeFilter } : {},
+        { signal: abortController.signal }
+      )
+      .then((response) => {
+        setState({
+          status: "success",
+          tickets: response.results,
+        });
+      })
+      .catch((error: unknown) => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        setState({
+          errorMessage: getApiErrorUserMessage(error),
+          status: "error",
+          tickets: [],
+        });
+      });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [activeFilter, retryCount]);
+
+  const handleRetry = useCallback(() => {
+    setRetryCount((current) => current + 1);
+  }, []);
+
+  return (
+    <MyTicketsContent
+      activeFilter={activeFilter}
+      errorMessage={state.errorMessage}
+      onRetry={handleRetry}
+      status={state.status}
+      tickets={state.tickets}
+    />
+  );
+}

--- a/frontend/src/components/tickets/my-tickets.test.ts
+++ b/frontend/src/components/tickets/my-tickets.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { UserTicket } from "@/types/ticket";
+
+import {
+  getTicketFilterFromSearchParams,
+  MyTicketsContent,
+  TicketCard,
+} from "./my-tickets";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const ticket: UserTicket = {
+  amount_paid: "21.25",
+  created_at: "2026-05-22T20:20:00-03:00",
+  movie: {
+    id: "movie-1",
+    poster_url: "https://cdn.example.com/movie.jpg",
+    title: "A Jornada",
+  },
+  payment_method: "pix",
+  room: {
+    id: "room-1",
+    name: "Sala 1",
+  },
+  seat: {
+    id: "seat-1",
+    identifier: "A1",
+    number: 1,
+    row: "A",
+  },
+  session: {
+    end_time: "2026-05-22T20:30:00-03:00",
+    id: "session-1",
+    start_time: "2026-05-22T18:30:00-03:00",
+  },
+  ticket_code: "ABC123",
+  ticket_id: "ticket-1",
+  ticket_type: "meia",
+};
+
+test("getTicketFilterFromSearchParams accepts only shareable ticket filters", () => {
+  assert.equal(
+    getTicketFilterFromSearchParams(new URLSearchParams("type=upcoming")),
+    "upcoming"
+  );
+  assert.equal(
+    getTicketFilterFromSearchParams(new URLSearchParams("type=past")),
+    "past"
+  );
+  assert.equal(
+    getTicketFilterFromSearchParams(new URLSearchParams("type=archived")),
+    null
+  );
+});
+
+test("my tickets content renders active pt-BR filter links", () => {
+  const html = renderToStaticMarkup(
+    createElement(MyTicketsContent, {
+      activeFilter: "upcoming",
+      status: "success",
+      tickets: [ticket],
+    })
+  );
+
+  assert.match(html, /href="\/my-tickets"/);
+  assert.match(html, /href="\/my-tickets\?type=upcoming"/);
+  assert.match(html, /href="\/my-tickets\?type=past"/);
+  assert.match(html, /aria-current="page"[^>]*>Próximos/);
+});
+
+test("my tickets content renders loading, empty, and error states", () => {
+  const loadingHtml = renderToStaticMarkup(
+    createElement(MyTicketsContent, {
+      activeFilter: null,
+      status: "loading",
+      tickets: [],
+    })
+  );
+  const emptyHtml = renderToStaticMarkup(
+    createElement(MyTicketsContent, {
+      activeFilter: "past",
+      status: "success",
+      tickets: [],
+    })
+  );
+  const errorHtml = renderToStaticMarkup(
+    createElement(MyTicketsContent, {
+      activeFilter: null,
+      errorMessage: "Sua sessão expirou. Faça login novamente.",
+      status: "error",
+      tickets: [],
+    })
+  );
+
+  assert.match(loadingHtml, /Carregando ingressos/);
+  assert.match(emptyHtml, /Nenhum ingresso anterior/);
+  assert.match(emptyHtml, /Nenhum ingresso anterior foi encontrado/);
+  assert.match(errorHtml, /Ingressos indisponíveis/);
+  assert.match(errorHtml, /Sua sessão expirou/);
+});
+
+test("ticket card renders ticket details with Brazilian formatting", () => {
+  const html = renderToStaticMarkup(createElement(TicketCard, { ticket }));
+
+  assert.match(html, /A Jornada/);
+  assert.match(html, /22\/05\/2026, 18:30/);
+  assert.match(html, /Sala 1/);
+  assert.match(html, /A1/);
+  assert.match(html, /Meia-entrada/);
+  assert.match(html, /R\$\s?21,25/);
+  assert.match(html, /PIX/);
+  assert.match(html, /ABC123/);
+});

--- a/frontend/src/components/tickets/my-tickets.tsx
+++ b/frontend/src/components/tickets/my-tickets.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+
+import { StateMessage } from "@/components/ui/StateMessage";
+import type { TicketFilterType, UserTicket } from "@/types/ticket";
+import { formatCurrency, formatDateTime } from "@/utils/formatters";
+
+import {
+  paymentMethodLabels,
+  ticketTypeLabels,
+} from "../reservations/order-summary";
+
+export type MyTicketsStatus = "error" | "loading" | "success";
+
+export type MyTicketsContentProps = {
+  activeFilter: TicketFilterType | null;
+  errorMessage?: string;
+  onRetry?: () => void;
+  status: MyTicketsStatus;
+  tickets: UserTicket[];
+};
+
+const filterOptions: Array<{
+  href: string;
+  label: string;
+  value: TicketFilterType | null;
+}> = [
+  { href: "/my-tickets", label: "Todos", value: null },
+  { href: "/my-tickets?type=upcoming", label: "Próximos", value: "upcoming" },
+  { href: "/my-tickets?type=past", label: "Anteriores", value: "past" },
+];
+
+export function MyTicketsContent({
+  activeFilter,
+  errorMessage,
+  onRetry,
+  status,
+  tickets,
+}: MyTicketsContentProps) {
+  return (
+    <section aria-labelledby="meus-ingressos" className="my-tickets">
+      <div className="my-tickets__toolbar">
+        <div>
+          <h2 id="meus-ingressos">Ingressos da sua conta</h2>
+          <p>{filterDescriptionLabels[activeFilter ?? "all"]}</p>
+        </div>
+
+        <nav aria-label="Filtros de ingressos" className="my-tickets__filters">
+          {filterOptions.map((option) => {
+            const isActive = option.value === activeFilter;
+
+            return (
+              <Link
+                aria-current={isActive ? "page" : undefined}
+                className={`button ${
+                  isActive ? "button-secondary" : "button-ghost"
+                }`}
+                href={option.href}
+                key={option.label}
+              >
+                {option.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+
+      {status === "loading" ? (
+        <StateMessage tone="loading" title="Carregando ingressos">
+          Aguarde enquanto buscamos seus ingressos.
+        </StateMessage>
+      ) : null}
+
+      {status === "error" ? (
+        <StateMessage
+          action={
+            onRetry ? (
+              <button className="button button-primary" onClick={onRetry} type="button">
+                Tentar novamente
+              </button>
+            ) : null
+          }
+          tone="error"
+          title="Ingressos indisponíveis"
+        >
+          {errorMessage ?? "Não foi possível carregar seus ingressos agora."}
+        </StateMessage>
+      ) : null}
+
+      {status === "success" && tickets.length === 0 ? (
+        <StateMessage title={emptyStateLabels[activeFilter ?? "all"].title}>
+          {emptyStateLabels[activeFilter ?? "all"].description}
+        </StateMessage>
+      ) : null}
+
+      {status === "success" && tickets.length > 0 ? (
+        <div className="my-tickets__list">
+          {tickets.map((ticket) => (
+            <TicketCard key={ticket.ticket_id} ticket={ticket} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function TicketCard({ ticket }: { ticket: UserTicket }) {
+  return (
+    <article className="my-ticket">
+      <div className="my-ticket__header">
+        <div>
+          <h3>{ticket.movie.title}</h3>
+          <p>{formatDateTime(ticket.session.start_time)}</p>
+        </div>
+        <span>{ticket.ticket_code}</span>
+      </div>
+
+      <dl className="my-ticket__details">
+        <div>
+          <dt>Sala</dt>
+          <dd>{ticket.room.name}</dd>
+        </div>
+        <div>
+          <dt>Assento</dt>
+          <dd>{ticket.seat.identifier}</dd>
+        </div>
+        <div>
+          <dt>Ingresso</dt>
+          <dd>{ticketTypeLabels[ticket.ticket_type]}</dd>
+        </div>
+        <div>
+          <dt>Valor pago</dt>
+          <dd>{formatCurrency(Number(ticket.amount_paid))}</dd>
+        </div>
+        <div>
+          <dt>Pagamento</dt>
+          <dd>{paymentMethodLabels[ticket.payment_method]}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export function getTicketFilterFromSearchParams(
+  searchParams: Pick<URLSearchParams, "get">
+): TicketFilterType | null {
+  const type = searchParams.get("type");
+
+  if (type === "upcoming" || type === "past") {
+    return type;
+  }
+
+  return null;
+}
+
+const filterDescriptionLabels: Record<TicketFilterType | "all", string> = {
+  all: "Veja todos os ingressos comprados.",
+  past: "Exibindo sessões que já aconteceram.",
+  upcoming: "Exibindo sessões futuras.",
+};
+
+const emptyStateLabels: Record<
+  TicketFilterType | "all",
+  { description: string; title: string }
+> = {
+  all: {
+    description:
+      "Quando você finalizar uma compra, seus ingressos aparecerão aqui.",
+    title: "Você ainda não tem ingressos",
+  },
+  past: {
+    description: "Nenhum ingresso anterior foi encontrado para sua conta.",
+    title: "Nenhum ingresso anterior",
+  },
+  upcoming: {
+    description: "Nenhum ingresso futuro foi encontrado para sua conta.",
+    title: "Nenhum ingresso futuro",
+  },
+};

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -1,0 +1,32 @@
+import type { PaymentMethod, TicketType } from "./reservation";
+
+export type TicketFilterType = "upcoming" | "past";
+
+export type UserTicket = {
+  ticket_id: string;
+  ticket_code: string;
+  ticket_type: TicketType;
+  amount_paid: string;
+  payment_method: PaymentMethod;
+  created_at: string;
+  movie: {
+    id: string;
+    title: string;
+    poster_url: string | null;
+  };
+  session: {
+    id: string;
+    start_time: string;
+    end_time: string;
+  };
+  room: {
+    id: string;
+    name: string;
+  };
+  seat: {
+    id: string;
+    row: string;
+    number: number;
+    identifier: string;
+  };
+};


### PR DESCRIPTION
## Objective

Implement the authenticated My Tickets experience so users can view their purchased tickets and filter them by upcoming or past sessions using the existing user tickets API.

## What was done

### 1. Tickets API module

Added a typed frontend API module for the current user's tickets:

- `GET /api/v1/users/me/tickets/`
- optional `type=upcoming`
- optional `type=past`
- DRF paginated response handling through the existing `PaginatedResponse<T>` helper

The module validates the ticket payload shape before returning data to the UI.

### 2. My Tickets page

Replaced the `/my-tickets` placeholder with a functional authenticated page:

- fetches tickets for the authenticated user
- keeps the route wrapped in `ProtectedRoute`
- shows a stable loading state
- shows localized empty states
- shows friendly API failure messages derived from `error.code`

### 3. Ticket filters

Added shareable query-driven filters:

- all tickets: `/my-tickets`
- upcoming tickets: `/my-tickets?type=upcoming`
- past tickets: `/my-tickets?type=past`

The active filter is clearly indicated in the UI.

### 4. Ticket display

Added ticket cards rendering the required ticket details:

- movie title
- session date and time
- room
- seat identifier
- ticket type
- amount paid
- payment method
- ticket code

Dates, currency, payment methods, and ticket types reuse the existing Brazilian formatting and labels.

### 5. UI and responsive styling

Added styles for:

- filter toolbar
- ticket list
- ticket cards
- responsive detail grids for tablet and mobile widths

The page follows the existing app visual language and pt-BR labels.

### 6. Automated test coverage

Added frontend tests covering:

- tickets API endpoint construction
- `type=upcoming` and `type=past` query construction
- paginated ticket response validation
- backend error code propagation
- filter parsing and active filter rendering
- loading, empty, and error states
- ticket card rendering with Brazilian date and currency formatting

## Acceptance Criteria

- Tickets API: a typed tickets API function calls `/api/v1/users/me/tickets/`.
- Filter Query: the API supports `type=upcoming` and `type=past`.
- Protected Route: `/my-tickets` remains protected by authentication.
- Ticket List: authenticated users can view their tickets.
- Upcoming Filter: users can filter upcoming tickets.
- Past Filter: users can filter past tickets.
- Loading State: page shows a stable loading state while tickets load.
- Empty State: page shows clear pt-BR empty states when no tickets match.
- Error State: API failures show friendly messages derived from `error.code`.
- Formatting: dates, currency, payment methods, and ticket types use Brazilian formatting.
- Automated Tests: tests cover API query construction, filter behavior, loading/empty/error states, and ticket rendering.

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

## Expected Result

- Authenticated users can open `/my-tickets` and see purchased tickets.
- Users can switch between all, upcoming, and past tickets with shareable URLs.
- Empty and error states are localized for Brazil.
- Ticket details render with Brazilian date, currency, payment method, and ticket type labels.
- Frontend automated validation passes.

closes #111
