### PR TITLE
fix: use SessionSeatStatus enum in Session.clean instead of hardcoded strings

### DIFF
--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -144,8 +144,13 @@ class Session(models.Model):
             )
 
             if sensitive_fields_changed:
+                from reservations.models import SessionSeatStatus
+
                 SessionSeat = apps.get_model("reservations", "SessionSeat")
-                sensitive_statuses = ["RESERVED", "PURCHASED"]
+                sensitive_statuses = [
+                    SessionSeatStatus.RESERVED,
+                    SessionSeatStatus.PURCHASED,
+                ]
 
                 has_reserved_or_purchased_seats = SessionSeat.objects.filter(
                     session=self,

--- a/backend/tests/integration/test_catalog_models.py
+++ b/backend/tests/integration/test_catalog_models.py
@@ -7,6 +7,7 @@ from django.db import IntegrityError
 from django.utils import timezone
 
 from catalog.models import Genre, Movie, MovieStatus, Room, Session
+from reservations.models import SeatRow, Seat, SessionSeat, SessionSeatStatus
 
 
 @pytest.mark.django_db
@@ -239,6 +240,114 @@ class TestCatalogModels:
 
         with pytest.raises(ValidationError):
             session.full_clean()
+
+    def test_session_cannot_change_sensitive_fields_with_reserved_seats(self, django_user_model):
+        genre = Genre.objects.create(name="Action")
+        movie = Movie.objects.create(
+            title="Interstellar",
+            synopsis="Space exploration",
+            duration_minutes=169,
+            release_date="2014-11-07",
+            poster_url="https://example.com/poster.jpg",
+        )
+        movie.genres.add(genre)
+        room = Room.objects.create(name="Room 1", capacity=10)
+
+        start_time = timezone.now() + timedelta(days=1)
+        end_time = start_time + timedelta(minutes=120)
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=start_time,
+            end_time=end_time,
+            base_price="30.00",
+        )
+
+        seat_row = SeatRow.objects.create(room=room, name="A")
+        seat = Seat.objects.create(row=seat_row, number=1)
+        user = django_user_model.objects.create_user(
+            email="user@example.com", username="user", password="pass"
+        )
+        session_seat = SessionSeat.objects.create(session=session, seat=seat)
+        SessionSeat.objects.filter(pk=session_seat.pk).update(
+            status=SessionSeatStatus.RESERVED,
+            locked_by_user=user,
+            lock_expires_at=timezone.now() + timedelta(minutes=10),
+        )
+
+        session.base_price = Decimal("50.00")
+        with pytest.raises(ValidationError) as exc_info:
+            session.full_clean()
+
+        assert "session" in exc_info.value.message_dict
+
+    def test_session_cannot_change_sensitive_fields_with_purchased_seats(self):
+        genre = Genre.objects.create(name="Drama")
+        movie = Movie.objects.create(
+            title="Arrival",
+            synopsis="Linguistics meets aliens",
+            duration_minutes=116,
+            release_date="2016-11-11",
+            poster_url="https://example.com/arrival.jpg",
+        )
+        movie.genres.add(genre)
+        room = Room.objects.create(name="Room 2", capacity=10)
+
+        start_time = timezone.now() + timedelta(days=2)
+        end_time = start_time + timedelta(minutes=120)
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=start_time,
+            end_time=end_time,
+            base_price="25.00",
+        )
+
+        seat_row = SeatRow.objects.create(room=room, name="B")
+        seat = Seat.objects.create(row=seat_row, number=1)
+        session_seat = SessionSeat.objects.create(session=session, seat=seat)
+        SessionSeat.objects.filter(pk=session_seat.pk).update(
+            status=SessionSeatStatus.PURCHASED,
+        )
+
+        session.base_price = Decimal("40.00")
+        with pytest.raises(ValidationError) as exc_info:
+            session.full_clean()
+
+        assert "session" in exc_info.value.message_dict
+
+    def test_session_can_change_sensitive_fields_with_only_available_seats(self):
+        genre = Genre.objects.create(name="Comedy")
+        movie = Movie.objects.create(
+            title="The Grand Budapest Hotel",
+            synopsis="A quirky tale",
+            duration_minutes=99,
+            release_date="2014-03-07",
+            poster_url="https://example.com/budapest.jpg",
+        )
+        movie.genres.add(genre)
+        room = Room.objects.create(name="Room 3", capacity=10)
+
+        start_time = timezone.now() + timedelta(days=3)
+        end_time = start_time + timedelta(minutes=120)
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=start_time,
+            end_time=end_time,
+            base_price="20.00",
+        )
+
+        seat_row = SeatRow.objects.create(room=room, name="A")
+        seat = Seat.objects.create(row=seat_row, number=1)
+        SessionSeat.objects.create(session=session, seat=seat)
+
+        session.base_price = Decimal("22.00")
+        session.full_clean()
+        session.save()
+
+        session.refresh_from_db()
+        assert session.base_price == Decimal("22.00")
 
     def test_session_can_overlap_in_different_rooms(self):
         genre = Genre.objects.create(name="Action")


### PR DESCRIPTION
## Objective

Replace the hardcoded `"RESERVED"` and `"PURCHASED"` string literals in `Session.clean()` with authoritative enum values from `SessionSeatStatus`, eliminating the risk of silent divergence if enum values ever change. Covers BUG-06 from BUGS.md.

## What was done

### 1. Replaced hardcoded strings with enum values

In `backend/catalog/models.py`, `Session.clean()` previously built the sensitive status list as raw strings:

```python
sensitive_statuses = ["RESERVED", "PURCHASED"]
```

This is now replaced with enum-sourced values:

```python
from reservations.models import SessionSeatStatus

sensitive_statuses = [
    SessionSeatStatus.RESERVED,
    SessionSeatStatus.PURCHASED,
]
```

### 2. Import strategy

The import is placed **locally inside the method**, consistent with how `SessionSeat` is already fetched via `apps.get_model()` in the same block. This avoids any module-level circular import risk: `reservations/models.py` references `catalog` only through string-based FK declarations and never imports `catalog.models` directly, so the import is safe — but keeping it local keeps the pattern defensive and explicit.

### 3. Validation behavior preserved

No change to validation semantics. The same statuses are checked, the same error message is raised, and the same fields trigger the guard. The enum values are identical to the former string literals (`"RESERVED"`, `"PURCHASED"`), so there is no behavioral difference — only coupling correctness.

### 4. Integration tests added

Three new tests in `backend/tests/integration/test_catalog_models.py`:

- `test_session_cannot_change_sensitive_fields_with_reserved_seats` — asserts that mutating a session's `base_price` raises `ValidationError` when a seat is in `RESERVED` status.
- `test_session_cannot_change_sensitive_fields_with_purchased_seats` — same assertion for `PURCHASED` status.
- `test_session_can_change_sensitive_fields_with_only_available_seats` — asserts that the mutation is allowed when all session seats are `AVAILABLE`.

Both blocking tests use `QuerySet.update()` to set the seat status directly in the database, bypassing model-level validation, which is the correct approach for placing the DB in the desired state without triggering unrelated constraints.

## How to test

### Automated validation

```bash
docker compose run --rm backend pytest -q
```

### Targeted run

```bash
docker compose run --rm backend pytest tests/integration/test_catalog_models.py -v
```

## Expected result

- `Session.clean()` no longer contains any hardcoded status strings.
- Enum values from `SessionSeatStatus` are the single source of truth for reserved/purchased seat checks.
- Full test suite passes (203 tests).
- No migration required — this is a code-only change.

closes #136