### PR TITLE
fix: add Docker Compose health checks for backend dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,10 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - .env
 
@@ -41,12 +43,22 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "cinepolis_natal"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   redis:
     image: redis:7
     container_name: cinepolis_natal_redis
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   celery:
     build:
@@ -57,8 +69,10 @@ services:
     volumes:
       - ./backend:/app
     depends_on:
-      - redis
-      - db
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - .env
 


### PR DESCRIPTION
## Objective

Add Docker Compose health checks and health-based dependencies so the backend and Celery services wait for PostgreSQL and Redis readiness before starting. This fixes the Compose startup race documented as BUG-02.

## What was done

### 1. PostgreSQL health check

Added a Compose health check to the `db` service using `pg_isready` against the configured local database.

- command: `pg_isready -U postgres -d cinepolis_natal`
- interval: `5s`
- timeout: `5s`
- retries: `10`

### 2. Redis health check

Added a Compose health check to the `redis` service using `redis-cli ping`.

- command: `redis-cli ping`
- interval: `5s`
- timeout: `3s`
- retries: `10`

### 3. Health-based backend dependencies

Updated the `backend` service dependencies so Docker Compose waits for both dependency services to become healthy before starting Django.

- `db` uses `condition: service_healthy`
- `redis` uses `condition: service_healthy`

### 4. Health-based Celery dependencies

Updated the `celery` service dependencies so Docker Compose waits for PostgreSQL and Redis readiness before starting the worker.

- `db` uses `condition: service_healthy`
- `redis` uses `condition: service_healthy`

### 5. Compose-only fix

Kept the change limited to Docker Compose infrastructure.

- no Django database code changes
- no Redis/cache logic changes
- no retry library or app-level startup retry changes
- no external orchestration changes

## How to test

### Automated validation

Validate the Compose file:

```bash
docker compose config
```

Check for whitespace or patch issues:

```bash
git diff --check -- docker-compose.yml
```

### Startup verification

Run repeated focused startup cycles for the dependent services:

```bash
docker compose up -d backend celery
docker compose ps
docker compose logs --no-color backend
docker compose logs --no-color celery
docker compose down
```

Expected observations:

- `db` reaches `healthy` before `backend` and `celery` start.
- `redis` reaches `healthy` before `backend` and `celery` start.
- backend startup reaches Django migrations/server startup without dependency connection-refused races.
- Celery starts and connects to Redis as broker.

## Expected Result

- PostgreSQL readiness is checked with `pg_isready`.
- Redis readiness is checked with `redis-cli ping`.
- `backend` waits for healthy `db` and `redis` services.
- `celery` waits for healthy `db` and `redis` services.
- repeated Compose startup avoids the previous dependency readiness race.
- `docker compose config` remains valid and CI-compatible.

closes #132
