### PR TITLE
test: expand unit and component test coverage for frontend modules

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -11,38 +11,19 @@ import {
   getSafeRedirectFromSearch,
 } from "./auth-form-utils";
 
-export function LoginForm() {
-  const router = useRouter();
-  const { loading, login } = useAuth();
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [confirmationMessage, setConfirmationMessage] = useState<string | null>(
-    null
-  );
+export type LoginFormViewProps = {
+  confirmationMessage: string | null;
+  errorMessage: string | null;
+  isSubmitting: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setErrorMessage(null);
-
-    const formData = new FormData(event.currentTarget);
-    const email = String(formData.get("email") ?? "");
-    const password = String(formData.get("password") ?? "");
-
-    try {
-      await login({ email, password });
-      const search = typeof window === "undefined" ? "" : window.location.search;
-      router.replace(getSafeRedirectFromSearch(search));
-    } catch (error) {
-      setErrorMessage(getLoginFormErrorMessage(error));
-    }
-  }
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      setConfirmationMessage(getLoginConfirmationMessage(window.location.search));
-    }
-  }, []);
-
-  const isSubmitting = loading;
+export function LoginFormView({
+  confirmationMessage,
+  errorMessage,
+  isSubmitting,
+  onSubmit,
+}: LoginFormViewProps) {
   const formErrorId = errorMessage ? "login-form-error" : undefined;
 
   return (
@@ -55,7 +36,7 @@ export function LoginForm() {
       <form
         aria-describedby={formErrorId}
         className="form-grid"
-        onSubmit={handleSubmit}
+        onSubmit={onSubmit}
       >
         <div className="form-field">
           <label htmlFor="email">E-mail</label>
@@ -95,5 +76,46 @@ export function LoginForm() {
         </button>
       </form>
     </div>
+  );
+}
+
+export function LoginForm() {
+  const router = useRouter();
+  const { loading, login } = useAuth();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [confirmationMessage, setConfirmationMessage] = useState<string | null>(
+    null
+  );
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const formData = new FormData(event.currentTarget);
+    const email = String(formData.get("email") ?? "");
+    const password = String(formData.get("password") ?? "");
+
+    try {
+      await login({ email, password });
+      const search = typeof window === "undefined" ? "" : window.location.search;
+      router.replace(getSafeRedirectFromSearch(search));
+    } catch (error) {
+      setErrorMessage(getLoginFormErrorMessage(error));
+    }
+  }
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setConfirmationMessage(getLoginConfirmationMessage(window.location.search));
+    }
+  }, []);
+
+  return (
+    <LoginFormView
+      confirmationMessage={confirmationMessage}
+      errorMessage={errorMessage}
+      isSubmitting={loading}
+      onSubmit={handleSubmit}
+    />
   );
 }

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -11,42 +11,27 @@ import {
   type AuthFieldErrors,
 } from "./auth-form-utils";
 
