### PR TITLE
feat: finalize frontend CI, Docker, and deployment readiness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
   frontend:
     name: Validate Frontend
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
     defaults:
       run:
         working-directory: frontend
@@ -78,6 +80,12 @@ jobs:
 
       - name: Run frontend tests
         run: npm run test
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run frontend E2E tests
+        run: npm run e2e:ci
 
       - name: Build frontend
         run: npm run build
@@ -111,4 +119,4 @@ jobs:
         run: docker build -t cinepolis-natal-backend:ci backend
 
       - name: Build frontend image
-        run: docker build -t cinepolis-natal-frontend:ci frontend
+        run: docker build --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 -t cinepolis-natal-frontend:ci frontend

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Detailed product requirements are in [`product-requirements-document.md`](./prod
 | Path | Ownership |
 | --- | --- |
 | [`backend/`](./backend/) | Django API, DRF apps, tests, Python dependency files, backend Dockerfile, Postman collection |
-| [`frontend/`](./frontend/) | Next.js App Router scaffold, route placeholders, API client boundary, frontend Dockerfile |
+| [`frontend/`](./frontend/) | Next.js App Router app, API client boundary, frontend Dockerfiles, tests |
 | [`docker-compose.yml`](./docker-compose.yml) | Full-stack local runtime wiring |
 | [`.github/workflows/`](./.github/workflows/) | Independent backend, frontend, and Docker validation |
 | [`product-requirements-document.md`](./product-requirements-document.md) | Full-stack PRD |
@@ -49,25 +49,28 @@ docker compose exec celery celery -A cinepolis_natal_api inspect ping
 
 ## Frontend
 
-Frontend commands and SPA scaffold notes live in [`frontend/README.md`](./frontend/README.md).
+Frontend commands, Docker usage, and deployment notes live in [`frontend/README.md`](./frontend/README.md).
 
 Common local commands:
 
 ```bash
 cd frontend
-npm install
+npm ci
 npm run dev
 npm run lint
 npm run test
+npm run e2e:ci
 npm run build
 ```
 
-The frontend reads the backend base URL from `NEXT_PUBLIC_API_BASE_URL`.
+The frontend requires `NEXT_PUBLIC_API_BASE_URL`. Local Compose injects
+`http://localhost:8000` for the frontend dev service; production frontend Docker
+builds must receive the deployed API origin as a build argument.
 
 ## CI
 
 GitHub Actions validates the two apps independently:
 
 - backend Docker Compose checks, migrations, and tests
-- frontend install, lint, tests, and build from `frontend/`
-- Docker Compose config plus backend/frontend image builds
+- frontend install, lint, unit/integration tests, Playwright E2E, and build from `frontend/`
+- Docker Compose config plus backend and production frontend image builds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   frontend:
     build:
       context: ./frontend
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     container_name: cinepolis_natal_frontend
     command: sh -c "npm ci && npm run dev -- -H 0.0.0.0"
     volumes:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -3,4 +3,7 @@ dist
 .next
 .env
 .env.local
+playwright-report
+test-results
+coverage
 npm-debug.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22-alpine AS deps
 
 WORKDIR /app
 
@@ -6,8 +6,36 @@ COPY package*.json ./
 
 RUN npm ci
 
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
+RUN npm run build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV HOSTNAME=0.0.0.0
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
 
 EXPOSE 3000
 
-CMD ["npm", "run", "dev", "--", "-H", "0.0.0.0"]
+CMD ["node", "server.js"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,13 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,6 @@
 # Cinepolis Natal Frontend
 
-Browser-based SPA foundation for the full-stack Cinepolis Natal platform.
-
-This workspace intentionally contains placeholders only. Full cinema UI flows will be implemented in dedicated frontend issues.
+Next.js App Router frontend for the full-stack Cinepolis Natal cinema ticket reservation platform.
 
 ## Stack
 
@@ -10,11 +8,12 @@ This workspace intentionally contains placeholders only. Full cinema UI flows wi
 - App Router
 - TypeScript
 - Node.js test runner with `tsx`
+- Playwright
 - ESLint
 
 ## Routes
 
-The scaffold defines the PRD page entrypoints:
+The frontend implements the PRD purchase and account entrypoints:
 
 | Route | Page |
 | --- | --- |
@@ -32,7 +31,12 @@ The scaffold defines the PRD page entrypoints:
 
 The API client boundary lives at [`src/api/client.ts`](./src/api/client.ts).
 
-Set the backend base URL with:
+The frontend requires `NEXT_PUBLIC_API_BASE_URL`, an absolute `http` or `https`
+URL for the Django/DRF API. Because this is a `NEXT_PUBLIC_*` variable, it is
+compiled into browser code during `npm run build`; set the production value at
+build time, not only when starting the container.
+
+Local development example:
 
 ```bash
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
@@ -44,18 +48,47 @@ For local setup:
 cp .env.example .env.local
 ```
 
-## Commands
+Docker Compose sets `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000` for the
+frontend dev service. This lets the browser call the backend through the API
+port exposed on the host.
+
+Production deployments should set the public API URL to the deployed backend
+origin, for example `https://api.example.com`, while the backend separately
+allows the frontend origin through CORS configuration. Do not commit secrets to
+frontend env files; public frontend variables are visible to users.
+
+The production build validates this required variable with:
 
 ```bash
-npm install
+npm run validate:env
+```
+
+## Commands
+
+Install with the lockfile:
+
+```bash
+npm ci
+```
+
+Run the local dev server on `http://localhost:3000`:
+
+```bash
 npm run dev
+```
+
+Quality and build checks:
+
+```bash
 npm run lint
 npm run test
-npm run e2e
+npm run e2e:ci
 npm run build
 ```
 
-The Next.js dev server runs on `http://localhost:3000`.
+`npm run test` covers unit and integration tests under `src/`.
+After a successful build, `npm run start` runs the generated Next.js standalone
+server.
 
 ## Browser E2E Tests
 
@@ -90,10 +123,60 @@ written to `playwright-report/`; both paths are ignored by git.
 
 ## Docker
 
-From the repository root:
+### Development
+
+The root Compose file uses [`Dockerfile.dev`](./Dockerfile.dev), bind mounts the
+frontend source, installs dependencies into a named volume, and runs the Next.js
+development server:
 
 ```bash
 docker compose up frontend
 ```
 
-The Compose service injects `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000` so the browser can call the backend through the host-exposed API port.
+This path is intended for local work and remains hot-reload friendly.
+
+### Production Image
+
+The default [`Dockerfile`](./Dockerfile) is production-oriented:
+
+- installs dependencies with `npm ci`
+- builds with `npm run build`
+- uses Next.js `output: "standalone"`
+- copies only the standalone server and static assets into the runtime stage
+- starts with `node server.js`, matching the package `npm run start` strategy
+
+Build it from the repository root with the public API URL supplied at build
+time:
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_API_BASE_URL=https://api.example.com \
+  -t cinepolis-natal-frontend:prod \
+  frontend
+```
+
+Run the production container:
+
+```bash
+docker run --rm -p 3000:3000 cinepolis-natal-frontend:prod
+```
+
+Static CDN or Nginx-only hosting should not be assumed for this app. Use that
+strategy only if the project is explicitly changed to a static export and the
+routes/data-fetching behavior are validated for that mode.
+
+## CI
+
+GitHub Actions validates the frontend from this package with:
+
+```bash
+npm ci
+npm run lint
+npm run test
+npx playwright install --with-deps chromium
+npm run e2e:ci
+npm run build
+```
+
+The Docker validation job also builds the production frontend image with
+`NEXT_PUBLIC_API_BASE_URL` passed as a build argument.

--- a/frontend/frontend-product-requirements-document.md
+++ b/frontend/frontend-product-requirements-document.md
@@ -900,7 +900,9 @@ The frontend CI workflow must run:
 1. `npm ci`
 2. `npm run lint`
 3. `npm run test`
-4. `npm run build`
+4. `npx playwright install --with-deps chromium`
+5. `npm run e2e:ci`
+6. `npm run build`
 
 ---
 
@@ -910,16 +912,17 @@ The frontend CI workflow must run:
 
 | Variable | Description | Example |
 |---|---|---|
-| `NEXT_PUBLIC_API_BASE_URL` | Backend REST API base URL | `http://localhost:8000` |
+| `NEXT_PUBLIC_API_BASE_URL` | Backend REST API base URL compiled into browser code at build time | `http://localhost:8000` |
 
 ### 12.2 Local Commands
 
 ```bash
 cd frontend
-npm install
+npm ci
 npm run dev
 npm run lint
 npm run test
+npm run e2e:ci
 npm run build
 ```
 
@@ -927,10 +930,10 @@ The development server runs on `http://localhost:3000`.
 
 ### 12.3 Docker and Deployment
 
-- The current frontend Dockerfile is development-oriented and runs `npm run dev`.
-- The root `docker-compose.yml` mounts the frontend directory and injects `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`.
-- Production deployment should use a Next.js-compatible runtime strategy.
-- A production Dockerfile should use a multi-stage build with `npm ci`, `npm run build`, and a minimal runtime.
+- The default frontend Dockerfile is production-oriented, multi-stage, installs with `npm ci`, runs `npm run build`, and uses a minimal Next.js standalone runtime.
+- The root `docker-compose.yml` keeps local development on `Dockerfile.dev`, mounts the frontend directory, and injects `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`.
+- Production Docker builds must pass `NEXT_PUBLIC_API_BASE_URL` as a build argument because public Next.js variables are compiled into browser assets.
+- The production container starts with the Next.js standalone runtime command `node server.js`.
 - Static CDN or Nginx-only hosting should be used only if the project is explicitly configured for static export.
 
 ---

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  output: "standalone",
+};
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,12 @@
     "build": "next build",
     "e2e": "playwright test",
     "e2e:ci": "playwright test --reporter=line",
-    "start": "next start",
+    "start": "node .next/standalone/server.js",
     "lint": "eslint .",
-    "test": "node --import tsx --test \"src/**/*.test.ts\""
+    "prebuild": "npm run validate:env",
+    "postbuild": "node scripts/prepare-standalone.mjs",
+    "test": "node --import tsx --test \"src/**/*.test.ts\" \"src/**/*.integration.test.ts\"",
+    "validate:env": "node scripts/validate-env.mjs"
   },
   "dependencies": {
     "next": "^15.5.0",

--- a/frontend/scripts/prepare-standalone.mjs
+++ b/frontend/scripts/prepare-standalone.mjs
@@ -1,0 +1,24 @@
+import { cpSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const standaloneDir = resolve(process.cwd(), ".next/standalone");
+
+if (!existsSync(standaloneDir)) {
+  process.exit(0);
+}
+
+copyIfExists(".next/static", ".next/standalone/.next/static");
+copyIfExists("public", ".next/standalone/public");
+
+function copyIfExists(source, destination) {
+  const sourcePath = resolve(process.cwd(), source);
+
+  if (!existsSync(sourcePath)) {
+    return;
+  }
+
+  cpSync(sourcePath, resolve(process.cwd(), destination), {
+    force: true,
+    recursive: true,
+  });
+}

--- a/frontend/scripts/validate-env.mjs
+++ b/frontend/scripts/validate-env.mjs
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const requiredPublicEnv = ["NEXT_PUBLIC_API_BASE_URL"];
+
+const nodeEnv = process.env.NODE_ENV;
+const envFiles = [
+  ".env",
+  nodeEnv ? `.env.${nodeEnv}` : null,
+  ".env.local",
+  nodeEnv ? `.env.${nodeEnv}.local` : null,
+].filter(Boolean);
+
+const fileEnv = Object.assign({}, ...envFiles.map(readEnvFile));
+const missingVariables = requiredPublicEnv.filter(
+  (name) => !getEnvValue(name, fileEnv)
+);
+
+if (missingVariables.length > 0) {
+  console.error(
+    `Missing required frontend environment variable: ${missingVariables.join(", ")}`
+  );
+  process.exit(1);
+}
+
+const apiBaseUrl = getEnvValue("NEXT_PUBLIC_API_BASE_URL", fileEnv);
+
+try {
+  const parsedUrl = new URL(apiBaseUrl);
+
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    throw new Error("URL must use http or https");
+  }
+} catch {
+  console.error(
+    "NEXT_PUBLIC_API_BASE_URL must be an absolute http(s) URL, for example http://localhost:8000"
+  );
+  process.exit(1);
+}
+
+function getEnvValue(name, fallbackEnv) {
+  return process.env[name]?.trim() || fallbackEnv[name]?.trim() || "";
+}
+
+function readEnvFile(fileName) {
+  const path = resolve(process.cwd(), fileName);
+
+  if (!existsSync(path)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    readFileSync(path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#") && line.includes("="))
+      .map((line) => {
+        const separatorIndex = line.indexOf("=");
+        const name = line.slice(0, separatorIndex).trim();
+        const value = line
+          .slice(separatorIndex + 1)
+          .trim()
+          .replace(/^['"]|['"]$/g, "");
+
+        return [name, value];
+      })
+  );
+}

--- a/product-requirements-document.md
+++ b/product-requirements-document.md
@@ -564,13 +564,13 @@ The seat map is a grid derived from the `SessionSeat` list returned by `GET /api
 
 - Docker Compose stack includes: `web`, `db`, `redis`, `celery`, and optionally `frontend` services.
 - Environment variables control DB connection, Redis, JWT lifetimes, throttling, email, logging behavior, and frontend API base URL.
-- The frontend build artifact (static files) may be served by a dedicated Nginx container or a CDN.
+- The frontend production deployment uses a Next.js-compatible runtime container unless the app is explicitly configured and validated for static export.
 
 ### 12.2 CI Requirements
 
 GitHub Actions pipeline validates:
 - Backend: dependency installation via Poetry, Django system check, migrations, test suite execution
-- Frontend: dependency installation, linting, build, unit and integration tests
+- Frontend: dependency installation, linting, unit/integration tests, Playwright E2E tests, and production build
 - Docker Compose configuration validation
 - Docker image build (both backend and frontend images)
 


### PR DESCRIPTION
## Objective

Finalize frontend operational readiness for the completed Next.js application by tightening CI gates, separating development and production Docker strategies, documenting environment expectations, and validating production build/runtime behavior.

## What was done

### 1. Frontend CI quality gates

Updated the frontend GitHub Actions job so it validates the full frontend quality path:

- `npm ci`
- `npm run lint`
- `npm run test`
- `npx playwright install --with-deps chromium`
- `npm run e2e:ci`
- `npm run build`

The Docker validation job now also builds the production frontend image with `NEXT_PUBLIC_API_BASE_URL` passed as a build argument.

### 2. Unit, integration, and E2E command coverage

Adjusted `npm run test` so it includes both unit tests and integration tests under `src/`.

Kept Playwright E2E coverage as a separate CI step through `npm run e2e:ci`, matching the browser-level critical flow coverage already present in the frontend package.

### 3. Production Docker strategy

Reworked the default frontend Dockerfile into a production-ready multi-stage build:

- installs dependencies with `npm ci`
- validates environment before build
- runs `npm run build`
- uses Next.js standalone output
- copies only standalone runtime assets into the final image
- runs with `node server.js` as a Next.js-compatible production runtime command

### 4. Development Docker preserved

Added `frontend/Dockerfile.dev` for local development and updated the root Compose frontend service to keep using a hot-reload friendly dev container.

The Compose service still bind mounts the frontend source, keeps dependencies in the named `frontend_node_modules` volume, and injects `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`.

### 5. Environment validation

Added frontend environment validation for `NEXT_PUBLIC_API_BASE_URL`.

The validator requires the value to be present and to use an absolute `http` or `https` URL. The production build runs this validation through `prebuild`.

### 6. Standalone runtime support

Enabled Next.js standalone output in `next.config.ts` and aligned `npm run start` with the standalone server.

Added a small post-build preparation script so local standalone starts have the expected static/public assets available.

### 7. Documentation and deployment notes

Updated the frontend README, root README, and PRD documentation to clarify:

- local frontend commands
- CI commands
- Docker development vs production usage
- `NEXT_PUBLIC_API_BASE_URL` behavior for local, Compose, CI, Docker, and production
- why static CDN/Nginx-only hosting should not be assumed unless static export is explicitly configured and validated

## How to test

### Automated validation

Run frontend validation locally:

```bash
cd frontend
npm ci
npm run lint
npm run test
npx playwright install chromium
npm run e2e:ci
NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run build
```

Validate Compose and Docker builds from the repository root:

```bash
docker compose -f docker-compose.yml config
docker compose build frontend
docker build --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 -t cinepolis-natal-frontend:issue-124 frontend
```

### Runtime smoke test

```bash
docker run --rm -d -p 3001:3000 --name cinepolis_frontend_issue_124 cinepolis-natal-frontend:issue-124
curl -I http://127.0.0.1:3001
docker stop cinepolis_frontend_issue_124
```

Expected response: `HTTP/1.1 200 OK`.

## Expected Result

- Frontend CI runs install, lint, tests, E2E, and production build.
- New integration and E2E commands are documented and wired into CI.
- A production-ready frontend Docker build strategy exists.
- Local Docker Compose development remains usable.
- `NEXT_PUBLIC_API_BASE_URL` is documented for local and production usage.
- Production builds validate required frontend environment configuration.
- The production image uses a Next.js-compatible standalone runtime command.
- README and PRD docs reflect local, CI, Docker, and deployment expectations.

closes #124
