### PR TITLE
fix: make catalog cache resilient to Redis outages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     name: Validate Backend
@@ -58,6 +62,7 @@ jobs:
   frontend:
     name: Validate Frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
     defaults:
@@ -71,6 +76,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
         run: npm ci
@@ -85,6 +92,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run frontend E2E tests
+        timeout-minutes: 5
         run: npm run e2e:ci
 
       - name: Build frontend

--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -24,21 +24,54 @@ SESSION_LIST_CACHE_VERSION_KEY = "catalog:sessions:version"
 INITIAL_CACHE_VERSION = 1
 
 
+def _safe_cache_add(key, value, *, timeout):
+    try:
+        return cache.add(key, value, timeout=timeout)
+    except Exception:
+        return None
+
+
+def _safe_cache_get(key):
+    try:
+        return cache.get(key)
+    except Exception:
+        return None
+
+
+def _safe_cache_set(key, value, *, timeout):
+    try:
+        cache.set(key, value, timeout=timeout)
+    except Exception:
+        return
+
+
+def _safe_cache_incr(key):
+    try:
+        return cache.incr(key)
+    except ValueError:
+        return None
+    except Exception:
+        return None
+
+
 def _get_cache_namespace_version(version_key):
-    cache.add(version_key, INITIAL_CACHE_VERSION, timeout=None)
-    return cache.get(version_key)
+    if _safe_cache_add(version_key, INITIAL_CACHE_VERSION, timeout=None) is None:
+        return None
+    return _safe_cache_get(version_key)
 
 
 def _bump_cache_namespace_version(version_key):
-    cache.add(version_key, INITIAL_CACHE_VERSION, timeout=None)
-    try:
-        cache.incr(version_key)
-    except ValueError:
-        cache.set(version_key, INITIAL_CACHE_VERSION + 1, timeout=None)
+    if _safe_cache_add(version_key, INITIAL_CACHE_VERSION, timeout=None) is None:
+        return
+
+    if _safe_cache_incr(version_key) is None:
+        _safe_cache_set(version_key, INITIAL_CACHE_VERSION + 1, timeout=None)
 
 
 def _catalog_list_cache_key(namespace, version_key, request):
     version = _get_cache_namespace_version(version_key)
+    if version is None:
+        return None
     return f"catalog:{namespace}:v{version}:{request.get_full_path()}"
 
 
@@ -151,13 +184,16 @@ class MovieListCreateView(ListCreateAPIView):
             MOVIE_LIST_CACHE_VERSION_KEY,
             request,
         )
-        cached_response = cache.get(cache_key)
+        cached_response = None
+        if cache_key is not None:
+            cached_response = _safe_cache_get(cache_key)
 
         if cached_response is not None:
             return Response(cached_response)
 
         response = super().list(request, *args, **kwargs)
-        cache.set(cache_key, response.data, timeout=self.CACHE_TTL_SECONDS)
+        if cache_key is not None:
+            _safe_cache_set(cache_key, response.data, timeout=self.CACHE_TTL_SECONDS)
         return response
 
     def create(self, request, *args, **kwargs):
@@ -306,13 +342,16 @@ class SessionListCreateView(ListCreateAPIView):
             SESSION_LIST_CACHE_VERSION_KEY,
             request,
         )
-        cached_response = cache.get(cache_key)
+        cached_response = None
+        if cache_key is not None:
+            cached_response = _safe_cache_get(cache_key)
 
         if cached_response is not None:
             return Response(cached_response)
 
         response = super().list(request, *args, **kwargs)
-        cache.set(cache_key, response.data, timeout=self.CACHE_TTL_SECONDS)
+        if cache_key is not None:
+            _safe_cache_set(cache_key, response.data, timeout=self.CACHE_TTL_SECONDS)
         return response
 
     def create(self, request, *args, **kwargs):

--- a/backend/tests/integration/test_catalog_api.py
+++ b/backend/tests/integration/test_catalog_api.py
@@ -9,8 +9,43 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
+import catalog.views as catalog_views
 from catalog.models import Genre, Movie, MovieStatus, Room, Session
 from users.models import User
