### PR TITLE
fix: align docker-build CI env with backend job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           SECRET_KEY=ci-secret-key
           DEBUG=False
           ALLOWED_HOSTS=127.0.0.1,localhost,backend
+          CORS_ALLOWED_ORIGINS=http://localhost:3000
           POSTGRES_DB=cinepolis_natal
           POSTGRES_USER=postgres
           POSTGRES_PASSWORD=postgres
@@ -110,6 +111,8 @@ jobs:
           cat << 'EOF' > .env
           SECRET_KEY=ci-secret-key
           DEBUG=False
+          ALLOWED_HOSTS=127.0.0.1,localhost,backend
+          CORS_ALLOWED_ORIGINS=http://localhost:3000
           POSTGRES_DB=cinepolis_natal
           POSTGRES_USER=postgres
           POSTGRES_PASSWORD=postgres
@@ -117,6 +120,10 @@ jobs:
           POSTGRES_PORT=5432
           REDIS_URL=redis://redis:6379/1
           CELERY_BROKER_URL=redis://redis:6379/1
+          THROTTLE_ANON_RATE=60/minute
+          THROTTLE_USER_RATE=120/minute
+          THROTTLE_LOGIN_RATE=5/minute
+          THROTTLE_RESERVATION_RATE=10/minute
           NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
           EOF
 


### PR DESCRIPTION
## Objective

Keep Docker Compose validation in CI aligned with the backend validation job by making the shared safe baseline environment explicit in the `docker-build` job. This fixes the missing Docker host allowance without changing production/runtime configuration.

## What was done

### 1. Docker-build CI env

Updated `.github/workflows/main.yml` so the `docker-build` job generated `.env` now includes:

- `ALLOWED_HOSTS=127.0.0.1,localhost,backend`

### 2. Env file alignment

Aligned the generated `.env` blocks used by the backend and docker-build jobs for shared safe CI baseline values:

- `SECRET_KEY=ci-secret-key`
- `DEBUG=False`
- `ALLOWED_HOSTS=127.0.0.1,localhost,backend`
- `CORS_ALLOWED_ORIGINS=http://localhost:3000`
- PostgreSQL connection variables
- Redis and Celery broker URLs
- throttle rate variables
- `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`

This keeps the CI validation environment consistent while avoiding production secrets or production host changes.

### 3. Docker build validation intent preserved

Kept the existing Docker build validation commands unchanged:

- backend image build still uses `docker build -t cinepolis-natal-backend:ci backend`
- frontend image build still uses `docker build --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 -t cinepolis-natal-frontend:ci frontend`

No CI pipeline redesign or backend code change was introduced.

## Acceptance criteria

- Allowed Hosts Added: satisfied; `docker-build` CI `.env` explicitly includes `ALLOWED_HOSTS=127.0.0.1,localhost,backend`.
- Env Consistency: satisfied; backend and docker-build generated `.env` blocks now match for shared safe CI baseline values.
- Compose Config Passes: satisfied; Compose config validation passes with the docker-build CI env.
- Docker Builds Pass: satisfied; backend and frontend Docker image build commands pass unchanged in intent.
- Workflow Valid: satisfied; GitHub Actions YAML parses successfully.
- No Secret Leakage: satisfied; only CI-safe placeholder/local values were committed.

## How to test

### Automated validation

Run the workflow-focused validations:

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
import yaml
with Path(".github/workflows/main.yml").open(encoding="utf-8") as fh:
    yaml.safe_load(fh)
text = Path(".github/workflows/main.yml").read_text(encoding="utf-8")
envs = []
for block in text.split("cat << 'EOF' > .env")[1:]:
    env = block.split("EOF", 1)[0]
    envs.append([line.strip() for line in env.splitlines() if line.strip()])
assert len(envs) == 2
assert envs[0] == envs[1]
assert "ALLOWED_HOSTS=127.0.0.1,localhost,backend" in envs[1]
print("workflow YAML and CI env alignment OK")
PY
```

### Compose validation

Validate Docker Compose config using the generated docker-build CI env in an isolated copy:

```bash
docker compose -f docker-compose.yml config
```

### Docker build validation

Run the unchanged Docker image build checks:

```bash
docker build -t cinepolis-natal-backend:ci backend
docker build --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 -t cinepolis-natal-frontend:ci frontend
```

## Expected Result

- The docker-build CI job validates Compose with an explicit `ALLOWED_HOSTS` value that includes the `backend` service host.
- Backend and docker-build CI env files stay aligned for shared safe baseline values.
- Compose config validation continues to pass.
- Backend and frontend Docker image build validation remains unchanged in purpose and continues to pass.
- No production host settings or sensitive values are committed.

closes #142