### PR TITLE
fix: run backend migrations during compose startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ cp .env.example .env
 docker compose up --build
 ```
 
+The backend container uses its Dockerfile startup command, which applies Django
+migrations before starting the development server.
+
 Services:
 
 - Backend API: `http://localhost:8000`

--- a/backend/README.md
+++ b/backend/README.md
@@ -142,7 +142,9 @@ cp .env.example .env
 docker compose up --build
 ```
 
-This provisions the backend API, frontend dev server, PostgreSQL, Redis, and Celery worker. The backend remains available at `http://localhost:8000`.
+This provisions the backend API, frontend dev server, PostgreSQL, Redis, and
+Celery worker. The backend runs Django migrations during container startup before
+serving requests, then remains available at `http://localhost:8000`.
 
 Common backend commands:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: cinepolis_natal_backend
-    command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./backend:/app
     ports:


### PR DESCRIPTION
## Objective

Fix Docker Compose startup so the backend applies Django database migrations before it begins serving API requests. This prevents fresh `docker compose up --build` environments from returning `500 Internal Server Error` responses caused by missing database tables.

## What was done

### 1. Backend Compose startup

Removed the backend `command` override from `docker-compose.yml`.

This lets the backend service use the Dockerfile `CMD`, which already runs:

```bash
python manage.py migrate && python manage.py runserver 0.0.0.0:8000
```

### 2. Fresh database startup behavior

Verified the startup flow with a clean temporary Compose project and a new PostgreSQL volume.

The backend logs showed all Django migrations applying before the development server started.

### 3. Documentation alignment

Updated the Docker startup instructions to make the migration behavior explicit:

- root `README.md`
- `backend/README.md`

The docs now state that Compose startup runs backend migrations before serving requests.

## How to test

### Automated/manual validation performed

Validated Compose configuration:

```bash
docker compose config --quiet
```

Validated a clean database startup using a temporary Compose project with an empty PostgreSQL volume:

```bash
docker compose -p cinepolis_issue_131 up --build -d db redis backend
```

Confirmed backend startup logs included migration execution before `runserver`:

```text
Operations to perform:
  Apply all migrations: admin, auth, catalog, contenttypes, reservations, sessions, users
Running migrations:
  ... OK
Starting development server at http://0.0.0.0:8000/
```

Validated the main API flows after fresh startup:

```bash
GET  /api/v1/catalog/movies/    -> 200
GET  /api/v1/catalog/sessions/  -> 200
POST /api/v1/auth/register/     -> 201
POST /api/v1/auth/login/        -> 200
```

Also ran:

```bash
git diff --check
```

## Expected Result

- `docker compose up --build` runs Django migrations before starting the backend server.
- Fresh PostgreSQL volumes no longer produce missing-table `500` responses for account, login, catalog, or session API calls.
- Registration and login work after a fresh Compose startup.
- Movie and session list endpoints work after a fresh Compose startup.
- Compose no longer silently overrides the migration-capable Dockerfile command.
- Docker documentation matches the actual startup behavior.

closes #131
