### PR TITLE
fix: add backend CI CORS origin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           SECRET_KEY=ci-secret-key
           DEBUG=False
           ALLOWED_HOSTS=127.0.0.1,localhost,backend
+          CORS_ALLOWED_ORIGINS=http://localhost:3000
           POSTGRES_DB=cinepolis_natal
           POSTGRES_USER=postgres
           POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
## Objective

Make the backend CI environment explicit by adding `CORS_ALLOWED_ORIGINS` to the `.env` generated by the GitHub Actions backend validation job.

This mirrors the realistic local frontend/backend baseline documented for the project: frontend at `http://localhost:3000` calling the backend API.

## What was done

### 1. Backend CI env

Updated `.github/workflows/main.yml` so the backend job's generated `.env` now includes:

```env
CORS_ALLOWED_ORIGINS=http://localhost:3000
```

### 2. Configuration consistency

Kept the value aligned with the documented local frontend origin without changing production defaults or backend settings code.

### 3. Scope control

Limited the change to CI configuration only:

- no backend settings changes
- no frontend workflow changes
- no production CORS default changes
- no secret values added

## Acceptance Criteria

- `CORS_ALLOWED_ORIGINS=http://localhost:3000` is explicitly present in the backend CI `.env`.
- The GitHub Actions workflow remains valid YAML.
- Backend validation steps remain unchanged and continue to cover dependency startup, backend image build, Django system check, migrations, and pytest.
- Backend tests, including CORS-related tests, pass.
- The added value is a safe localhost CI configuration and does not leak secrets.

## How to test

### Automated validation

Validate the workflow YAML:

```bash
python - <<'PY'
import yaml
with open('.github/workflows/main.yml', 'r', encoding='utf-8') as f:
    yaml.safe_load(f)
print('workflow yaml ok')
PY
```

Run the backend CI-equivalent validation with Docker:

```bash
docker compose up -d db redis
docker compose build backend
docker compose run --rm backend python manage.py check
docker compose run --rm backend python manage.py migrate --noinput
docker compose run --rm backend pytest -q
```

## Expected Result

- Backend CI no longer relies only on Django's local CORS default.
- The backend CI baseline explicitly represents the local frontend/backend setup.
- Existing backend validation behavior stays stable.
- Full backend pytest suite passes.

closes #141
