### PR TITLE
fix: add release_date to CatalogMovie frontend type

### DIFF
--- a/frontend/src/api/catalog.test.ts
+++ b/frontend/src/api/catalog.test.ts
@@ -24,6 +24,34 @@ const paginatedMoviesResponse = {
   results: [],
 };
 
+const paginatedMoviesWithReleaseDateResponse = {
+  count: 2,
+  next: null,
+  previous: null,
+  results: [
+    {
+      duration_minutes: 125,
+      genres: [{ id: "genre-1", name: "Aventura" }],
+      id: "movie-123",
+      is_featured: true,
+      poster_url: "https://cdn.example.com/movie.jpg",
+      release_date: "2026-05-13",
+      status: "em_cartaz",
+      title: "A Jornada",
+    },
+    {
+      duration_minutes: 90,
+      genres: [],
+      id: "movie-456",
+      is_featured: false,
+      poster_url: "https://cdn.example.com/movie2.jpg",
+      release_date: null,
+      status: "pre_venda",
+      title: "Sem Data",
+    },
+  ],
+};
+
 const sessionResponse = {
   count: 1,
   next: null,
@@ -203,6 +231,42 @@ test("catalogApi rejects unexpected movie detail responses", async () => {
     await assert.rejects(
       catalogApi.getMovie("movie-123"),
       /Unexpected catalog movie detail response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi lists movies with release_date field in results", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json(paginatedMoviesWithReleaseDateResponse);
+
+    const response = await catalogApi.listMovies();
+
+    assert.deepEqual(response, paginatedMoviesWithReleaseDateResponse);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("catalogApi rejects movie list results with invalid movie objects", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () =>
+      Response.json({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [{ id: "movie-bad" }],
+      });
+
+    await assert.rejects(
+      catalogApi.listMovies(),
+      /Unexpected catalog movie list response/
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -92,7 +92,10 @@ async function listMovies(params: ListMoviesParams) {
     method: "GET",
   });
 
-  if (!isPaginatedResponse<CatalogMovie>(response)) {
+  if (
+    !isPaginatedResponse<CatalogMovie>(response) ||
+    !response.results.every(isCatalogMovie)
+  ) {
     throw new Error("Unexpected catalog movie list response.");
   }
 
@@ -144,6 +147,9 @@ function isCatalogMovie(value: unknown): value is CatalogMovie {
     Array.isArray(value.genres) &&
     value.genres.every(isCatalogGenre) &&
     typeof value.duration_minutes === "number" &&
+    (typeof value.release_date === "string" ||
+      value.release_date === null ||
+      value.release_date === undefined) &&
     typeof value.poster_url === "string" &&
     (value.status === "em_cartaz" || value.status === "pre_venda") &&
     typeof value.is_featured === "boolean"

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -10,6 +10,7 @@ export type CatalogMovie = {
   title: string;
   genres: CatalogGenre[];
   duration_minutes: number;
+  release_date?: string | null;
   poster_url: string;
   status: MovieStatus;
   is_featured: boolean;
@@ -17,7 +18,6 @@ export type CatalogMovie = {
 
 export type CatalogMovieDetail = CatalogMovie & {
   created_at?: string;
-  release_date?: string | null;
   synopsis: string;
   updated_at?: string;
 };


### PR DESCRIPTION
## Objective

Fix the frontend `CatalogMovie` TypeScript type so movie list results expose the backend-provided `release_date` field consistently with movie detail data. This eliminates any TypeScript error a component would get when reading `movie.release_date` from a list result, without changing any backend serializer.

## What was done

### 1. `CatalogMovie` type updated

Added `release_date?: string | null` to the base `CatalogMovie` type in `frontend/src/types/catalog.ts`.

This field is already returned by the backend `MovieSummarySerializer` and was previously only declared on `CatalogMovieDetail`. Any component that receives a `CatalogMovie` from the list endpoint can now access `release_date` without a type workaround.

### 2. `CatalogMovieDetail` deduplication

Removed the redundant `release_date` declaration from `CatalogMovieDetail`.

Since `CatalogMovieDetail` extends `CatalogMovie`, the field is now inherited from the base type. Both shapes remain compatible with the backend response contract.

### 3. `isCatalogMovie` runtime validator updated

Added `release_date` validation to `isCatalogMovie` in `frontend/src/api/catalog.ts`, matching the same pattern already used in `isCatalogMovieDetail`:

```ts
(typeof value.release_date === "string" ||
  value.release_date === null ||
  value.release_date === undefined)
```

This accepts a date string, explicit `null`, or a missing field — consistent with the backend's optional nullable serializer field.

### 4. Per-item validation added to `listMovies`

`listMovies` now validates each item in `results` via `isCatalogMovie`, matching the pattern already used by `getSessions`. This ensures malformed movie objects in list responses are caught at the API boundary instead of silently propagating.

### 5. Test coverage

Added two new tests in `catalog.test.ts`:

- **`catalogApi lists movies with release_date field in results`** — verifies that a paginated response containing movies with `release_date` (string and `null`) is accepted and returned correctly.
- **`catalogApi rejects movie list results with invalid movie objects`** — verifies that a response with incomplete movie objects in `results` throws the expected error, covering the new per-item validation path.

## How to test

### Automated

```bash
cd frontend && npm test
```

All 157 tests pass, 0 failures.

### Type check

```bash
cd frontend && npx tsc --noEmit
```

Exits cleanly with no output.

## Expected result

- `CatalogMovie` exposes `release_date` to all components consuming list results.
- Detail and list movie types share a consistent, non-conflicting `release_date` shape.
- Runtime validation in `listMovies` catches malformed items per-response.
- TypeScript build and all tests succeed without errors.

closes #134