-export function RegisterForm() {
-  const router = useRouter();
-  const [fieldErrors, setFieldErrors] = useState<AuthFieldErrors>({});
-  const [formError, setFormError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+export type RegisterFormViewProps = {
+  fieldErrors: AuthFieldErrors;
+  formError: string | null;
+  isSubmitting: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+export function RegisterFormView({
+  fieldErrors,
+  formError,
+  isSubmitting,
+  onSubmit,
+}: RegisterFormViewProps) {
   const formErrorId = formError ? "register-form-error" : undefined;
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setFieldErrors({});
-    setFormError(null);
-    setIsSubmitting(true);
-
-    const formData = new FormData(event.currentTarget);
-    const username = String(formData.get("username") ?? "");
-    const email = String(formData.get("email") ?? "");
-    const password = String(formData.get("password") ?? "");
-
-    try {
-      await authApi.register({ email, password, username });
-      router.replace(buildRegisteredLoginUrl());
-    } catch (error) {
-      const validationState = getRegistrationValidationState(error);
-      setFieldErrors(validationState.fieldErrors);
-      setFormError(validationState.formError);
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
 
   return (
     <div className="panel">
       <form
         aria-describedby={formErrorId}
         className="form-grid"
-        onSubmit={handleSubmit}
+        onSubmit={onSubmit}
       >
         <div className="form-field">
           <label htmlFor="username">Nome de usuário</label>
@@ -115,5 +100,44 @@ export function RegisterForm() {
         </button>
       </form>
     </div>
+  );
+}
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [fieldErrors, setFieldErrors] = useState<AuthFieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFieldErrors({});
+    setFormError(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const username = String(formData.get("username") ?? "");
+    const email = String(formData.get("email") ?? "");
+    const password = String(formData.get("password") ?? "");
+
+    try {
+      await authApi.register({ email, password, username });
+      router.replace(buildRegisteredLoginUrl());
+    } catch (error) {
+      const validationState = getRegistrationValidationState(error);
+      setFieldErrors(validationState.fieldErrors);
+      setFormError(validationState.formError);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <RegisterFormView
+      fieldErrors={fieldErrors}
+      formError={formError}
+      isSubmitting={isSubmitting}
+      onSubmit={handleSubmit}
+    />
   );
 }

--- a/frontend/src/components/auth/auth-forms.test.ts
+++ b/frontend/src/components/auth/auth-forms.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { LoginFormView } from "./LoginForm";
+import { RegisterFormView } from "./RegisterForm";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const noop = () => undefined;
+
+test("login form view renders accessible email and password fields with labels", () => {
+  const html = renderToStaticMarkup(
+    createElement(LoginFormView, {
+      confirmationMessage: null,
+      errorMessage: null,
+      isSubmitting: false,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /<label[^>]*for="email"/);
+  assert.match(html, /E-mail/);
+  assert.match(html, /<input[^>]*id="email"/);
+  assert.match(html, /type="email"/);
+  assert.match(html, /<label[^>]*for="password"/);
+  assert.match(html, /Senha/);
+  assert.match(html, /<input[^>]*id="password"/);
+  assert.match(html, /type="password"/);
+  assert.match(html, /Entrar/);
+  assert.doesNotMatch(html, /role="alert"/);
+  assert.doesNotMatch(html, /aria-invalid/);
+});
+
+test("login form view renders error message with accessible alert markup when login fails", () => {
+  const html = renderToStaticMarkup(
+    createElement(LoginFormView, {
+      confirmationMessage: null,
+      errorMessage: "E-mail ou senha incorretos.",
+      isSubmitting: false,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /E-mail ou senha incorretos\./);
+  assert.match(html, /role="alert"/);
+  assert.match(html, /id="login-form-error"/);
+  assert.match(html, /aria-describedby="login-form-error"/);
+  assert.match(html, /aria-invalid="true"/);
+});
+
+test("login form view renders confirmation message after successful registration", () => {
+  const html = renderToStaticMarkup(
+    createElement(LoginFormView, {
+      confirmationMessage: "Cadastro criado com sucesso. Entre para continuar.",
+      errorMessage: null,
+      isSubmitting: false,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /Cadastro criado com sucesso\. Entre para continuar\./);
+  assert.match(html, /role="status"/);
+  assert.doesNotMatch(html, /role="alert"/);
+});
+
+test("login form view disables inputs and submit button while the request is in progress", () => {
+  const html = renderToStaticMarkup(
+    createElement(LoginFormView, {
+      confirmationMessage: null,
+      errorMessage: null,
+      isSubmitting: true,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /Entrando\.\.\./);
+  assert.match(html, /disabled=""/);
+});
+
+test("register form view renders accessible username, email, and password fields", () => {
+  const html = renderToStaticMarkup(
+    createElement(RegisterFormView, {
+      fieldErrors: {},
+      formError: null,
+      isSubmitting: false,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /<label[^>]*for="username"/);
+  assert.match(html, /Nome de usuário/);
+  assert.match(html, /<input[^>]*id="username"/);
+  assert.match(html, /<label[^>]*for="email"/);
+  assert.match(html, /E-mail/);
+  assert.match(html, /<input[^>]*id="email"/);
+  assert.match(html, /<label[^>]*for="password"/);
+  assert.match(html, /Senha/);
+  assert.match(html, /<input[^>]*id="password"/);
+  assert.match(html, /Criar conta/);
+  assert.doesNotMatch(html, /aria-invalid/);
+  assert.doesNotMatch(html, /form-error/);
+});
+
+test("register form view renders field-level errors linked by id and aria attributes", () => {
+  const html = renderToStaticMarkup(
+    createElement(RegisterFormView, {
+      fieldErrors: {
+        email: "Informe um e-mail válido.",
+        username: "Informe um nome de usuário válido.",
+      },
+      formError: null,
+      isSubmitting: false,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /Informe um nome de usuário válido\./);
+  assert.match(html, /id="username-error"/);
+  assert.match(html, /aria-describedby="username-error"/);
+  assert.match(html, /aria-invalid="true"[^>]*id="username"/);
+
+  assert.match(html, /Informe um e-mail válido\./);
+  assert.match(html, /id="email-error"/);
+  assert.match(html, /aria-describedby="email-error"/);
+  assert.match(html, /aria-invalid="true"[^>]*id="email"/);
+
+  assert.doesNotMatch(html, /id="password-error"/);
+});
+
+test("register form view renders a form-level error when no field errors are present", () => {
+  const html = renderToStaticMarkup(
+    createElement(RegisterFormView, {
+      fieldErrors: {},
+      formError: "Confira os dados informados e tente novamente.",
+      isSubmitting: false,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /Confira os dados informados e tente novamente\./);
+  assert.match(html, /role="alert"/);
+  assert.match(html, /id="register-form-error"/);
+  assert.match(html, /aria-describedby="register-form-error"/);
+  assert.doesNotMatch(html, /id="username-error"/);
+  assert.doesNotMatch(html, /id="email-error"/);
+  assert.doesNotMatch(html, /id="password-error"/);
+});
+
+test("register form view disables all inputs and the submit button while creating the account", () => {
+  const html = renderToStaticMarkup(
+    createElement(RegisterFormView, {
+      fieldErrors: {},
+      formError: null,
+      isSubmitting: true,
+      onSubmit: noop,
+    })
+  );
+
+  assert.match(html, /Criando conta\.\.\./);
+  assert.match(html, /disabled=""/);
+});

--- a/frontend/src/components/reservations/CheckoutReview.tsx
+++ b/frontend/src/components/reservations/CheckoutReview.tsx
@@ -28,7 +28,45 @@ type SessionDetailState =
   | { errorMessage: string; status: "error" }
   | { session: CatalogSession; status: "success" };
 
-const paymentMethods: PaymentMethod[] = ["cartao_credito", "pix"];
+export const PAYMENT_METHODS: PaymentMethod[] = ["cartao_credito", "pix"];
+
+export type PaymentMethodSelectorProps = {
+  disabled?: boolean;
+  onChange: (method: PaymentMethod) => void;
+  selectedMethod: PaymentMethod | null;
+};
+
+export function PaymentMethodSelector({
+  disabled = false,
+  onChange,
+  selectedMethod,
+}: PaymentMethodSelectorProps) {
+  return (
+    <fieldset className="payment-methods">
+      <legend className="sr-only">Forma de pagamento</legend>
+      {PAYMENT_METHODS.map((method) => (
+        <label className="payment-methods__option" key={method}>
+          <input
+            checked={selectedMethod === method}
+            disabled={disabled}
+            name="payment_method"
+            onChange={() => onChange(method)}
+            type="radio"
+            value={method}
+          />
+          <span>
+            <strong>{paymentMethodLabels[method]}</strong>
+            <small>
+              {method === "cartao_credito"
+                ? "Finalize com cartão de crédito."
+                : "Finalize com pagamento via PIX."}
+            </small>
+          </span>
+        </label>
+      ))}
+    </fieldset>
+  );
+}
 
 export function CheckoutReview() {
   const router = useRouter();
@@ -213,36 +251,14 @@ export function CheckoutReview() {
           </div>
         </div>
 
-        <fieldset
-          aria-describedby={errorMessage ? "checkout-review-error" : undefined}
-          aria-labelledby="forma-pagamento"
-          className="payment-methods"
-        >
-          <legend className="sr-only">Forma de pagamento</legend>
-          {paymentMethods.map((method) => (
-            <label className="payment-methods__option" key={method}>
-              <input
-                checked={reservation.paymentMethod === method}
-                disabled={isSubmitting}
-                name="payment_method"
-                onChange={() => {
-                  reservation.setPaymentMethod(method);
-                  setErrorMessage(null);
-                }}
-                type="radio"
-                value={method}
-              />
-              <span>
-                <strong>{paymentMethodLabels[method]}</strong>
-                <small>
-                  {method === "cartao_credito"
-                    ? "Finalize com cartão de crédito."
-                    : "Finalize com pagamento via PIX."}
-                </small>
-              </span>
-            </label>
-          ))}
-        </fieldset>
+        <PaymentMethodSelector
+          disabled={isSubmitting}
+          onChange={(method) => {
+            reservation.setPaymentMethod(method);
+            setErrorMessage(null);
+          }}
+          selectedMethod={reservation.paymentMethod}
+        />
       </section>
 
       {errorMessage ? (

--- a/frontend/src/components/reservations/checkout-review.test.ts
+++ b/frontend/src/components/reservations/checkout-review.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PAYMENT_METHODS, PaymentMethodSelector } from "./CheckoutReview";
+import { paymentMethodLabels } from "./order-summary";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const noop = () => undefined;
+
+test("payment method selector covers all supported payment methods", () => {
+  assert.deepEqual(PAYMENT_METHODS, ["cartao_credito", "pix"]);
+  assert.equal(paymentMethodLabels.cartao_credito, "Cartão de crédito");
+  assert.equal(paymentMethodLabels.pix, "PIX");
+});
+
+test("payment method selector renders cartao_credito and pix options with pt-BR labels", () => {
+  const html = renderToStaticMarkup(
+    createElement(PaymentMethodSelector, {
+      onChange: noop,
+      selectedMethod: null,
+    })
+  );
+
+  assert.match(html, /Cartão de crédito/);
+  assert.match(html, /Finalize com cartão de crédito\./);
+  assert.match(html, /PIX/);
+  assert.match(html, /Finalize com pagamento via PIX\./);
+  assert.match(html, /name="payment_method"/);
+  assert.match(html, /type="radio"/);
+  assert.match(html, /value="cartao_credito"/);
+  assert.match(html, /value="pix"/);
+});
+
+test("payment method selector marks the selected method as checked", () => {
+  const pixHtml = renderToStaticMarkup(
+    createElement(PaymentMethodSelector, {
+      onChange: noop,
+      selectedMethod: "pix",
+    })
+  );
+
+  assert.match(pixHtml, /checked=""[^/]*value="pix"|value="pix"[^/]*checked=""/);
+  assert.doesNotMatch(pixHtml, /checked=""[^/]*value="cartao_credito"|value="cartao_credito"[^/]*checked=""/);
+
+  const creditHtml = renderToStaticMarkup(
+    createElement(PaymentMethodSelector, {
+      onChange: noop,
+      selectedMethod: "cartao_credito",
+    })
+  );
+
+  assert.match(creditHtml, /checked=""[^/]*value="cartao_credito"|value="cartao_credito"[^/]*checked=""/);
+  assert.doesNotMatch(creditHtml, /checked=""[^/]*value="pix"|value="pix"[^/]*checked=""/);
+});
+
+test("payment method selector does not mark any option as checked when no method is selected", () => {
+  const html = renderToStaticMarkup(
+    createElement(PaymentMethodSelector, {
+      onChange: noop,
+      selectedMethod: null,
+    })
+  );
+
+  assert.doesNotMatch(html, /checked=""/);
+});
+
+test("payment method selector disables all radio inputs while the checkout is submitting", () => {
+  const html = renderToStaticMarkup(
+    createElement(PaymentMethodSelector, {
+      disabled: true,
+      onChange: noop,
+      selectedMethod: "pix",
+    })
+  );
+
+  const disabledCount = (html.match(/disabled=""/g) ?? []).length;
+  assert.equal(disabledCount, PAYMENT_METHODS.length);
+});

--- a/frontend/src/contexts/auth-security.test.ts
+++ b/frontend/src/contexts/auth-security.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { initialAuthState } from "./auth-state";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BROWSER_STORAGE = /localStorage|sessionStorage/;
+
+function readSrc(relativePath: string) {
+  return readFileSync(resolve(__dirname, relativePath), "utf8");
+}
+
+test("auth state module does not reference browser storage APIs", () => {
+  const source = readSrc("auth-state.ts");
+  assert.doesNotMatch(
+    source,
+    BROWSER_STORAGE,
+    "auth-state.ts must not use localStorage or sessionStorage"
+  );
+});
+
+test("AuthContext does not store access or refresh tokens in browser storage", () => {
+  const source = readSrc("AuthContext.tsx");
+  assert.doesNotMatch(
+    source,
+    BROWSER_STORAGE,
+    "AuthContext.tsx must not use localStorage or sessionStorage"
+  );
+});
+
+test("API client module does not use browser storage for token handling", () => {
+  const source = readSrc("../api/client.ts");
+  assert.doesNotMatch(
+    source,
+    BROWSER_STORAGE,
+    "client.ts must not use localStorage or sessionStorage"
+  );
+});
+
+test("auth API module does not persist tokens in browser storage", () => {
+  const source = readSrc("../api/auth.ts");
+  assert.doesNotMatch(
+    source,
+    BROWSER_STORAGE,
+    "auth.ts must not use localStorage or sessionStorage"
+  );
+});
+
+test("auth state initial value holds no tokens or user data", () => {
+  assert.equal(initialAuthState.accessToken, null);
+  assert.equal(initialAuthState.refreshToken, null);
+  assert.equal(initialAuthState.user, null);
+  assert.equal(initialAuthState.status, "unauthenticated");
+});


### PR DESCRIPTION
## Objective

Expand unit and component test coverage for the completed frontend modules so that form validation display, checkout payment method selection, and token storage safety are explicitly protected from regressions.

## What was done

### 1. Form validation display — `auth-forms.test.ts` (8 new tests)

Extracted `LoginFormView` and `RegisterFormView` as pure presentational components from `LoginForm.tsx` and `RegisterForm.tsx` respectively. The original hooks-based `LoginForm` and `RegisterForm` components now delegate their rendering to these views, preserving all existing behaviour.

Tests verify:

- `LoginFormView`: accessible `<label>`/`<input>` pairs for email and password; error message renders with `role="alert"`, `aria-invalid`, and linked `aria-describedby`; registration confirmation message renders with `role="status"`; inputs and submit button are disabled while submitting.
- `RegisterFormView`: accessible fields for username, email, and password; field-level errors render with `id` and `aria-describedby` on the matching input; form-level error renders with `role="alert"`; all controls are disabled while submitting.

### 2. Checkout payment method selection — `checkout-review.test.ts` (5 new tests)

Extracted `PaymentMethodSelector` as a pure presentational component from `CheckoutReview.tsx`. The original component now composes it, passing `selectedMethod`, `onChange`, and `disabled` as props.

Tests verify:

- All payment methods (`cartao_credito`, `pix`) render with their pt-BR labels.
- The selected method carries the `checked` attribute; the unselected one does not.
- When no method is selected, no option is checked.
- The `disabled` flag propagates to every radio input.

### 3. Token storage security — `auth-security.test.ts` (5 new tests)

Static source-file checks read `auth-state.ts`, `AuthContext.tsx`, `client.ts`, and `auth.ts` and assert that none of them reference `localStorage` or `sessionStorage`. An additional structural test confirms `initialAuthState` carries null tokens and user.

These tests act as a regression guard: any future accidental introduction of browser storage for JWT tokens will cause the suite to fail in CI.

## How to test

```bash
cd frontend
npm ci
npm run lint
npm run test
npm run build
```

closes #121