### PR TITLE
fix: remove empty Django tests placeholders

### DIFF
--- a/backend/catalog/tests.py
+++ b/backend/catalog/tests.py
@@ -1,1 +1,0 @@
-# Create your tests here.

--- a/backend/reservations/tests.py
+++ b/backend/reservations/tests.py
@@ -1,1 +1,0 @@
-# Create your tests here.

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,1 +1,0 @@
-# Create your tests here.


### PR DESCRIPTION
## Objective

Clean up empty Django app-level `tests.py` placeholders so contributors are not misled about where the backend test suite lives, while keeping pytest discovery intentional and preserving the existing integration coverage.

## What was done

### 1. Placeholder cleanup

Removed the auto-generated empty Django test placeholder files:

- `backend/catalog/tests.py`
- `backend/users/tests.py`
- `backend/reservations/tests.py`

Each file only contained `# Create your tests here.`, so no real tests were deleted.

### 2. Consistent cleanup strategy

Used one consistent approach across all affected apps: delete the placeholder files.

This avoids keeping discoverable empty `tests.py` modules around solely as comments.

### 3. Pytest discovery validation

Confirmed pytest discovery remains focused on the actual backend test suite under `tests/integration/`.

No pytest configuration rewrite was needed.

### 4. Contributor clarity

The backend README already documents that integration tests live under `tests/integration/`. With the empty app-level placeholders removed, contributors are no longer pointed toward misleading generated files.

## How to test

### Automated validation

Run the full backend test suite with Docker:

```bash
docker compose exec backend pytest -q
```

### Discovery validation

Confirm pytest only discovers the real backend tests:

```bash
docker compose exec backend pytest --collect-only -q
```

## Expected Result

- Empty Django-generated `tests.py` placeholders are gone.
- All affected apps use the same cleanup strategy.
- Pytest discovery remains clean and intentional.
- Existing integration tests under `tests/integration/` are preserved.
- Full Docker-based backend test suite continues to pass.

closes #140
