### PR TITLE
feat: add frontend browser E2E coverage for critical flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,4 +216,6 @@ frontend/.next/
 frontend/out/
 frontend/.env
 frontend/.env.local
+frontend/playwright-report/
+frontend/test-results/
 *.tsbuildinfo

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,10 +51,42 @@ npm install
 npm run dev
 npm run lint
 npm run test
+npm run e2e
 npm run build
 ```
 
 The Next.js dev server runs on `http://localhost:3000`.
+
+## Browser E2E Tests
+
+The frontend uses Playwright for browser coverage of the critical purchase and
+guard flows required by the PRD.
+
+```bash
+npm run e2e
+npm run e2e:ci
+```
+
+The Playwright config is scoped to this package in
+[`playwright.config.ts`](./playwright.config.ts). It starts the Next.js app on
+`http://127.0.0.1:3100` and injects a stable
+`NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:40123`.
+
+E2E tests do not call a live backend. They mock all `/api/v1/**` browser
+requests through Playwright route handlers in [`e2e/support`](./e2e/support),
+using fixed catalog, auth, reservation, checkout, and expiration data. This
+keeps CI deterministic and avoids Redis, Celery, payment gateways, third-party
+services, or uncontrolled seed data.
+
+For a new CI job, install browsers once before running the CI script:
+
+```bash
+npx playwright install --with-deps chromium
+npm run e2e:ci
+```
+
+Failure artifacts are retained under `test-results/`, and the HTML report is
+written to `playwright-report/`; both paths are ignored by git.
 
 ## Docker
 

