### PR TITLE
feat: harden frontend responsive accessibility

### DIFF
--- a/frontend/docs/responsive-accessibility-checklist.md
+++ b/frontend/docs/responsive-accessibility-checklist.md
@@ -1,0 +1,37 @@
+# Checklist responsiva e WCAG 2.1 AA
+
+Escopo da issue #120: fluxo principal de compra do frontend, sem alterar a identidade visual nem adicionar assets decorativos.
+
+## Viewports obrigatorios
+
+- Mobile: validar a partir de 375 px de largura.
+- Desktop: validar a partir de 1024 px de largura.
+- Wide desktop: confirmar que o conteudo permanece limitado pelo container principal e legivel.
+- Mapa de assentos: confirmar rolagem horizontal no container do mapa sem perda de foco, clique ou teclado.
+
+## Fluxo principal
+
+- Navegacao: links e acoes de conta quebram linha ou rolam horizontalmente sem sobreposicao.
+- Home/catalogo: banner, grids, estados de carregamento, vazio e erro permanecem legiveis.
+- Detalhe do filme: poster, metadados, sinopse, seletor de datas e sessoes nao estouram o container.
+- Mapa de assentos: legenda textual, marcadores de estado, foco nos assentos e container rolavel funcionam em mobile.
+- Resumo do pedido: sidebar em desktop; painel empilhado em mobile.
+- Tipos de ingresso: cada grupo de radio tem legenda por assento, foco visivel e subtotal legivel.
+- Checkout: resumo, grupos de pagamento, erro de envio e botao final permanecem associados semanticamente.
+- Confirmacao: lista de ingressos, codigo visual e acoes se adaptam sem overflow.
+- Meus ingressos: filtros, lista, estados vazios e erro funcionam em 375 px e desktop.
+
+## Acessibilidade
+
+- Landmarks: header, main e secoes principais presentes; skip link leva ao `main`.
+- Titulos: cada pagina tem `h1`; secoes internas usam headings associados por `aria-labelledby` quando aplicavel.
+- Teclado: links, botoes, filtros, radios e assentos disponiveis/selecionados sao alcancaveis e operaveis por Tab + Enter/Espaco.
+- Foco: estados `:focus-visible` aparecem em botoes, links, cards clicaveis, opcoes de radio e mapa rolavel.
+- Formularios: login, cadastro, cupom, tipos de ingresso e pagamento possuem label/legend; erros usam `role="alert"` e `aria-describedby` quando aplicavel.
+- Assentos: estados nao dependem so de cor; cada assento tem texto acessivel e marcador visual (`L`, `S`, `R`, `C` ou acessivel).
+- Contraste: texto principal, botoes e estados devem preservar contraste compativel com WCAG 2.1 AA.
+
+## Automacao adicionada
+
+- Testes de renderizacao estatica cobrem lista/legenda do mapa de assentos, instrucao de rolagem, labels acessiveis de sessoes, grupos de ingresso e listas de ingressos.
+- Nenhuma ferramenta de snapshot visual ou E2E foi introduzida nesta issue; a validacao manual acima continua sendo a referencia para comportamento de viewport.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -57,6 +57,18 @@ button {
   outline-offset: 3px;
 }
 