+
+
+class UnavailableCatalogCache:
+    def add(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def get(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def set(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def incr(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+
+class FailingCatalogCacheRead:
+    def __init__(self):
+        self.get_calls = 0
+
+    def add(self, *args, **kwargs):
+        return False
+
+    def get(self, *args, **kwargs):
+        self.get_calls += 1
+        if self.get_calls == 1:
+            return 1
+        raise ConnectionError("Redis unavailable")
+
+    def set(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def incr(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
 
 
 @pytest.mark.django_db
@@ -714,6 +749,21 @@ class TestCatalogApi:
         assert first_response.data == second_response.data
         assert len(second_request_queries) < len(first_request_queries)
 
+    def test_list_movies_should_fall_back_to_database_when_cache_read_fails(
+        self,
+        monkeypatch,
+        anonymous_api_client,
+        movie,
+    ):
+        monkeypatch.setattr(catalog_views, "cache", FailingCatalogCacheRead())
+
+        response = anonymous_api_client.get("/api/v1/catalog/movies/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == str(movie.id)
+        assert "error" not in response.data
+
     def test_movie_list_cache_should_remain_query_aware(self, api_client, genre):
         cache.clear()
         current_movie = self.create_movie(
@@ -754,6 +804,21 @@ class TestCatalogApi:
         assert second_response.status_code == status.HTTP_200_OK
         assert first_response.data == second_response.data
         assert len(second_request_queries) < len(first_request_queries)
+
+    def test_list_sessions_should_fall_back_to_database_when_cache_is_unavailable(
+        self,
+        monkeypatch,
+        anonymous_api_client,
+        session,
+    ):
+        monkeypatch.setattr(catalog_views, "cache", UnavailableCatalogCache())
+
+        response = anonymous_api_client.get("/api/v1/catalog/sessions/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == str(session.id)
+        assert "error" not in response.data
 
     def test_movie_list_cache_should_be_invalidated_after_movie_creation(
         self,


### PR DESCRIPTION
## Objective

Make catalog list caching resilient when Redis is unavailable, so public movie and session listing endpoints continue to serve database-backed responses instead of returning `500 Internal Server Error`.

## What was done

### 1. Cache namespace version fallback

Wrapped catalog cache namespace operations in safe helpers:

- `cache.add()` failures now return a safe fallback.
- `cache.get()` failures are treated as cache misses.
- Redis/cache connection exceptions no longer propagate from namespace version handling to DRF responses.

### 2. Cache key handling

Updated catalog list cache key construction so a missing namespace version is handled gracefully.

- When the namespace version cannot be read, no cache key is generated.
- The endpoint skips cache read/write and proceeds with the normal database-backed list response.

### 3. Catalog endpoint fallback behavior

Adjusted both cached catalog list endpoints to treat cache failures as miss semantics:

- `GET /api/v1/catalog/movies/` falls back to the movie queryset and serializer path.
- `GET /api/v1/catalog/sessions/` falls back to the session queryset and serializer path.
- Cache write failures after a database response is built are ignored so the API response still succeeds.

### 4. Redis failure test coverage

Added integration tests that monkeypatch the catalog cache object to simulate Redis/cache failures:

- movie list fallback when cache reads fail
- session list fallback when the cache is unavailable
- assertions that responses remain `200 OK`, return database records, and do not leak raw error payloads

### 5. Existing cache behavior preserved

Kept the normal Redis caching path intact.

- Existing cache-hit tests for movie and session list endpoints still pass.
- Existing namespace-version invalidation tests still pass.
- Redis caching remains enabled; this only makes catalog list caching failure-tolerant.

### 6. CI runtime guard for frontend validation

Added frontend CI safeguards after the PR run exposed a stuck Playwright E2E step:

- workflow concurrency now cancels older runs for the same PR/ref
- frontend job has a 10-minute timeout
- frontend E2E step has a 5-minute timeout
- setup-node now caches npm dependencies using `frontend/package-lock.json`

## Acceptance Criteria

- Redis Failure Safe: satisfied. Catalog list endpoints no longer return `500` when cache operations fail.
- Database Fallback: satisfied. Movies and sessions are still returned from PostgreSQL-backed querysets.
- Cache Miss Semantics: satisfied. Cache read/version failures are treated like misses.
- No Raw Exceptions: satisfied. Simulated Redis connection failures do not leak to API clients.
- Tests Added: satisfied. Added fallback coverage for movie and session listing.
- Normal Cache Path: satisfied. Existing cache behavior and invalidation tests continue to pass.

## How to test

### Automated validation

```bash
POSTGRES_HOST=localhost REDIS_URL=redis://localhost:6379/1 poetry run pytest tests/integration/test_catalog_api.py -q
```

### Full backend validation

```bash
POSTGRES_HOST=localhost REDIS_URL=redis://localhost:6379/1 poetry run pytest -q
```

### Frontend E2E validation

```bash
CI=1 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run e2e:ci
```

### Lint and formatting

```bash
RUFF_CACHE_DIR=/tmp/cinepolis-ruff-cache poetry run ruff check catalog/views.py tests/integration/test_catalog_api.py
poetry run black --check catalog/views.py tests/integration/test_catalog_api.py
git diff --check
```

## Expected Result

- Catalog movie and session list endpoints remain available when Redis is down.
- Redis-backed caching still works normally when Redis is available.
- Cache errors are contained to the cache integration boundary.
- Public catalog browsing remains backed by database data instead of failing with `500`.
- Full backend test suite passes.
- Frontend CI does not remain stuck indefinitely when an E2E step hangs.

closes #133
