### PR TITLE
feat: render checkout confirmation tickets

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1419,14 +1419,12 @@ h1 {
   white-space: nowrap;
 }
 
-.checkout-review__session,
-.confirmation-ticket__details {
+.checkout-review__session {
   display: grid;
   gap: 10px;
 }
 
-.checkout-review__session div,
-.confirmation-ticket__details div {
+.checkout-review__session div {
   align-items: center;
   border-bottom: 1px solid var(--color-border);
   display: flex;
@@ -1435,15 +1433,13 @@ h1 {
   padding-bottom: 10px;
 }
 
-.checkout-review__session dt,
-.confirmation-ticket__details dt {
+.checkout-review__session dt {
   color: var(--color-muted);
   font-size: 14px;
   font-weight: 800;
 }
 
-.checkout-review__session dd,
-.confirmation-ticket__details dd {
+.checkout-review__session dd {
   font-weight: 850;
   margin: 0;
   text-align: right;
@@ -1532,47 +1528,9 @@ h1 {
   min-width: 190px;
 }
 
-.confirmation-ticket {
-  background: #f8fafc;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  display: grid;
-  gap: 14px;
-  padding: 16px;
-}
-
-.confirmation-ticket__header {
-  align-items: start;
-  display: grid;
-  gap: 12px;
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
-.confirmation-ticket__header h3,
-.confirmation-ticket__header p {
-  margin: 0;
-}
-
-.confirmation-ticket__header h3 {
-  font-size: 18px;
-  line-height: 1.25;
-}
-
-.confirmation-ticket__header p {
-  color: var(--color-muted);
-  font-weight: 750;
-  margin-top: 4px;
-}
-
-.confirmation-ticket__header span {
-  background: #ffffff;
-  border: 1px dashed var(--color-border);
-  border-radius: 6px;
-  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-  font-size: 13px;
-  font-weight: 850;
-  padding: 8px 10px;
-  white-space: nowrap;
+.confirmation-tickets__actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .my-tickets {
@@ -1621,6 +1579,7 @@ h1 {
   gap: 12px;
 }
 
+.ticket-card,
 .my-ticket {
   background: #ffffff;
   border: 1px solid var(--color-border);
@@ -1631,6 +1590,12 @@ h1 {
   padding: 18px;
 }
 
+.confirmation-tickets .ticket-card {
+  background: #f8fafc;
+  box-shadow: none;
+}
+
+.ticket-card__header,
 .my-ticket__header {
   align-items: start;
   display: grid;
@@ -1638,23 +1603,28 @@ h1 {
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
+.ticket-card__header h3,
+.ticket-card__header p,
 .my-ticket__header h3,
 .my-ticket__header p {
   margin: 0;
 }
 
+.ticket-card__header h3,
 .my-ticket__header h3 {
   font-size: 19px;
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
 
+.ticket-card__header p,
 .my-ticket__header p {
   color: var(--color-muted);
   font-weight: 750;
   margin-top: 4px;
 }
 
+.ticket-card__header span,
 .my-ticket__header span {
   background: #f8fafc;
   border: 1px dashed var(--color-border);
@@ -1666,13 +1636,19 @@ h1 {
   white-space: nowrap;
 }
 
+.confirmation-tickets .ticket-card__header span {
+  background: #ffffff;
+}
+
+.ticket-card__details,
 .my-ticket__details {
   display: grid;
   gap: 10px;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(138px, 1fr));
   margin: 0;
 }
 
+.ticket-card__details div,
 .my-ticket__details div {
   background: #f8fafc;
   border: 1px solid var(--color-border);
@@ -1683,16 +1659,69 @@ h1 {
   padding: 10px;
 }
 
+.confirmation-tickets .ticket-card__details div {
+  background: #ffffff;
+}
+
+.ticket-card__details dt,
 .my-ticket__details dt {
   color: var(--color-muted);
   font-size: 13px;
   font-weight: 800;
 }
 
+.ticket-card__details dd,
 .my-ticket__details dd {
   font-weight: 850;
   margin: 0;
   overflow-wrap: anywhere;
+}
+
+.ticket-card__visual-code {
+  align-items: center;
+  background: #ffffff;
+  border: 1px dashed var(--color-border);
+  border-radius: 6px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  padding: 12px;
+}
+
+.ticket-card__visual-code p {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 750;
+  line-height: 1.35;
+  margin: 0;
+  max-width: 220px;
+}
+
+.ticket-card__barcode {
+  align-items: flex-end;
+  display: flex;
+  gap: 2px;
+  height: 58px;
+  overflow: hidden;
+}
+
+.ticket-card__barcode-bar {
+  background: #111827;
+  border-radius: 1px;
+  display: block;
+  height: 100%;
+}
+
+.ticket-card__barcode-bar--narrow {
+  width: 3px;
+}
+
+.ticket-card__barcode-bar--medium {
+  width: 5px;
+}
+
+.ticket-card__barcode-bar--wide {
+  width: 8px;
 }
 
 .movie-detail-loading__poster,
@@ -1825,7 +1854,7 @@ h1 {
   .checkout-review__heading,
   .ticket-types__heading,
   .confirmation-tickets__heading,
-  .confirmation-ticket__header,
+  .ticket-card__header,
   .my-tickets__toolbar,
   .my-ticket__header {
     grid-template-columns: 1fr;
@@ -1835,8 +1864,8 @@ h1 {
     justify-content: flex-start;
   }
 
-  .my-ticket__details {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .ticket-card__visual-code {
+    grid-template-columns: 1fr;
   }
 
   .checkout-review__item {

--- a/frontend/src/components/reservations/CheckoutConfirmation.tsx
+++ b/frontend/src/components/reservations/CheckoutConfirmation.tsx
@@ -2,29 +2,37 @@
 
 import Link from "next/link";
 
+import { TicketCard } from "@/components/tickets/TicketCard";
 import { StateMessage } from "@/components/ui/StateMessage";
 import { useReservation } from "@/contexts/ReservationContext";
-import { formatCurrency, formatDateTime } from "@/utils/formatters";
+import type { CheckoutResponse } from "@/types/reservation";
+import { formatCurrency } from "@/utils/formatters";
 
-import {
-  paymentMethodLabels,
-  ticketTypeLabels,
-} from "./order-summary";
+import { paymentMethodLabels } from "./order-summary";
 
 export function CheckoutConfirmation() {
   const { checkoutResult } = useReservation();
 
+  return <CheckoutConfirmationContent checkoutResult={checkoutResult} />;
+}
+
+export function CheckoutConfirmationContent({
+  checkoutResult,
+}: {
+  checkoutResult: CheckoutResponse | null;
+}) {
   if (!checkoutResult || checkoutResult.tickets.length === 0) {
     return (
       <StateMessage
         action={
-          <Link className="button button-primary" href="/">
-            Voltar ao catálogo
+          <Link className="button button-primary" href="/my-tickets">
+            Ver meus ingressos
           </Link>
         }
-        title="Nenhum ingresso em memória"
+        title="Confirmação indisponível"
       >
-        Finalize uma compra para visualizar a confirmação nesta sessão.
+        Os dados desta confirmação ficam apenas na memória da sessão. Se a
+        página foi recarregada, consulte seus ingressos em Meus Ingressos.
       </StateMessage>
     );
   }
@@ -38,8 +46,8 @@ export function CheckoutConfirmation() {
         <div>
           <h2 id="ingressos-gerados">Compra confirmada</h2>
           <p>
-            {checkoutResult.tickets.length} ingresso
-            {checkoutResult.tickets.length === 1 ? "" : "s"} gerado
+            Sua compra foi concluída com sucesso. {checkoutResult.tickets.length}{" "}
+            ingresso{checkoutResult.tickets.length === 1 ? "" : "s"} gerado
             {checkoutResult.tickets.length === 1 ? "" : "s"} com pagamento em{" "}
             {paymentMethodLabels[checkoutResult.payment_method]}.
           </p>
@@ -49,35 +57,14 @@ export function CheckoutConfirmation() {
 
       <div className="confirmation-tickets__list">
         {checkoutResult.tickets.map((ticket) => (
-          <article className="confirmation-ticket" key={ticket.ticket_id}>
-            <div className="confirmation-ticket__header">
-              <div>
-                <h3>{ticket.movie.title}</h3>
-                <p>{formatDateTime(ticket.session.start_time)}</p>
-              </div>
-              <span>{ticket.ticket_code}</span>
-            </div>
-
-            <dl className="confirmation-ticket__details">
-              <div>
-                <dt>Sala</dt>
-                <dd>{ticket.room.name}</dd>
-              </div>
-              <div>
-                <dt>Assento</dt>
-                <dd>{ticket.seat.identifier}</dd>
-              </div>
-              <div>
-                <dt>Ingresso</dt>
-                <dd>{ticketTypeLabels[ticket.ticket_type]}</dd>
-              </div>
-              <div>
-                <dt>Valor</dt>
-                <dd>{formatCurrency(Number(ticket.amount_paid))}</dd>
-              </div>
-            </dl>
-          </article>
+          <TicketCard key={ticket.ticket_id} ticket={ticket} />
         ))}
+      </div>
+
+      <div className="confirmation-tickets__actions">
+        <Link className="button button-primary" href="/my-tickets">
+          Ir para Meus Ingressos
+        </Link>
       </div>
     </section>
   );

--- a/frontend/src/components/reservations/checkout-confirmation.test.ts
+++ b/frontend/src/components/reservations/checkout-confirmation.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TicketCard, buildDisplayOnlyBars } from "@/components/tickets/TicketCard";
+import type { CheckoutResponse } from "@/types/reservation";
+
+import { CheckoutConfirmationContent } from "./CheckoutConfirmation";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const checkoutResult: CheckoutResponse = {
+  payment_method: "pix",
+  seats: [
+    {
+      amount_paid: "42.50",
+      number: 7,
+      row: "B",
+      seat_id: "seat-1",
+      session_seat_id: "session-seat-1",
+      status: "PURCHASED",
+      ticket_type: "inteira",
+    },
+  ],
+  status: "PURCHASED",
+  tickets: [
+    {
+      amount_paid: "42.50",
+      movie: { id: "movie-1", title: "A Jornada" },
+      payment_method: "pix",
+      room: { id: "room-1", name: "Sala 1" },
+      seat: {
+        id: "seat-1",
+        identifier: "B7",
+        number: 7,
+        row: "B",
+      },
+      seat_id: "seat-1",
+      session: {
+        end_time: "2026-05-22T23:00:00-03:00",
+        id: "session-1",
+        start_time: "2026-05-22T21:00:00-03:00",
+      },
+      session_seat_id: "session-seat-1",
+      ticket_code: "ABC123",
+      ticket_id: "ticket-1",
+      ticket_type: "inteira",
+    },
+  ],
+  total_amount: "42.50",
+};
+
+test("ticket card renders generated ticket details and a display-only visual code", () => {
+  const html = renderToStaticMarkup(
+    createElement(TicketCard, { ticket: checkoutResult.tickets[0] })
+  );
+
+  assert.match(html, /A Jornada/);
+  assert.match(html, /22\/05\/2026, 21:00/);
+  assert.match(html, /Sala 1/);
+  assert.match(html, /B7/);
+  assert.match(html, /Inteira/);
+  assert.match(html, /R\$\s?42,50/);
+  assert.match(html, /PIX/);
+  assert.match(html, /ABC123/);
+  assert.match(html, /Representação visual do ingresso ABC123/);
+  assert.match(html, /ticket-card__barcode-bar/);
+});
+
+test("display-only bars are deterministic and do not encode fake ticket data", () => {
+  assert.deepEqual(buildDisplayOnlyBars("ABC123"), buildDisplayOnlyBars("ABC123"));
+  assert.notDeepEqual(buildDisplayOnlyBars("ABC123"), buildDisplayOnlyBars("XYZ987"));
+});
+
+test("checkout confirmation renders the success state and generated tickets", () => {
+  const html = renderToStaticMarkup(
+    createElement(CheckoutConfirmationContent, { checkoutResult })
+  );
+
+  assert.match(html, /Compra confirmada/);
+  assert.match(html, /Sua compra foi concluída com sucesso/);
+  assert.match(html, /1 ingresso gerado/);
+  assert.match(html, /R\$\s?42,50/);
+  assert.match(html, /A Jornada/);
+  assert.match(html, /ABC123/);
+  assert.match(html, /href="\/my-tickets"/);
+});
+
+test("checkout confirmation reload fallback guides users to my tickets without fake tickets", () => {
+  const html = renderToStaticMarkup(
+    createElement(CheckoutConfirmationContent, { checkoutResult: null })
+  );
+
+  assert.match(html, /Confirmação indisponível/);
+  assert.match(html, /página foi recarregada/);
+  assert.match(html, /href="\/my-tickets"/);
+  assert.doesNotMatch(html, /A Jornada/);
+  assert.doesNotMatch(html, /ABC123/);
+});

--- a/frontend/src/components/tickets/TicketCard.tsx
+++ b/frontend/src/components/tickets/TicketCard.tsx
@@ -1,0 +1,107 @@
+import { formatCurrency, formatDateTime } from "@/utils/formatters";
+
+import {
+  paymentMethodLabels,
+  ticketTypeLabels,
+} from "../reservations/order-summary";
+
+export type TicketCardTicket = {
+  amount_paid: string;
+  movie: {
+    title: string;
+  };
+  payment_method: keyof typeof paymentMethodLabels;
+  room: {
+    name: string;
+  };
+  seat: {
+    identifier: string;
+  };
+  session: {
+    start_time: string;
+  };
+  ticket_code: string;
+  ticket_type: keyof typeof ticketTypeLabels;
+};
+
+type TicketCardProps = {
+  ticket: TicketCardTicket;
+  showVisualCode?: boolean;
+};
+
+export function TicketCard({ showVisualCode = true, ticket }: TicketCardProps) {
+  return (
+    <article className="ticket-card">
+      <div className="ticket-card__header">
+        <div>
+          <h3>{ticket.movie.title}</h3>
+          <p>{formatDateTime(ticket.session.start_time)}</p>
+        </div>
+        <span>{ticket.ticket_code}</span>
+      </div>
+
+      <dl className="ticket-card__details">
+        <div>
+          <dt>Sessão</dt>
+          <dd>{formatDateTime(ticket.session.start_time)}</dd>
+        </div>
+        <div>
+          <dt>Sala</dt>
+          <dd>{ticket.room.name}</dd>
+        </div>
+        <div>
+          <dt>Assento</dt>
+          <dd>{ticket.seat.identifier}</dd>
+        </div>
+        <div>
+          <dt>Tipo</dt>
+          <dd>{ticketTypeLabels[ticket.ticket_type]}</dd>
+        </div>
+        <div>
+          <dt>Valor pago</dt>
+          <dd>{formatCurrency(Number(ticket.amount_paid))}</dd>
+        </div>
+        <div>
+          <dt>Pagamento</dt>
+          <dd>{paymentMethodLabels[ticket.payment_method]}</dd>
+        </div>
+        <div>
+          <dt>Código</dt>
+          <dd>{ticket.ticket_code}</dd>
+        </div>
+      </dl>
+
+      {showVisualCode ? (
+        <div className="ticket-card__visual-code">
+          <div
+            aria-label={`Representação visual do ingresso ${ticket.ticket_code}`}
+            className="ticket-card__barcode"
+            role="img"
+          >
+            {buildDisplayOnlyBars(ticket.ticket_code).map((bar, index) => (
+              <span
+                className={`ticket-card__barcode-bar ticket-card__barcode-bar--${bar}`}
+                key={`${ticket.ticket_code}-${index}`}
+              />
+            ))}
+          </div>
+          <p>Representação visual para conferência em tela.</p>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function buildDisplayOnlyBars(ticketCode: string) {
+  const source = ticketCode.trim() || "INGRESSO";
+  const bars: Array<"narrow" | "medium" | "wide"> = [];
+
+  for (const character of source) {
+    const value = character.charCodeAt(0);
+
+    bars.push(value % 2 === 0 ? "wide" : "narrow");
+    bars.push(value % 3 === 0 ? "medium" : "narrow");
+  }
+
+  return bars.slice(0, 28).concat(["wide", "narrow", "medium"]);
+}

--- a/frontend/src/components/tickets/my-tickets.tsx
+++ b/frontend/src/components/tickets/my-tickets.tsx
@@ -2,12 +2,8 @@ import Link from "next/link";
 
 import { StateMessage } from "@/components/ui/StateMessage";
 import type { TicketFilterType, UserTicket } from "@/types/ticket";
-import { formatCurrency, formatDateTime } from "@/utils/formatters";
 
-import {
-  paymentMethodLabels,
-  ticketTypeLabels,
-} from "../reservations/order-summary";
+import { TicketCard as SharedTicketCard } from "./TicketCard";
 
 export type MyTicketsStatus = "error" | "loading" | "success";
 
@@ -104,40 +100,7 @@ export function MyTicketsContent({
 }
 
 export function TicketCard({ ticket }: { ticket: UserTicket }) {
-  return (
-    <article className="my-ticket">
-      <div className="my-ticket__header">
-        <div>
-          <h3>{ticket.movie.title}</h3>
-          <p>{formatDateTime(ticket.session.start_time)}</p>
-        </div>
-        <span>{ticket.ticket_code}</span>
-      </div>
-
-      <dl className="my-ticket__details">
-        <div>
-          <dt>Sala</dt>
-          <dd>{ticket.room.name}</dd>
-        </div>
-        <div>
-          <dt>Assento</dt>
-          <dd>{ticket.seat.identifier}</dd>
-        </div>
-        <div>
-          <dt>Ingresso</dt>
-          <dd>{ticketTypeLabels[ticket.ticket_type]}</dd>
-        </div>
-        <div>
-          <dt>Valor pago</dt>
-          <dd>{formatCurrency(Number(ticket.amount_paid))}</dd>
-        </div>
-        <div>
-          <dt>Pagamento</dt>
-          <dd>{paymentMethodLabels[ticket.payment_method]}</dd>
-        </div>
-      </dl>
-    </article>
-  );
+  return <SharedTicketCard showVisualCode={false} ticket={ticket} />;
 }
 
 export function getTicketFilterFromSearchParams(


### PR DESCRIPTION
## Objective

Render the post-checkout confirmation experience using the generated tickets returned by the checkout success response, while keeping the confirmation data in memory only and handling reloads without fabricating ticket data.

## What was done

### 1. Checkout confirmation state consumption

Updated the confirmation flow to read the existing in-memory `checkoutResult` stored by the checkout success path in `ReservationContext`.

The confirmation page now renders:

- generated tickets from the checkout response
- payment method
- total amount
- order details needed for display

### 2. Reusable ticket card component

Added a reusable `TicketCard` component under `frontend/src/components/tickets/`.

Each ticket card displays:

- movie title
- session date and time
- room
- seat identifier
- ticket type
- amount paid
- payment method
- ticket code

### 3. Display-only visual code

Added a deterministic display-only barcode-style visual representation for generated tickets.

This representation is intentionally UI-only and does not implement physical validation behavior.

### 4. Confirmation success UI

Updated `/confirmation` to clearly communicate successful purchase completion and render all generated tickets after checkout.

The page also provides navigation to `/my-tickets` after purchase.

### 5. Reload fallback without fake data

Updated the missing-state fallback for `/confirmation`.

If the page is reloaded and the in-memory checkout state is lost, the UI now explains the situation in Brazilian Portuguese and guides the user to `/my-tickets`.

No fake or placeholder ticket data is shown in this state.

### 6. Shared ticket presentation

Reused the new ticket card for the My Tickets display path, keeping ticket formatting consistent while disabling the visual barcode there.

### 7. Styling updates

Adjusted confirmation and ticket card CSS to support the reusable card, responsive ticket details, and the display-only visual code.

### 8. Automated test coverage

Added frontend tests covering:

- ticket card rendering with Brazilian formatting
- display-only visual code rendering
- confirmation success state
- reload fallback without fabricated ticket data

## How to test

### Automated validation

Run the frontend test suite:

```bash
cd frontend
npm run test
```

Run lint:

```bash
cd frontend
npm run lint
```

Run the production build:

```bash
cd frontend
npm run build
```

### Manual validation

1. Start the frontend and backend locally.
2. Complete a checkout successfully.
3. Confirm that `/confirmation` shows the success state and generated tickets.
4. Confirm each ticket shows movie, session, room, seat, ticket type, amount paid, payment method, ticket code, and visual barcode-style representation.
5. Reload `/confirmation`.
6. Confirm no fake ticket data appears and the page guides the user to `/my-tickets`.

## Expected Result

- Successful checkout redirects to a useful confirmation page with the generated tickets.
- Ticket cards show all required details with Brazilian formatting.
- The barcode-style visual code is present but display-only.
- Reloading `/confirmation` does not fabricate tickets and guides the user to My Tickets.
- The route remains protected by authentication.
- Frontend tests, lint, and production build pass.

closes #112