--- a/frontend/e2e/critical-flows.spec.ts
+++ b/frontend/e2e/critical-flows.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { fixedNow, setupMockApi } from "./support/api-mocks";
+
+test.beforeEach(async ({ page }) => {
+  await page.clock.install({ time: fixedNow });
+});
+
+test("registers, logs in, reserves a seat, and completes a mocked purchase", async ({
+  page,
+}) => {
+  const api = await setupMockApi(page);
+
+  await test.step("register and log in through the forms", async () => {
+    await page.goto("/register");
+    await expect(page.getByRole("heading", { name: "Criar conta" })).toBeVisible();
+
+    await page.getByLabel("Nome de usuário").fill("ana");
+    await page.getByLabel("E-mail").fill("ana@example.com");
+    await page.getByLabel("Senha").fill("senha-super-segura");
+    await page.getByRole("button", { name: "Criar conta" }).click();
+
+    await expect(
+      page.getByText("Cadastro criado com sucesso. Entre para continuar.")
+    ).toBeVisible();
+
+    await page.getByLabel("E-mail").fill("ana@example.com");
+    await page.getByLabel("Senha").fill("senha-super-segura");
+    await page.getByRole("button", { name: "Entrar" }).click();
+    await expect(page).toHaveURL("/");
+  });
+
+  await test.step("browse to a session and reserve a seat", async () => {
+    await page
+      .getByRole("link", { name: "Ver detalhes de A Jornada de Natal" })
+      .first()
+      .click();
+    await expect(page).toHaveURL("/movies/movie-natal");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "A Jornada de Natal" })
+    ).toBeVisible();
+
+    await page
+      .getByRole("link", { name: /Selecionar sessão das 15:00, sala Sala 1/ })
+      .click();
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Mapa de assentos" })
+    ).toBeVisible();
+
+    await page
+      .getByRole("button", {
+        name: /Assento A1, fileira A, número 1, Disponível/,
+      })
+      .click();
+    await expect(
+      page.getByRole("button", {
+        name: /Assento A1, fileira A, número 1, Selecionado/,
+      })
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: "Continuar" }).click();
+  });
+
+  await test.step("choose a ticket type and check out with fake PIX", async () => {
+    await expect(
+      page.getByRole("heading", { name: "Tipos de ingresso" })
+    ).toBeVisible();
+
+    await page.getByLabel(/Meia-entrada/).check();
+    await page.getByRole("link", { name: "Continuar para pagamento" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Finalizar compra" })
+    ).toBeVisible();
+    await expect(page.getByText("A Jornada de Natal").first()).toBeVisible();
+
+    await page.getByLabel(/PIX/).check();
+    await page.getByRole("button", { name: "Confirmar compra" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Compra confirmada" })
+    ).toBeVisible();
+    await expect(page.getByText("CN-E2E-A1").first()).toBeVisible();
+    expect(api.checkoutPayloads).toEqual([
+      {
+        payment_method: "pix",
+        seats: [
+          {
+            session_seat_id: "session-seat-a1",
+            ticket_type: "meia",
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+test("shows a conflict when another user already reserved the selected seat", async ({
+  page,
+}) => {
+  await setupMockApi(page, { failNextReservation: true });
+  await login(page, "/sessions/session-morning/seats");
+
+  await page
+    .getByRole("button", {
+      name: /Assento A1, fileira A, número 1, Disponível/,
+    })
+    .click();
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText:
+        "Esse assento acabou de ser reservado por outra pessoa. Escolha outro lugar.",
+    })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: /Assento A1, fileira A, número 1, Disponível/,
+    })
+  ).toBeVisible();
+});
+
+test("redirects unauthenticated visitors away from protected routes", async ({
+  page,
+}) => {
+  await setupMockApi(page);
+
+  await page.goto("/checkout");
+
+  await expect(page).toHaveURL(/\/login\?redirect=%2Fcheckout$/);
+  await expect(page.getByRole("heading", { name: "Entrar" })).toBeVisible();
+});
+
+test("expires a temporary reservation and resets the seat selection state", async ({
+  page,
+}) => {
+  await setupMockApi(page, {
+    reservationExpiresAt: new Date(fixedNow.getTime() + 5 * 60_000).toISOString(),
+  });
+  await login(page, "/sessions/session-morning/seats");
+
+  await page
+    .getByRole("button", {
+      name: /Assento A1, fileira A, número 1, Disponível/,
+    })
+    .click();
+
+  await expect(page.getByRole("timer")).toContainText("Expira em");
+
+  await page.clock.fastForward(5 * 60_000 + 1_000);
+
+  await expect(page.getByRole("timer")).toBeHidden();
+  await expect(
+    page.getByText(
+      "Sua reserva temporária expirou. Os assentos foram liberados; escolha seus lugares novamente para continuar a compra."
+    )
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: /Assento A1, fileira A, número 1, Disponível/,
+    })
+  ).toBeVisible();
+  await expect(page.getByText("Nenhum assento selecionado")).toBeVisible();
+});
+
+async function login(page: Page, redirectPath = "/") {
+  const loginPath =
+    redirectPath === "/"
+      ? "/login"
+      : `/login?redirect=${encodeURIComponent(redirectPath)}`;
+
+  await page.goto(loginPath);
+  await page.getByLabel("E-mail").fill("ana@example.com");
+  await page.getByLabel("Senha").fill("senha-super-segura");
+  await page.getByRole("button", { name: "Entrar" }).click();
+  await expect(page).toHaveURL(redirectPath);
+}

--- a/frontend/e2e/support/api-mocks.ts
+++ b/frontend/e2e/support/api-mocks.ts
@@ -1,0 +1,350 @@
+import type { Page, Route } from "@playwright/test";
+
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:40123";
+
+export const fixedNow = new Date("2026-05-24T12:00:00-03:00");
+
+const posterDataUrl =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='480' viewBox='0 0 320 480'%3E%3Crect width='320' height='480' fill='%2314141f'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff' font-family='Arial' font-size='28'%3ECinepolis%3C/text%3E%3C/svg%3E";
+
+type SessionSeat = {
+  is_accessible: boolean;
+  lock_expires_at: string | null;
+  number: number;
+  reserved_by_current_user?: boolean;
+  row: string;
+  seat_id: string;
+  session_seat_id: string;
+  status: "AVAILABLE" | "RESERVED" | "PURCHASED";
+};
+
+type MockOptions = {
+  failNextReservation?: boolean;
+  reservationExpiresAt?: string;
+};
+
+export function createMockApiState(options: MockOptions = {}) {
+  let failNextReservation = options.failNextReservation ?? false;
+  const reservationExpiresAt =
+    options.reservationExpiresAt ??
+    new Date(fixedNow.getTime() + 10 * 60 * 1000).toISOString();
+  const checkoutPayloads: unknown[] = [];
+  const reservations: string[] = [];
+  const seats: SessionSeat[] = [
+    {
+      is_accessible: false,
+      lock_expires_at: null,
+      number: 1,
+      row: "A",
+      seat_id: "seat-a1",
+      session_seat_id: "session-seat-a1",
+      status: "AVAILABLE",
+    },
+    {
+      is_accessible: false,
+      lock_expires_at: null,
+      number: 2,
+      row: "A",
+      seat_id: "seat-a2",
+      session_seat_id: "session-seat-a2",
+      status: "AVAILABLE",
+    },
+    {
+      is_accessible: false,
+      lock_expires_at: null,
+      number: 3,
+      row: "A",
+      seat_id: "seat-a3",
+      session_seat_id: "session-seat-a3",
+      status: "RESERVED",
+    },
+    {
+      is_accessible: true,
+      lock_expires_at: null,
+      number: 4,
+      row: "A",
+      seat_id: "seat-a4",
+      session_seat_id: "session-seat-a4",
+      status: "AVAILABLE",
+    },
+  ];
+
+  return {
+    checkoutPayloads,
+    handleRoute: (route: Route) =>
+      handleApiRoute(route, {
+        checkoutPayloads,
+        failNextReservation: () => failNextReservation,
+        markReservationFailureConsumed: () => {
+          failNextReservation = false;
+        },
+        reservationExpiresAt,
+        reservations,
+        seats,
+      }),
+    reservations,
+    seats,
+  };
+}
+
+export async function setupMockApi(page: Page, options: MockOptions = {}) {
+  const state = createMockApiState(options);
+
+  await page.route(`${apiBaseUrl}/api/v1/**`, state.handleRoute);
+
+  return state;
+}
+
+type ApiRouteState = {
+  checkoutPayloads: unknown[];
+  failNextReservation: () => boolean;
+  markReservationFailureConsumed: () => void;
+  reservationExpiresAt: string;
+  reservations: string[];
+  seats: SessionSeat[];
+};
+
+async function handleApiRoute(route: Route, state: ApiRouteState) {
+  const request = route.request();
+  const url = new URL(request.url());
+  const path = `${url.pathname}${url.search}`;
+  const method = request.method();
+
+  if (method === "POST" && url.pathname === "/api/v1/auth/register/") {
+    return json(route, {
+      created_at: fixedNow.toISOString(),
+      email: "ana@example.com",
+      id: "user-1",
+      username: "ana",
+    });
+  }
+
+  if (method === "POST" && url.pathname === "/api/v1/auth/login/") {
+    return json(route, {
+      access: "access-token-e2e",
+      refresh: "refresh-token-e2e",
+    });
+  }
+
+  if (method === "GET" && url.pathname === "/api/v1/users/me/") {
+    return json(route, {
+      created_at: fixedNow.toISOString(),
+      email: "ana@example.com",
+      id: "user-1",
+      username: "ana",
+    });
+  }
+
+  if (method === "GET" && url.pathname === "/api/v1/catalog/movies/") {
+    if (url.searchParams.get("status") === "pre_venda") {
+      return json(route, paginated([preSaleMovie]));
+    }
+
+    return json(route, paginated([movie]));
+  }
+
+  if (method === "GET" && url.pathname === `/api/v1/catalog/movies/${movie.id}/`) {
+    return json(route, movie);
+  }
+
+  if (method === "GET" && url.pathname === "/api/v1/catalog/sessions/") {
+    return json(route, paginated([session]));
+  }
+
+  if (method === "GET" && url.pathname === `/api/v1/catalog/sessions/${session.id}/`) {
+    return json(route, session);
+  }
+
+  if (
+    method === "GET" &&
+    url.pathname === `/api/v1/reservation/sessions/${session.id}/seats/`
+  ) {
+    return json(route, state.seats);
+  }
+
+  if (
+    method === "POST" &&
+    url.pathname === `/api/v1/reservation/sessions/${session.id}/reservations/`
+  ) {
+    if (state.failNextReservation()) {
+      state.markReservationFailureConsumed();
+      return backendError(route, 409, "SEAT_ALREADY_RESERVED");
+    }
+
+    const payload = request.postDataJSON() as { seat_ids?: string[] };
+    const requestedSeatIds = payload.seat_ids ?? [];
+    const reservedSeats = state.seats.filter((seat) =>
+      requestedSeatIds.includes(seat.seat_id)
+    );
+
+    for (const seat of reservedSeats) {
+      seat.status = "RESERVED";
+      seat.reserved_by_current_user = true;
+      seat.lock_expires_at = state.reservationExpiresAt;
+      state.reservations.push(seat.session_seat_id);
+    }
+
+    return json(route, {
+      expires_at: state.reservationExpiresAt,
+      seats: reservedSeats.map((seat) => ({
+        number: seat.number,
+        row: seat.row,
+        seat_id: seat.seat_id,
+        status: "RESERVED",
+      })),
+      session_id: session.id,
+      status: "reserved",
+    });
+  }
+
+  if (
+    method === "DELETE" &&
+    url.pathname === `/api/v1/reservation/sessions/${session.id}/reservations/`
+  ) {
+    const payload = request.postDataJSON() as { session_seat_ids?: string[] };
+    const sessionSeatIds = payload.session_seat_ids ?? [];
+    const releasedSeats = state.seats.filter((seat) =>
+      sessionSeatIds.includes(seat.session_seat_id)
+    );
+
+    for (const seat of releasedSeats) {
+      seat.status = "AVAILABLE";
+      seat.reserved_by_current_user = false;
+      seat.lock_expires_at = null;
+    }
+
+    return json(route, {
+      seats: releasedSeats,
+      session_id: session.id,
+      status: "released",
+    });
+  }
+
+  if (method === "POST" && url.pathname === "/api/v1/reservation/checkout/") {
+    const payload = request.postDataJSON();
+    state.checkoutPayloads.push(payload);
+
+    return json(route, {
+      payment_method: "pix",
+      seats: [
+        {
+          amount_paid: "18.00",
+          number: 1,
+          row: "A",
+          seat_id: "seat-a1",
+          session_seat_id: "session-seat-a1",
+          status: "PURCHASED",
+          ticket_type: "meia",
+        },
+      ],
+      status: "confirmed",
+      tickets: [
+        {
+          amount_paid: "18.00",
+          movie: {
+            id: movie.id,
+            title: movie.title,
+          },
+          payment_method: "pix",
+          room: {
+            id: session.room.id,
+            name: session.room.name,
+          },
+          seat: {
+            id: "seat-a1",
+            identifier: "A1",
+            number: 1,
+            row: "A",
+          },
+          seat_id: "seat-a1",
+          session: {
+            end_time: session.end_time,
+            id: session.id,
+            start_time: session.start_time,
+          },
+          session_seat_id: "session-seat-a1",
+          ticket_code: "CN-E2E-A1",
+          ticket_id: "ticket-a1",
+          ticket_type: "meia",
+        },
+      ],
+      total_amount: "18.00",
+    });
+  }
+
+  return backendError(route, 500, "INTERNAL_SERVER_ERROR", {
+    details: { method, path },
+    message: `Unhandled E2E API route: ${method} ${path}`,
+  });
+}
+
+const movie = {
+  duration_minutes: 128,
+  genres: [{ id: "genre-adventure", name: "Aventura" }],
+  id: "movie-natal",
+  is_featured: true,
+  poster_url: posterDataUrl,
+  release_date: "2026-05-20",
+  status: "em_cartaz",
+  synopsis: "Uma aventura criada para validar o fluxo de compra em browser.",
+  title: "A Jornada de Natal",
+};
+
+const preSaleMovie = {
+  ...movie,
+  id: "movie-presale",
+  is_featured: false,
+  status: "pre_venda",
+  title: "Estreia da Semana",
+};
+
+const session = {
+  base_price: "36.00",
+  end_time: "2026-05-24T17:10:00-03:00",
+  id: "session-morning",
+  movie,
+  room: {
+    capacity: 4,
+    id: "room-1",
+    name: "Sala 1",
+  },
+  start_time: "2026-05-24T15:00:00-03:00",
+};
+
+function paginated<T>(results: T[]) {
+  return {
+    count: results.length,
+    next: null,
+    previous: null,
+    results,
+  };
+}
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    body: JSON.stringify(body),
+    contentType: "application/json",
+    status,
+  });
+}
+
+function backendError(
+  route: Route,
+  status: number,
+  code: string,
+  options: { details?: unknown; message?: string } = {}
+) {
+  return json(
+    route,
+    {
+      error: {
+        code,
+        details: options.details ?? {},
+        message: options.message ?? code,
+        status,
+      },
+    },
+    status
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -1389,6 +1390,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4834,6 +4852,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "e2e": "playwright test",
+    "e2e:ci": "playwright test --reporter=line",
     "start": "next start",
     "lint": "eslint .",
     "test": "node --import tsx --test \"src/**/*.test.ts\""
@@ -16,6 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const frontendPort = Number(process.env.PLAYWRIGHT_FRONTEND_PORT ?? 3100);
+const frontendBaseUrl = `http://127.0.0.1:${frontendPort}`;
+const mockedApiBaseUrl =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:40123";
+
+export default defineConfig({
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  outputDir: "test-results",
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  reporter: process.env.CI
+    ? [["line"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  retries: process.env.CI ? 2 : 0,
+  testDir: "./e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: frontendBaseUrl,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: `npm run dev -- --hostname 127.0.0.1 --port ${frontendPort}`,
+    env: {
+      NEXT_PUBLIC_API_BASE_URL: mockedApiBaseUrl,
+    },
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: frontendBaseUrl,
+  },
+});


### PR DESCRIPTION
## Objective

Add deterministic browser end-to-end coverage for the critical frontend flows required by the PRD, validating the purchase flow and guard behavior from the user's perspective without depending on a live backend or external services.

## What was done

### 1. Playwright frontend E2E tooling

Added Playwright to the frontend package and scoped the configuration to `frontend/`:

- Added `@playwright/test` as a frontend dev dependency.
- Added `frontend/playwright.config.ts`.
- Added `npm run e2e` for local browser execution.
- Added `npm run e2e:ci` for CI-friendly line reporting.

The Playwright config starts the Next.js app on `http://127.0.0.1:3100` and injects a stable mocked API base URL.

### 2. Deterministic API mock strategy

Added Playwright route-based API mocks under `frontend/e2e/support/`.

The E2E tests mock all `/api/v1/**` browser requests with fixed data for:

- auth registration and login
- current user lookup
- movie catalog
- sessions
- seat maps
- temporary reservation
- checkout confirmation
- reservation conflict errors
- reservation expiration timing

This keeps the tests deterministic in CI and avoids Redis, Celery, a seeded database, payment gateways, third-party services, or uncontrolled backend data.

### 3. Purchase E2E coverage

Added a browser test covering the full mocked purchase journey:

- register a new user
- log in
- browse to a movie session
- reserve a seat
- select a ticket type
- choose PIX payment
- complete checkout
- verify the confirmation ticket
- verify the checkout payload uses the expected session seat ID and ticket type

### 4. Reserved seat conflict coverage

Added a browser test that simulates `SEAT_ALREADY_RESERVED` from the reservation endpoint.

The test verifies that the UI:

- shows the friendly Portuguese conflict message
- reverts the optimistic seat selection state
- leaves the seat available for a new choice

### 5. Protected route guard coverage

Added a browser test for unauthenticated protected-route access.

The test verifies that visiting `/checkout` while unauthenticated redirects to `/login?redirect=%2Fcheckout` and renders the login page instead of protected checkout content.

### 6. Reservation expiration coverage

Added a browser test using Playwright's controlled clock to validate temporary reservation expiration.

The test verifies that the UI:

- starts with an active reservation countdown
- expires the reservation deterministically
- clears selected seats from the order summary
- restores the expired seat to available
- displays the PRD-required recovery message

### 7. CI readiness and failure artifacts

Configured Playwright to retain useful debugging artifacts on failure:

- traces retained on failure
- screenshots captured on failure
- videos retained on failure
- artifacts written under `frontend/test-results/`
- HTML report written under `frontend/playwright-report/`

Both artifact directories are ignored by git.

### 8. Documentation

Updated `frontend/README.md` with:

- the new E2E commands
- the mocked API strategy
- CI installation guidance for Chromium
- the stable `NEXT_PUBLIC_API_BASE_URL`
- artifact locations for debugging failures

## How to test

### Automated validation

From `frontend/`:

```bash
npm run lint
npm run test
npm run e2e:ci
```

### Local browser E2E run

From `frontend/`:

```bash
npx playwright install chromium
npm run e2e
```

### CI setup note

A CI job can install the browser once and run the CI script:

```bash
npx playwright install --with-deps chromium
npm run e2e:ci
```

## Expected Result

- Playwright is available as the frontend browser E2E framework.
- Critical PRD purchase and guard flows are covered from a user's perspective.
- Tests run deterministically against mocked browser network calls.
- E2E execution can be safely added to CI without backend services.
- Failure artifacts are available for debugging.
- Existing lint and frontend tests continue to pass.

closes #123