+.sr-only {
+  clip: rect(0 0 0 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .app-shell {
   min-height: 100vh;
 }
@@ -491,6 +503,10 @@ h1 {
   height: 100%;
 }
 
+.movie-card__link:focus-visible {
+  outline-offset: -4px;
+}
+
 .movie-card__link:hover .movie-card__title {
   color: var(--color-brand);
 }
@@ -733,6 +749,11 @@ h1 {
   border-color: #d8a907;
 }
 
+.session-option:focus-visible {
+  background: #fff8df;
+  border-color: var(--color-info);
+}
+
 .session-option strong {
   font-size: 22px;
   line-height: 1;
@@ -776,6 +797,9 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   gap: 10px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .seat-map__legend-item {
@@ -1247,6 +1271,7 @@ h1 {
   display: grid;
   gap: 12px;
   margin: 0;
+  min-inline-size: 0;
   min-width: 0;
   padding: 14px;
 }
@@ -1295,6 +1320,11 @@ h1 {
   border-color: #d8a907;
 }
 
+.ticket-types__option:focus-within {
+  border-color: var(--color-info);
+  box-shadow: 0 0 0 3px rgb(31 111 235 / 18%);
+}
+
 .ticket-types__option input {
   height: 18px;
   width: 18px;
@@ -1320,6 +1350,7 @@ h1 {
 
 .ticket-types__option b {
   font-size: 15px;
+  overflow-wrap: anywhere;
   white-space: nowrap;
 }
 
@@ -1430,6 +1461,7 @@ h1 {
   display: flex;
   gap: 14px;
   justify-content: space-between;
+  min-width: 0;
   padding-bottom: 10px;
 }
 
@@ -1442,6 +1474,7 @@ h1 {
 .checkout-review__session dd {
   font-weight: 850;
   margin: 0;
+  overflow-wrap: anywhere;
   text-align: right;
 }
 
@@ -1480,8 +1513,12 @@ h1 {
 }
 
 .payment-methods {
+  border: 0;
   display: grid;
   gap: 10px;
+  margin: 0;
+  min-inline-size: 0;
+  padding: 0;
 }
 
 .payment-methods__option {
@@ -1502,6 +1539,11 @@ h1 {
   border-color: #d8a907;
 }
 
+.payment-methods__option:focus-within {
+  border-color: var(--color-info);
+  box-shadow: 0 0 0 3px rgb(31 111 235 / 18%);
+}
+
 .payment-methods__option input {
   height: 18px;
   width: 18px;
@@ -1510,10 +1552,12 @@ h1 {
 .payment-methods__option span {
   display: grid;
   gap: 4px;
+  min-width: 0;
 }
 
 .payment-methods__option strong {
   font-size: 16px;
+  overflow-wrap: anywhere;
 }
 
 .payment-methods__option small {
@@ -1632,8 +1676,10 @@ h1 {
   font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
   font-size: 13px;
   font-weight: 850;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   padding: 8px 10px;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .confirmation-tickets .ticket-card__header span {
@@ -1796,6 +1842,13 @@ h1 {
   .primary-nav,
   .header-actions {
     justify-content: flex-start;
+    width: 100%;
+  }
+
+  .primary-nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
   }
 
   .page-heading {
@@ -1908,6 +1961,10 @@ h1 {
     white-space: normal;
   }
 
+  .header-actions .button {
+    flex: 1 1 132px;
+  }
+
   .panel {
     padding: 18px;
   }
@@ -1932,5 +1989,17 @@ h1 {
 
   .my-ticket__details {
     grid-template-columns: 1fr;
+  }
+
+  .checkout-review__session div,
+  .order-summary__details div {
+    align-items: start;
+    display: grid;
+    gap: 4px;
+  }
+
+  .checkout-review__session dd,
+  .order-summary__details dd {
+    text-align: left;
   }
 }

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -52,7 +52,11 @@ export function LoginForm() {
           {confirmationMessage}
         </p>
       ) : null}
-      <form className="form-grid" onSubmit={handleSubmit}>
+      <form
+        aria-describedby={formErrorId}
+        className="form-grid"
+        onSubmit={handleSubmit}
+      >
         <div className="form-field">
           <label htmlFor="email">E-mail</label>
           <input

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -16,6 +16,7 @@ export function RegisterForm() {
   const [fieldErrors, setFieldErrors] = useState<AuthFieldErrors>({});
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const formErrorId = formError ? "register-form-error" : undefined;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -42,7 +43,11 @@ export function RegisterForm() {
 
   return (
     <div className="panel">
-      <form className="form-grid" onSubmit={handleSubmit}>
+      <form
+        aria-describedby={formErrorId}
+        className="form-grid"
+        onSubmit={handleSubmit}
+      >
         <div className="form-field">
           <label htmlFor="username">Nome de usuário</label>
           <input
@@ -101,7 +106,7 @@ export function RegisterForm() {
           ) : null}
         </div>
         {formError ? (
-          <p className="form-error" role="alert">
+          <p className="form-error" id="register-form-error" role="alert">
             {formError}
           </p>
         ) : null}

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -54,7 +54,7 @@ export function AppHeader() {
           })}
         </nav>
 
-        <div className="header-actions" aria-label="Ações da conta">
+        <div className="header-actions" aria-label="Ações da conta" role="group">
           {isAuthenticated ? (
             <>
               <Link className="button button-secondary" href="/my-tickets">

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -277,7 +277,6 @@ function MovieSessionSelector({ movieId }: { movieId: string }) {
       <div
         aria-label="Datas disponíveis"
         className="session-date-selector"
-        role="list"
       >
         {dateOptions.map((dateOption) => (
           <button
@@ -355,6 +354,11 @@ function SessionList({
           <div className="session-time-grid">
             {group.sessions.map((session) => (
               <Link
+                aria-label={`Selecionar sessão das ${formatSessionTime(
+                  session.start_time
+                )}, sala ${group.roomName}, valor ${formatSessionPrice(
+                  session.base_price
+                )}`}
                 className="session-option"
                 href={getSessionSeatsHref(session.id)}
                 key={session.id}

--- a/frontend/src/components/movies/movie-detail.test.ts
+++ b/frontend/src/components/movies/movie-detail.test.ts
@@ -44,6 +44,7 @@ test("movie detail renders backend movie fields with accessible media", () => {
   assert.match(html, /13\/05\/2026/);
   assert.match(html, /Sessões/);
   assert.match(html, /Carregando sessões/);
+  assert.doesNotMatch(html, /role="list" class="session-date-selector"/);
   assert.doesNotMatch(html, /age_rating|classificação|room_type|audio_format|sala tradicional|legendado/i);
 });
 

--- a/frontend/src/components/reservations/CheckoutConfirmation.tsx
+++ b/frontend/src/components/reservations/CheckoutConfirmation.tsx
@@ -55,9 +55,11 @@ export function CheckoutConfirmationContent({
         <strong>{formatCurrency(Number(checkoutResult.total_amount))}</strong>
       </div>
 
-      <div className="confirmation-tickets__list">
+      <div className="confirmation-tickets__list" role="list">
         {checkoutResult.tickets.map((ticket) => (
-          <TicketCard key={ticket.ticket_id} ticket={ticket} />
+          <div key={ticket.ticket_id} role="listitem">
+            <TicketCard ticket={ticket} />
+          </div>
         ))}
       </div>
 

--- a/frontend/src/components/reservations/CheckoutReview.tsx
+++ b/frontend/src/components/reservations/CheckoutReview.tsx
@@ -130,7 +130,11 @@ export function CheckoutReview() {
   }
 
   return (
-    <form className="checkout-review" onSubmit={submitCheckout}>
+    <form
+      aria-describedby={errorMessage ? "checkout-review-error" : undefined}
+      className="checkout-review"
+      onSubmit={submitCheckout}
+    >
       <section aria-labelledby="revisao-pedido" className="checkout-review__panel">
         <div className="checkout-review__heading">
           <div>
@@ -209,7 +213,12 @@ export function CheckoutReview() {
           </div>
         </div>
 
-        <div className="payment-methods" role="radiogroup">
+        <fieldset
+          aria-describedby={errorMessage ? "checkout-review-error" : undefined}
+          aria-labelledby="forma-pagamento"
+          className="payment-methods"
+        >
+          <legend className="sr-only">Forma de pagamento</legend>
           {paymentMethods.map((method) => (
             <label className="payment-methods__option" key={method}>
               <input
@@ -233,13 +242,15 @@ export function CheckoutReview() {
               </span>
             </label>
           ))}
-        </div>
+        </fieldset>
       </section>
 
       {errorMessage ? (
-        <StateMessage tone="error" title="Não foi possível finalizar">
-          {errorMessage}
-        </StateMessage>
+        <div id="checkout-review-error">
+          <StateMessage tone="error" title="Não foi possível finalizar">
+            {errorMessage}
+          </StateMessage>
+        </div>
       ) : null}
 
       <button

--- a/frontend/src/components/reservations/checkout-confirmation.test.ts
+++ b/frontend/src/components/reservations/checkout-confirmation.test.ts
@@ -86,6 +86,8 @@ test("checkout confirmation renders the success state and generated tickets", ()
   assert.match(html, /R\$\s?42,50/);
   assert.match(html, /A Jornada/);
   assert.match(html, /ABC123/);
+  assert.match(html, /role="list"/);
+  assert.match(html, /role="listitem"/);
   assert.match(html, /href="\/my-tickets"/);
 });
 

--- a/frontend/src/components/reservations/ticket-type-selection.test.ts
+++ b/frontend/src/components/reservations/ticket-type-selection.test.ts
@@ -94,6 +94,9 @@ test("ticket type selection form renders seats, options, voucher field, and subt
   assert.match(html, /B7/);
   assert.match(html, /Fileira B, assento 7/);
   assert.match(html, /B8/);
+  assert.match(html, /<fieldset/);
+  assert.match(html, /name="ticket-type-session-seat-1"/);
+  assert.match(html, /name="ticket-type-session-seat-2"/);
   assert.match(html, /Inteira/);
   assert.match(html, /Meia-entrada/);
   assert.match(html, /Código promocional/);

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -364,6 +364,11 @@ export function SeatMapLayout({
           Visitantes podem consultar a sala. Para reservar ou liberar assentos,
           entre na sua conta.
         </p>
+        <p className="sr-only" id="mapa-assentos-instrucoes">
+          Em telas estreitas, role horizontalmente para acessar todos os
+          assentos. Use Tab para chegar aos assentos e Enter ou Espaço para
+          selecionar ou liberar um assento disponível.
+        </p>
       </div>
 
       <SeatMapLegend />
@@ -375,6 +380,7 @@ export function SeatMapLayout({
       ) : null}
 
       <div
+        aria-describedby="mapa-assentos-instrucoes"
         aria-label="Área rolável do mapa de assentos"
         className="seat-map-scroll"
         tabIndex={0}
@@ -511,9 +517,9 @@ export function SeatMapLegend() {
   ];
 
   return (
-    <div aria-label="Legenda dos assentos" className="seat-map__legend">
+    <ul aria-label="Legenda dos assentos" className="seat-map__legend">
       {legendItems.map((item) => (
-        <div className="seat-map__legend-item" key={item.label}>
+        <li className="seat-map__legend-item" key={item.label}>
           <span
             aria-hidden="true"
             className={[
@@ -524,9 +530,9 @@ export function SeatMapLegend() {
             {item.marker}
           </span>
           <span>{item.label}</span>
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }
 

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -103,6 +103,9 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, /Fundo da sala/);
   assert.match(html, /Fileira A/);
   assert.match(html, /Fileira B/);
+  assert.match(html, /tabindex="0"/);
+  assert.match(html, /aria-describedby="mapa-assentos-instrucoes"/);
+  assert.match(html, /role="group"/);
   assert.match(html, /seat-map__seat--available/);
   assert.match(html, /seat-map__seat--accessible/);
   assert.match(html, /seat-map__seat--reserved/);
@@ -110,11 +113,13 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, /seat-map__seat--selected/);
   assert.match(html, /aria-disabled="true"/);
   assert.match(html, /aria-pressed="true"/);
+  assert.match(html, /Assento A2, fileira A, número 2, Disponível, assento acessível/);
 });
 
 test("seat legend explains every state in pt-BR", () => {
   const html = renderToStaticMarkup(createElement(SeatMapLegend));
 
+  assert.match(html, /<ul/);
   assert.match(html, /Legenda dos assentos/);
   assert.match(html, /Disponível/);
   assert.match(html, /Selecionado/);

--- a/frontend/src/components/tickets/my-tickets.test.ts
+++ b/frontend/src/components/tickets/my-tickets.test.ts
@@ -72,6 +72,8 @@ test("my tickets content renders active pt-BR filter links", () => {
   assert.match(html, /href="\/my-tickets\?type=upcoming"/);
   assert.match(html, /href="\/my-tickets\?type=past"/);
   assert.match(html, /aria-current="page"[^>]*>Próximos/);
+  assert.match(html, /role="list"/);
+  assert.match(html, /role="listitem"/);
 });
 
 test("my tickets content renders loading, empty, and error states", () => {

--- a/frontend/src/components/tickets/my-tickets.tsx
+++ b/frontend/src/components/tickets/my-tickets.tsx
@@ -89,9 +89,11 @@ export function MyTicketsContent({
       ) : null}
 
       {status === "success" && tickets.length > 0 ? (
-        <div className="my-tickets__list">
+        <div className="my-tickets__list" role="list">
           {tickets.map((ticket) => (
-            <TicketCard key={ticket.ticket_id} ticket={ticket} />
+            <div key={ticket.ticket_id} role="listitem">
+              <TicketCard ticket={ticket} />
+            </div>
           ))}
         </div>
       ) : null}


### PR DESCRIPTION
## Objective

Perform a final responsive and WCAG 2.1 AA hardening pass across the frontend purchase journey, preserving the existing visual system while improving mobile behavior, keyboard usability, semantic structure, and practical verification support.

## What was done

### 1. Responsive viewport hardening

Adjusted frontend layout behavior for the main flow at mobile and desktop sizes:

- Improved mobile navigation behavior with horizontal scrolling for primary links when space is constrained.
- Kept account actions flexible on narrow screens.
- Hardened checkout session rows and order summary details against narrow viewport overflow.
- Allowed ticket codes and ticket-card metadata to wrap instead of forcing horizontal overflow.
- Preserved the existing desktop sidebar behavior for the order summary and the stacked mobile panel behavior.

### 2. Seat map usability and accessibility

Improved the seat map without changing the underlying interaction model:

- Added screen-reader instructions for horizontal scrolling and keyboard operation.
- Associated those instructions with the scrollable seat-map container.
- Kept the map container keyboard-focusable for horizontal scrolling.
- Converted the seat legend into a semantic list.
- Preserved visible and textual seat-state markers so states do not rely on color alone.

### 3. Keyboard and focus state hardening

Expanded focus treatment across interactive elements in the purchase journey:

- Added visible focus treatment for movie cards.
- Added visible focus treatment for session time options.
- Added `focus-within` states for ticket-type radio options.
- Added `focus-within` states for checkout payment options.
- Preserved the global `:focus-visible` outline and skip-link behavior.

### 4. Form and control semantics

Improved accessible associations for forms and grouped controls:

- Associated login form-level errors through `aria-describedby`.
- Associated register form-level errors through `aria-describedby`.
- Converted checkout payment methods to a semantic `fieldset` with an accessible legend.
- Associated checkout submission errors with the form and payment group.
- Kept ticket type selection grouped by per-seat `fieldset` and `legend`.

### 5. Purchase flow semantic hardening

Improved list and navigation semantics across the post-selection flow:

- Added semantic list/listitem structure to confirmation tickets.
- Added semantic list/listitem structure to My Tickets results.
- Added accessible labels for session selection links with time, room, and price context.
- Marked header account actions as a grouped control area.

### 6. Documented viewport and WCAG checklist

Added `frontend/docs/responsive-accessibility-checklist.md` with practical manual verification coverage for:

- 375 px mobile viewport.
- 1024 px and wider desktop viewport.
- Wide desktop readability.
- Horizontal seat-map scrolling.
- Navigation, catalog, movie detail, seat map, order summary, ticket types, checkout, confirmation, and My Tickets.
- Keyboard flow, visible focus, form labeling, status color independence, and WCAG 2.1 AA review expectations.

### 7. Automated semantic assertions

Expanded component-level render assertions where practical:

- Seat map scroll instructions, semantic row grouping, legend list, and accessible seat labels.
- Ticket type fieldset/radio naming coverage.
- Confirmation ticket list semantics.
- My Tickets list semantics.
- Movie detail/session selector semantic regression coverage.

### 8. Acceptance criteria confirmation

Confirmed the issue criteria through implementation and validation:

- Mobile support: layouts are hardened for 375 px and narrow screens.
- Desktop support: existing 1024 px+ layout density is preserved.
- Seat map usability: horizontal scrolling remains available and keyboard-focusable.
- Order summary: sidebar behavior remains for desktop and stacked panel behavior remains for mobile.
- Keyboard flow: primary actions, radios, session links, filters, and seat controls remain keyboard reachable.
- Focus states: visible focus treatment exists globally and was expanded for cards, session options, and radio-like choices.
- Accessible forms: login, register, ticket type, and checkout controls have labels/legends and useful error associations.
- Color independence: seat/status states include text or marker alternatives.
- WCAG review: main flow checklist documents WCAG 2.1 AA-oriented manual review.
- Automated tests: semantic and accessibility assertions were added where practical.

## How to test

### Automated validation

Run the frontend validation suite:

```bash
cd frontend
npm test
npm run lint
npm run build
```

### Manual validation

1. Start the frontend:

```bash
cd frontend
npm run dev
```

2. Open the app and validate the checklist:

- `frontend/docs/responsive-accessibility-checklist.md`

3. Check the main purchase journey at:

- 375 px mobile width.
- 1024 px desktop width.
- Wider desktop widths.

4. Validate the main expected behaviors:

- navigation remains usable without overlap
- catalog and movie detail remain readable
- session links and date controls are keyboard reachable
- seat map scrolls horizontally on narrow screens
- seat controls expose state without relying only on color
- order summary stacks on mobile and remains a sidebar on desktop
- ticket type and payment controls expose grouped labels
- login/register/checkout errors are associated with forms
- confirmation and My Tickets render ticket lists semantically

## Expected Result

- Main frontend purchase flows work at 375 px and 1024 px+ without incoherent overlap.
- Seat maps remain usable on narrow screens through horizontal scrolling.
- Order summary behavior remains appropriate for desktop and mobile.
- Keyboard users can reach and operate primary controls in the purchase journey.
- Interactive elements have visible focus states.
- Forms and grouped controls expose useful labels, legends, and error associations.
- Seat and status states do not rely on color alone.
- WCAG 2.1 AA-oriented manual review is documented.
- Practical component-level semantic assertions pass.

closes #120
