### PR TITLE
fix: align seat map layout and accessible seats

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -818,10 +818,10 @@ h1 {
   display: inline-flex;
   font-size: 12px;
   font-weight: 900;
-  height: 26px;
+  height: 24px;
   justify-content: center;
   line-height: 1;
-  width: 26px;
+  width: 24px;
 }
 
 .seat-map__legend-swatch--available {
@@ -854,6 +854,13 @@ h1 {
   color: #0b57b7;
 }
 
+.seat-map__legend-swatch--companion {
+  background: #143d78;
+  border-color: #143d78;
+  color: #ffffff;
+  font-size: 10px;
+}
+
 .seat-map-scroll {
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -866,6 +873,7 @@ h1 {
 }
 
 .seat-map {
+  --seat-size: clamp(32px, 4.5vw, 38px);
   display: grid;
   gap: 18px;
   margin: 0 auto;
@@ -875,22 +883,49 @@ h1 {
 
 .seat-map__screen {
   background: #1f6feb;
-  border-radius: 999px 999px 12px 12px;
+  border-radius: 999px 999px 10px 10px;
   color: #ffffff;
   font-size: 13px;
   font-weight: 900;
   letter-spacing: 0;
   line-height: 1;
-  margin: 0 auto;
-  min-width: 280px;
-  padding: 12px 34px;
+  min-width: 0;
+  padding: 12px 24px;
   text-align: center;
   text-transform: uppercase;
+  width: 100%;
 }
 
 .seat-map__rows {
   display: grid;
   gap: 10px;
+}
+
+.seat-map__accessible-row {
+  align-items: center;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 28px minmax(0, 1fr) 28px;
+}
+
+.seat-map__accessible-list {
+  align-items: center;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.seat-map__accessible-group {
+  display: flex;
+  gap: 10px;
+}
+
+.seat-map__accessible-group--left {
+  justify-content: flex-end;
+}
+
+.seat-map__accessible-group--right {
+  justify-content: flex-start;
 }
 
 .seat-map__row {
@@ -908,8 +943,33 @@ h1 {
 }
 
 .seat-map__seat-list {
+  align-items: center;
+  display: grid;
+  gap: 0;
+  grid-template-columns: minmax(0, 1fr) 20px minmax(0, 1fr);
+}
+
+.seat-map__seat-group {
   display: flex;
   gap: 8px;
+}
+
+.seat-map__seat-group--left {
+  justify-content: flex-end;
+}
+
+.seat-map__seat-group--right {
+  justify-content: flex-start;
+}
+
+.seat-map__center-aisle {
+  display: block;
+  width: 20px;
+}
+
+.seat-map__accessible-pair {
+  display: inline-flex;
+  gap: 4px;
 }
 
 .seat-map__seat {
@@ -919,14 +979,14 @@ h1 {
   border-radius: 6px;
   color: var(--color-text);
   display: grid;
-  flex: 0 0 42px;
+  flex: 0 0 var(--seat-size);
   gap: 2px;
   grid-template-columns: 1fr auto;
   grid-template-rows: 1fr auto;
-  height: 42px;
+  height: var(--seat-size);
   justify-items: center;
   line-height: 1;
-  min-width: 42px;
+  min-width: var(--seat-size);
   padding: 4px;
   position: relative;
 }
@@ -965,8 +1025,10 @@ h1 {
   box-shadow: inset 0 -4px 0 #1f6feb;
 }
 
-.seat-map__seat--after-aisle {
-  margin-right: 20px;
+.seat-map__seat--companion {
+  background: #143d78;
+  border-color: #143d78;
+  color: #ffffff;
 }
 
 .seat-map__seat-number {

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -81,7 +81,7 @@ const seatStateMarkers: Record<SeatVisualState, string> = {
   available: "",
   purchased: "C",
   reserved: "R",
-  selected: "S",
+  selected: "",
 };
 
 const ACCESSIBLE_SEAT_COUNT = 6;

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -52,6 +52,11 @@ export type SeatVisualState =
   | "reserved"
   | "selected";
 
+type SeatAccessibleLabelOptions = {
+  displayLabel?: string;
+  displayNumber?: number;
+};
+
 type SeatMapProps = {
   sessionId: string;
 };
@@ -580,14 +585,20 @@ function renderSeatButton({
       aria-disabled={isUnavailable || isPending}
       aria-label={
         isCompanion
-          ? getCompanionSeatAccessibleLabel(seat, visualState)
-          : getSeatAccessibleLabel(seat, visualState)
+          ? getCompanionSeatAccessibleLabel(seat, visualState, {
+              displayLabel,
+              displayNumber,
+            })
+          : getSeatAccessibleLabel(seat, visualState, {
+              displayLabel,
+              displayNumber,
+            })
       }
       aria-pressed={isSelected}
       className={[
         "seat-map__seat",
         `seat-map__seat--${visualState}`,
-        seat.is_accessible ? "seat-map__seat--accessible" : "",
+        seat.is_accessible && !isCompanion ? "seat-map__seat--accessible" : "",
         isCompanion ? "seat-map__seat--companion" : "",
         isPending ? "seat-map__seat--pending" : "",
       ]
@@ -701,17 +712,20 @@ export function buildSeatMapLayout(
   const accessibleSeatIds = new Set(
     accessibleSeats.map((seat) => seat.session_seat_id)
   );
-  const companionSeats = getCompanionDisplaySeats(seats, accessibleSeatIds);
+  const accessiblePairs = pairAccessibleSeatsWithCompanions(
+    withDisplayNumbers(accessibleSeats),
+    seats,
+    accessibleSeatIds
+  );
+  const companionSeatIds = accessiblePairs
+    .map((pair) => pair.companionSeat?.seat.session_seat_id)
+    .filter((seatId): seatId is string => Boolean(seatId));
   const reservedFrontSeatIds = new Set([
     ...accessibleSeats.map((seat) => seat.session_seat_id),
-    ...companionSeats.map((seat) => seat.session_seat_id),
+    ...companionSeatIds,
   ]);
   const roomRows = groupSeatMapRows(
     seats.filter((seat) => !reservedFrontSeatIds.has(seat.session_seat_id))
-  );
-  const accessiblePairs = pairAccessibleSeatsWithCompanions(
-    withDisplayNumbers(accessibleSeats),
-    withDisplayNumbers(companionSeats)
   );
 
   return {
@@ -748,21 +762,38 @@ export function getSeatVisualState(
 
 export function getSeatAccessibleLabel(
   seat: SessionSeatMapItem,
-  visualState: SeatVisualState
+  visualState: SeatVisualState,
+  options: SeatAccessibleLabelOptions = {}
 ) {
-  const identifier = `${seat.row}${seat.number}`;
+  const displaySeat = getAccessibleLabelDisplaySeat(seat, options);
   const accessibleSuffix = seat.is_accessible ? ", assento acessível" : "";
 
-  return `Assento ${identifier}, fileira ${seat.row}, número ${seat.number}, ${seatStateLabels[visualState]}${accessibleSuffix}.`;
+  return `Assento ${displaySeat.identifier}, fileira ${seat.row}, número ${displaySeat.number}${displaySeat.originalSuffix}, ${seatStateLabels[visualState]}${accessibleSuffix}.`;
 }
 
 export function getCompanionSeatAccessibleLabel(
   seat: SessionSeatMapItem,
-  visualState: SeatVisualState
+  visualState: SeatVisualState,
+  options: SeatAccessibleLabelOptions = {}
 ) {
-  const identifier = `${seat.row}${seat.number}`;
+  const displaySeat = getAccessibleLabelDisplaySeat(seat, options);
 
-  return `Assento acompanhante ${identifier}, fileira ${seat.row}, número ${seat.number}, ${seatStateLabels[visualState]}.`;
+  return `Assento acompanhante ${displaySeat.identifier}, fileira ${seat.row}, número ${displaySeat.number}${displaySeat.originalSuffix}, ${seatStateLabels[visualState]}.`;
+}
+
+function getAccessibleLabelDisplaySeat(
+  seat: SessionSeatMapItem,
+  { displayLabel, displayNumber }: SeatAccessibleLabelOptions
+) {
+  const displayValue = displayLabel ?? displayNumber ?? seat.number;
+  const displayNumberText = String(displayValue);
+  const isOverridden = displayNumberText !== String(seat.number);
+
+  return {
+    identifier: displayLabel ?? `${seat.row}${displayNumberText}`,
+    number: displayNumberText,
+    originalSuffix: isOverridden ? `, assento original ${seat.row}${seat.number}` : "",
+  };
 }
 
 export function buildReservedSeatsFromReservation(
@@ -903,23 +934,86 @@ function getAccessibleDisplaySeats(seats: SessionSeatMapItem[]) {
     .map((seat) => ({ ...seat, is_accessible: true }));
 }
 
-function getCompanionDisplaySeats(
-  seats: SessionSeatMapItem[],
-  selectedSeatIds: ReadonlySet<string>
-) {
-  return getAccessibleFallbackSeats(seats, selectedSeatIds)
-    .slice(0, ACCESSIBLE_SEAT_COUNT)
-    .sort(compareSeatPositions);
-}
-
 function pairAccessibleSeatsWithCompanions(
   accessibleSeats: SeatMapDisplaySeat[],
-  companionSeats: SeatMapDisplaySeat[]
+  seats: SessionSeatMapItem[],
+  selectedSeatIds: ReadonlySet<string>
 ): SeatMapAccessiblePair[] {
-  return accessibleSeats.map((accessibleSeat, index) => ({
-    accessibleSeat,
-    companionSeat: companionSeats[index],
-  }));
+  const usedSeatIds = new Set(selectedSeatIds);
+
+  return accessibleSeats.map((accessibleSeat) => {
+    const companionSeat =
+      findAdjacentCompanionSeat(accessibleSeat.seat, seats, usedSeatIds) ??
+      findFallbackCompanionSeat(accessibleSeat.seat, seats, usedSeatIds);
+
+    if (companionSeat) {
+      usedSeatIds.add(companionSeat.session_seat_id);
+    }
+
+    return {
+      accessibleSeat,
+      companionSeat: companionSeat
+        ? {
+            displayNumber: companionSeat.number,
+            seat: companionSeat,
+          }
+        : undefined,
+    };
+  });
+}
+
+function findAdjacentCompanionSeat(
+  accessibleSeat: SessionSeatMapItem,
+  seats: SessionSeatMapItem[],
+  usedSeatIds: ReadonlySet<string>
+) {
+  return seats
+    .filter(
+      (seat) =>
+        isCompanionCandidate(seat, usedSeatIds) &&
+        seat.row === accessibleSeat.row &&
+        Math.abs(seat.number - accessibleSeat.number) === 1
+    )
+    .sort(compareSeatPositions)[0];
+}
+
+function findFallbackCompanionSeat(
+  accessibleSeat: SessionSeatMapItem,
+  seats: SessionSeatMapItem[],
+  usedSeatIds: ReadonlySet<string>
+) {
+  const sameRowSeat = seats
+    .filter(
+      (seat) =>
+        isCompanionCandidate(seat, usedSeatIds) &&
+        seat.row === accessibleSeat.row
+    )
+    .sort((leftSeat, rightSeat) => {
+      const distanceComparison =
+        Math.abs(leftSeat.number - accessibleSeat.number) -
+        Math.abs(rightSeat.number - accessibleSeat.number);
+
+      if (distanceComparison !== 0) {
+        return distanceComparison;
+      }
+
+      return compareSeatPositions(leftSeat, rightSeat);
+    })[0];
+
+  if (sameRowSeat) {
+    return sameRowSeat;
+  }
+
+  return getAccessibleFallbackSeats(seats, usedSeatIds).find((seat) =>
+    isCompanionCandidate(seat, usedSeatIds)
+  );
+}
+
+function isCompanionCandidate(
+  seat: SessionSeatMapItem,
+  usedSeatIds: ReadonlySet<string>
+) {
+  return !seat.is_accessible && !usedSeatIds.has(seat.session_seat_id);
 }
 
 function getAccessibleFallbackSeats(

--- a/frontend/src/components/seats/SeatMap.tsx
+++ b/frontend/src/components/seats/SeatMap.tsx
@@ -25,6 +25,27 @@ export type SeatMapRow = {
   seats: SessionSeatMapItem[];
 };
 
+export type SeatMapDisplaySeat = {
+  displayNumber: number;
+  seat: SessionSeatMapItem;
+};
+
+export type SeatMapAccessiblePair = {
+  accessibleSeat: SeatMapDisplaySeat;
+  companionSeat?: SeatMapDisplaySeat;
+};
+
+export type SeatMapRenderedRow = SeatMapRow & {
+  leftSeats: SeatMapDisplaySeat[];
+  rightSeats: SeatMapDisplaySeat[];
+};
+
+export type SeatMapLayoutModel = {
+  accessibleLeftPairs: SeatMapAccessiblePair[];
+  accessibleRightPairs: SeatMapAccessiblePair[];
+  rows: SeatMapRenderedRow[];
+};
+
 export type SeatVisualState =
   | "available"
   | "purchased"
@@ -57,11 +78,14 @@ const seatStateLabels: Record<SeatVisualState, string> = {
 };
 
 const seatStateMarkers: Record<SeatVisualState, string> = {
-  available: "L",
+  available: "",
   purchased: "C",
   reserved: "R",
   selected: "S",
 };
+
+const ACCESSIBLE_SEAT_COUNT = 6;
+const ACCESSIBLE_SEATS_PER_SIDE = 3;
 
 export function SeatMap({ sessionId }: SeatMapProps) {
   const [state, setState] = useState<SeatMapLoadState>({ status: "loading" });
@@ -346,9 +370,9 @@ export function SeatMapLayout({
   seats,
   selectedSeatIds = new Set(),
 }: SeatMapLayoutProps) {
-  const rows = useMemo(() => groupSeatMapRows(seats), [seats]);
+  const layout = useMemo(() => buildSeatMapLayout(seats), [seats]);
 
-  if (rows.length === 0) {
+  if (seats.length === 0) {
     return (
       <StateMessage title="Sala sem assentos">
         Ainda não há assentos cadastrados para esta sessão.
@@ -391,8 +415,40 @@ export function SeatMapLayout({
         >
           <div className="seat-map__screen">Tela</div>
 
+          <div
+            aria-label="Assentos acessíveis e prioritários"
+            className="seat-map__accessible-row"
+            role="group"
+          >
+            <span aria-hidden="true" className="seat-map__row-label" />
+            <div className="seat-map__accessible-list">
+              <div className="seat-map__accessible-group seat-map__accessible-group--left">
+                {layout.accessibleLeftPairs.map((pair) =>
+                  renderAccessiblePair({
+                    companionFirst: true,
+                    onSeatToggle,
+                    pair,
+                    pendingSeatIds,
+                    selectedSeatIds,
+                  })
+                )}
+              </div>
+              <div className="seat-map__accessible-group seat-map__accessible-group--right">
+                {layout.accessibleRightPairs.map((pair) =>
+                  renderAccessiblePair({
+                    onSeatToggle,
+                    pair,
+                    pendingSeatIds,
+                    selectedSeatIds,
+                  })
+                )}
+              </div>
+            </div>
+            <span aria-hidden="true" className="seat-map__row-label" />
+          </div>
+
           <div className="seat-map__rows">
-            {rows.map((row) => (
+            {layout.rows.map((row) => (
               <div className="seat-map__row" key={row.rowLabel}>
                 <span
                   aria-hidden="true"
@@ -405,66 +461,31 @@ export function SeatMapLayout({
                   className="seat-map__seat-list"
                   role="group"
                 >
-                  {row.seats.map((seat, seatIndex) => {
-                    const visualState = getSeatVisualState(
-                      seat,
-                      selectedSeatIds
-                    );
-                    const isSelected = visualState === "selected";
-                    const isUnavailable =
-                      visualState === "reserved" ||
-                      visualState === "purchased";
-                    const isPending = pendingSeatIds.has(
-                      seat.session_seat_id
-                    );
-
-                    return (
-                      <button
-                        aria-busy={isPending}
-                        aria-disabled={isUnavailable || isPending}
-                        aria-label={getSeatAccessibleLabel(
-                          seat,
-                          visualState
-                        )}
-                        aria-pressed={isSelected}
-                        className={[
-                          "seat-map__seat",
-                          `seat-map__seat--${visualState}`,
-                          seat.is_accessible
-                            ? "seat-map__seat--accessible"
-                            : "",
-                          isPending ? "seat-map__seat--pending" : "",
-                          shouldAddCenterAisle(row.seats, seatIndex)
-                            ? "seat-map__seat--after-aisle"
-                            : "",
-                        ]
-                          .filter(Boolean)
-                          .join(" ")}
-                        data-state={visualState}
-                        key={seat.session_seat_id}
-                        onClick={() => onSeatToggle?.(seat)}
-                        type="button"
-                      >
-                        <span className="seat-map__seat-number">
-                          {seat.number}
-                        </span>
-                        <span
-                          aria-hidden="true"
-                          className="seat-map__seat-marker"
-                        >
-                          {seatStateMarkers[visualState]}
-                        </span>
-                        {seat.is_accessible ? (
-                          <span
-                            aria-hidden="true"
-                            className="seat-map__seat-accessible"
-                          >
-                            ♿
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
+                  <div className="seat-map__seat-group seat-map__seat-group--left">
+                    {row.leftSeats.map((seat) =>
+                      renderSeatButton({
+                        displayNumber: seat.displayNumber,
+                        key: seat.seat.session_seat_id,
+                        onSeatToggle,
+                        pendingSeatIds,
+                        seat: seat.seat,
+                        selectedSeatIds,
+                      })
+                    )}
+                  </div>
+                  <span aria-hidden="true" className="seat-map__center-aisle" />
+                  <div className="seat-map__seat-group seat-map__seat-group--right">
+                    {row.rightSeats.map((seat) =>
+                      renderSeatButton({
+                        displayNumber: seat.displayNumber,
+                        key: seat.seat.session_seat_id,
+                        onSeatToggle,
+                        pendingSeatIds,
+                        seat: seat.seat,
+                        selectedSeatIds,
+                      })
+                    )}
+                  </div>
                 </div>
                 <span
                   aria-hidden="true"
@@ -480,6 +501,117 @@ export function SeatMapLayout({
         </div>
       </div>
     </section>
+  );
+}
+
+function renderAccessiblePair({
+  companionFirst = false,
+  onSeatToggle,
+  pair,
+  pendingSeatIds,
+  selectedSeatIds,
+}: {
+  companionFirst?: boolean;
+  onSeatToggle?: (seat: SessionSeatMapItem) => void;
+  pair: SeatMapAccessiblePair;
+  pendingSeatIds: ReadonlySet<string>;
+  selectedSeatIds: ReadonlySet<string>;
+}) {
+  const accessibleSeatButton = renderSeatButton({
+    displayNumber: pair.accessibleSeat.displayNumber,
+    key: `${pair.accessibleSeat.seat.session_seat_id}-accessible`,
+    onSeatToggle,
+    pendingSeatIds,
+    seat: pair.accessibleSeat.seat,
+    selectedSeatIds,
+  });
+  const companionSeatButton = pair.companionSeat
+    ? renderSeatButton({
+        displayLabel: "AC",
+        isCompanion: true,
+        key: `${pair.companionSeat.seat.session_seat_id}-companion`,
+        onSeatToggle,
+        pendingSeatIds,
+        seat: pair.companionSeat.seat,
+        selectedSeatIds,
+      })
+    : null;
+
+  return (
+    <span
+      className="seat-map__accessible-pair"
+      key={pair.accessibleSeat.seat.session_seat_id}
+    >
+      {companionFirst ? companionSeatButton : accessibleSeatButton}
+      {companionFirst ? accessibleSeatButton : companionSeatButton}
+    </span>
+  );
+}
+
+function renderSeatButton({
+  displayLabel,
+  displayNumber,
+  isCompanion = false,
+  key,
+  onSeatToggle,
+  pendingSeatIds,
+  seat,
+  selectedSeatIds,
+}: {
+  displayLabel?: string;
+  displayNumber?: number;
+  isCompanion?: boolean;
+  key: string;
+  onSeatToggle?: (seat: SessionSeatMapItem) => void;
+  pendingSeatIds: ReadonlySet<string>;
+  seat: SessionSeatMapItem;
+  selectedSeatIds: ReadonlySet<string>;
+}) {
+  const visualState = getSeatVisualState(seat, selectedSeatIds);
+  const isSelected = visualState === "selected";
+  const isUnavailable =
+    visualState === "reserved" || visualState === "purchased";
+  const isPending = pendingSeatIds.has(seat.session_seat_id);
+  const stateMarker = isCompanion ? "" : seatStateMarkers[visualState];
+
+  return (
+    <button
+      aria-busy={isPending}
+      aria-disabled={isUnavailable || isPending}
+      aria-label={
+        isCompanion
+          ? getCompanionSeatAccessibleLabel(seat, visualState)
+          : getSeatAccessibleLabel(seat, visualState)
+      }
+      aria-pressed={isSelected}
+      className={[
+        "seat-map__seat",
+        `seat-map__seat--${visualState}`,
+        seat.is_accessible ? "seat-map__seat--accessible" : "",
+        isCompanion ? "seat-map__seat--companion" : "",
+        isPending ? "seat-map__seat--pending" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      data-state={visualState}
+      key={key}
+      onClick={() => onSeatToggle?.(seat)}
+      type="button"
+    >
+      <span className="seat-map__seat-number">
+        {displayLabel ?? displayNumber ?? seat.number}
+      </span>
+      {stateMarker ? (
+        <span aria-hidden="true" className="seat-map__seat-marker">
+          {stateMarker}
+        </span>
+      ) : null}
+      {seat.is_accessible && !isCompanion ? (
+        <span aria-hidden="true" className="seat-map__seat-accessible">
+          ♿
+        </span>
+      ) : null}
+    </button>
   );
 }
 
@@ -513,6 +645,11 @@ export function SeatMapLegend() {
       className: "seat-map__legend-swatch--accessible",
       label: "Acessível",
       marker: "♿",
+    },
+    {
+      className: "seat-map__legend-swatch--companion",
+      label: "Acompanhante",
+      marker: "AC",
     },
   ];
 
@@ -552,9 +689,39 @@ export function groupSeatMapRows(
     .map(([rowLabel, rowSeats]) => ({
       rowLabel,
       seats: [...rowSeats].sort((leftSeat, rightSeat) => {
-        return leftSeat.number - rightSeat.number;
+        return compareSeatPositions(leftSeat, rightSeat);
       }),
     }));
+}
+
+export function buildSeatMapLayout(
+  seats: SessionSeatMapItem[]
+): SeatMapLayoutModel {
+  const accessibleSeats = getAccessibleDisplaySeats(seats);
+  const accessibleSeatIds = new Set(
+    accessibleSeats.map((seat) => seat.session_seat_id)
+  );
+  const companionSeats = getCompanionDisplaySeats(seats, accessibleSeatIds);
+  const reservedFrontSeatIds = new Set([
+    ...accessibleSeats.map((seat) => seat.session_seat_id),
+    ...companionSeats.map((seat) => seat.session_seat_id),
+  ]);
+  const roomRows = groupSeatMapRows(
+    seats.filter((seat) => !reservedFrontSeatIds.has(seat.session_seat_id))
+  );
+  const accessiblePairs = pairAccessibleSeatsWithCompanions(
+    withDisplayNumbers(accessibleSeats),
+    withDisplayNumbers(companionSeats)
+  );
+
+  return {
+    accessibleLeftPairs: accessiblePairs.slice(0, ACCESSIBLE_SEATS_PER_SIDE),
+    accessibleRightPairs: accessiblePairs.slice(ACCESSIBLE_SEATS_PER_SIDE),
+    rows: roomRows.map((row) => ({
+      ...row,
+      ...splitRowSeats(withDisplayNumbers(row.seats)),
+    })),
+  };
 }
 
 export function getSeatVisualState(
@@ -587,6 +754,15 @@ export function getSeatAccessibleLabel(
   const accessibleSuffix = seat.is_accessible ? ", assento acessível" : "";
 
   return `Assento ${identifier}, fileira ${seat.row}, número ${seat.number}, ${seatStateLabels[visualState]}${accessibleSuffix}.`;
+}
+
+export function getCompanionSeatAccessibleLabel(
+  seat: SessionSeatMapItem,
+  visualState: SeatVisualState
+) {
+  const identifier = `${seat.row}${seat.number}`;
+
+  return `Assento acompanhante ${identifier}, fileira ${seat.row}, número ${seat.number}, ${seatStateLabels[visualState]}.`;
 }
 
 export function buildReservedSeatsFromReservation(
@@ -687,8 +863,8 @@ function removeFromSet<T>(set: ReadonlySet<T>, value: T) {
   return nextSet;
 }
 
-function shouldAddCenterAisle(seats: SessionSeatMapItem[], seatIndex: number) {
-  return seats.length > 4 && seatIndex === Math.ceil(seats.length / 2) - 1;
+export function getCenterAisleAfterIndex(seatCount: number) {
+  return seatCount > 4 ? Math.ceil(seatCount / 2) - 1 : -1;
 }
 
 function compareRowLabels(leftRow: string, rightRow: string) {
@@ -696,4 +872,129 @@ function compareRowLabels(leftRow: string, rightRow: string) {
     numeric: true,
     sensitivity: "base",
   });
+}
+
+function getAccessibleDisplaySeats(seats: SessionSeatMapItem[]) {
+  const selectedSeatIds = new Set<string>();
+  const selectedSeats: SessionSeatMapItem[] = [];
+
+  for (const seat of seats
+    .filter((seat) => seat.is_accessible)
+    .sort(compareSeatPositions)) {
+    if (selectedSeats.length >= ACCESSIBLE_SEAT_COUNT) {
+      break;
+    }
+
+    selectedSeatIds.add(seat.session_seat_id);
+    selectedSeats.push(seat);
+  }
+
+  for (const seat of getAccessibleFallbackSeats(seats, selectedSeatIds)) {
+    if (selectedSeats.length >= ACCESSIBLE_SEAT_COUNT) {
+      break;
+    }
+
+    selectedSeatIds.add(seat.session_seat_id);
+    selectedSeats.push(seat);
+  }
+
+  return selectedSeats
+    .sort(compareSeatPositions)
+    .map((seat) => ({ ...seat, is_accessible: true }));
+}
+
+function getCompanionDisplaySeats(
+  seats: SessionSeatMapItem[],
+  selectedSeatIds: ReadonlySet<string>
+) {
+  return getAccessibleFallbackSeats(seats, selectedSeatIds)
+    .slice(0, ACCESSIBLE_SEAT_COUNT)
+    .sort(compareSeatPositions);
+}
+
+function pairAccessibleSeatsWithCompanions(
+  accessibleSeats: SeatMapDisplaySeat[],
+  companionSeats: SeatMapDisplaySeat[]
+): SeatMapAccessiblePair[] {
+  return accessibleSeats.map((accessibleSeat, index) => ({
+    accessibleSeat,
+    companionSeat: companionSeats[index],
+  }));
+}
+
+function getAccessibleFallbackSeats(
+  seats: SessionSeatMapItem[],
+  selectedSeatIds: ReadonlySet<string>
+) {
+  const rows = groupSeatMapRows(
+    seats.filter((seat) => !selectedSeatIds.has(seat.session_seat_id))
+  ).sort((leftRow, rightRow) => {
+    const widthComparison = rightRow.seats.length - leftRow.seats.length;
+
+    if (widthComparison !== 0) {
+      return widthComparison;
+    }
+
+    return compareRowLabels(rightRow.rowLabel, leftRow.rowLabel);
+  });
+  const fallbackSeats: SessionSeatMapItem[] = [];
+
+  for (const row of rows) {
+    for (const seat of getOuterSeatOrder(row.seats)) {
+      fallbackSeats.push(seat);
+    }
+  }
+
+  return fallbackSeats;
+}
+
+function getOuterSeatOrder(seats: SessionSeatMapItem[]) {
+  const orderedSeats: SessionSeatMapItem[] = [];
+  let leftIndex = 0;
+  let rightIndex = seats.length - 1;
+
+  while (leftIndex <= rightIndex) {
+    orderedSeats.push(seats[leftIndex]);
+
+    if (leftIndex !== rightIndex) {
+      orderedSeats.push(seats[rightIndex]);
+    }
+
+    leftIndex += 1;
+    rightIndex -= 1;
+  }
+
+  return orderedSeats;
+}
+
+function splitRowSeats(seats: SeatMapDisplaySeat[]) {
+  const leftSeatCount = Math.ceil(seats.length / 2);
+
+  return {
+    leftSeats: seats.slice(0, leftSeatCount),
+    rightSeats: seats.slice(leftSeatCount),
+  };
+}
+
+function withDisplayNumbers(
+  seats: SessionSeatMapItem[],
+  startNumber = 1
+): SeatMapDisplaySeat[] {
+  return seats.map((seat, index) => ({
+    displayNumber: startNumber + index,
+    seat,
+  }));
+}
+
+function compareSeatPositions(
+  leftSeat: SessionSeatMapItem,
+  rightSeat: SessionSeatMapItem
+) {
+  const rowComparison = compareRowLabels(leftSeat.row, rightSeat.row);
+
+  if (rowComparison !== 0) {
+    return rowComparison;
+  }
+
+  return leftSeat.number - rightSeat.number;
 }

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -12,6 +12,7 @@ import {
   buildSeatMapLayout,
   buildReservedSeatsFromReservation,
   getCenterAisleAfterIndex,
+  getCompanionSeatAccessibleLabel,
   getSeatAccessibleLabel,
   getSeatInteractionErrorMessage,
   getSeatVisualState,
@@ -89,6 +90,7 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
           row: "A",
           status: "AVAILABLE",
         }),
+        seat({ number: 3, row: "A" }),
         seat({ number: 1, row: "B", status: "RESERVED" }),
         seat({ number: 2, row: "B", status: "PURCHASED" }),
         seat({
@@ -119,7 +121,10 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, /seat-map__seat--selected/);
   assert.match(html, /aria-disabled="true"/);
   assert.match(html, /aria-pressed="true"/);
-  assert.match(html, /Assento A2, fileira A, número 2, Disponível, assento acessível/);
+  assert.match(
+    html,
+    /Assento A1, fileira A, número 1, assento original A2, Disponível, assento acessível/
+  );
   assert.equal((html.match(/seat-map__seat--accessible/g) ?? []).length, 6);
   assert.equal((html.match(/seat-map__seat--companion/g) ?? []).length, 6);
   assert.match(html, />AC</);
@@ -205,6 +210,44 @@ test("seat map layout fills missing priority positions with real selectable seat
   assert.equal(layout.rows[0].seats.length, 5);
 });
 
+test("seat map layout pairs companions with adjacent non-accessible seats", () => {
+  const layout = buildSeatMapLayout([
+    seat({ number: 1, row: "A" }),
+    seat({ is_accessible: true, number: 2, row: "A" }),
+    seat({ number: 3, row: "A" }),
+    seat({ is_accessible: true, number: 4, row: "A" }),
+    seat({ number: 5, row: "A" }),
+    seat({ is_accessible: true, number: 6, row: "A" }),
+    seat({ number: 7, row: "A" }),
+    seat({ number: 1, row: "B" }),
+    seat({ is_accessible: true, number: 2, row: "B" }),
+    seat({ number: 3, row: "B" }),
+    seat({ is_accessible: true, number: 4, row: "B" }),
+    seat({ number: 5, row: "B" }),
+    seat({ is_accessible: true, number: 6, row: "B" }),
+    seat({ number: 7, row: "B" }),
+  ]);
+  const accessiblePairs = [
+    ...layout.accessibleLeftPairs,
+    ...layout.accessibleRightPairs,
+  ];
+
+  assert.equal(accessiblePairs.length, 6);
+  assert.ok(accessiblePairs.every((pair) => pair.companionSeat));
+  assert.ok(
+    accessiblePairs.every((pair) => {
+      const companionSeat = pair.companionSeat?.seat;
+
+      return (
+        companionSeat &&
+        !companionSeat.is_accessible &&
+        companionSeat.row === pair.accessibleSeat.seat.row &&
+        Math.abs(companionSeat.number - pair.accessibleSeat.seat.number) === 1
+      );
+    })
+  );
+});
+
 test("seat map center aisle keeps rows with two extra seats symmetric", () => {
   assert.equal(getCenterAisleAfterIndex(4), -1);
   assert.equal(getCenterAisleAfterIndex(10), 4);
@@ -213,8 +256,11 @@ test("seat map center aisle keeps rows with two extra seats symmetric", () => {
 
 test("seat map row split puts two extra seats one on each side", () => {
   const layout = buildSeatMapLayout([
-    ...Array.from({ length: 12 }, (_, index) =>
+    ...Array.from({ length: 6 }, (_, index) =>
       seat({ is_accessible: true, number: index + 1, row: "P" })
+    ),
+    ...Array.from({ length: 6 }, (_, index) =>
+      seat({ number: index + 7, row: "P" })
     ),
     ...Array.from({ length: 12 }, (_, index) =>
       seat({ number: index + 1, row: "Z" })
@@ -263,9 +309,18 @@ test("seat accessible labels expose row, number, state, and accessible marker", 
   assert.equal(
     getSeatAccessibleLabel(
       seat({ is_accessible: true, number: 8, row: "C" }),
-      "selected"
+      "selected",
+      { displayNumber: 2 }
     ),
-    "Assento C8, fileira C, número 8, Selecionado, assento acessível."
+    "Assento C2, fileira C, número 2, assento original C8, Selecionado, assento acessível."
+  );
+  assert.equal(
+    getCompanionSeatAccessibleLabel(
+      seat({ number: 9, row: "C" }),
+      "available",
+      { displayLabel: "AC" }
+    ),
+    "Assento acompanhante AC, fileira C, número AC, assento original C9, Disponível."
   );
 });
 

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -9,7 +9,9 @@ import { ApiError } from "@/api/client";
 import type { SessionSeatMapItem } from "@/types/reservation";
 
 import {
+  buildSeatMapLayout,
   buildReservedSeatsFromReservation,
+  getCenterAisleAfterIndex,
   getSeatAccessibleLabel,
   getSeatInteractionErrorMessage,
   getSeatVisualState,
@@ -95,12 +97,16 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
           row: "B",
           status: "RESERVED",
         }),
+        ...Array.from({ length: 10 }, (_, index) =>
+          seat({ number: index + 1, row: "C" })
+        ),
       ],
     })
   );
 
   assert.match(html, /Tela/);
   assert.match(html, /Fundo da sala/);
+  assert.ok(html.indexOf("Assentos acessíveis") < html.indexOf("Fileira A"));
   assert.match(html, /Fileira A/);
   assert.match(html, /Fileira B/);
   assert.match(html, /tabindex="0"/);
@@ -114,6 +120,122 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, /aria-disabled="true"/);
   assert.match(html, /aria-pressed="true"/);
   assert.match(html, /Assento A2, fileira A, número 2, Disponível, assento acessível/);
+  assert.equal((html.match(/seat-map__seat--accessible/g) ?? []).length, 6);
+  assert.equal((html.match(/seat-map__seat--companion/g) ?? []).length, 6);
+  assert.match(html, />AC</);
+  assert.match(html, /Acompanhante/);
+  assert.doesNotMatch(html, /seat-map__seat-marker">L/);
+  assert.doesNotMatch(html, /accessible-placeholder/);
+});
+
+test("seat map layout moves accessible seats and companions before the first row", () => {
+  const layout = buildSeatMapLayout([
+    seat({ is_accessible: true, number: 9, row: "C" }),
+    seat({ is_accessible: true, number: 10, row: "C" }),
+    seat({ is_accessible: true, number: 11, row: "C" }),
+    seat({ is_accessible: true, number: 12, row: "C" }),
+    seat({ is_accessible: true, number: 13, row: "C" }),
+    seat({ is_accessible: true, number: 14, row: "C" }),
+    seat({ number: 1, row: "A" }),
+    seat({ number: 2, row: "A" }),
+    ...Array.from({ length: 6 }, (_, index) =>
+      seat({ number: index + 15, row: "C" })
+    ),
+  ]);
+  const accessiblePairs = [
+    ...layout.accessibleLeftPairs,
+    ...layout.accessibleRightPairs,
+  ];
+
+  assert.equal(layout.accessibleLeftPairs.length, 3);
+  assert.equal(layout.accessibleRightPairs.length, 3);
+  assert.deepEqual(
+    accessiblePairs.map(
+      (accessiblePair) => accessiblePair.accessibleSeat.seat.number
+    ),
+    [9, 10, 11, 12, 13, 14]
+  );
+  assert.deepEqual(
+    accessiblePairs.map(
+      (accessiblePair) => accessiblePair.accessibleSeat.displayNumber
+    ),
+    [1, 2, 3, 4, 5, 6]
+  );
+  assert.ok(accessiblePairs.every((accessiblePair) => accessiblePair.companionSeat));
+  assert.deepEqual(
+    layout.rows.map((row) => ({
+      rowLabel: row.rowLabel,
+      seatNumbers: row.seats.map((rowSeat) => rowSeat.number),
+    })),
+    [{ rowLabel: "A", seatNumbers: [1, 2] }]
+  );
+});
+
+test("seat map layout fills missing priority positions with real selectable seats", () => {
+  const layout = buildSeatMapLayout([
+    ...Array.from({ length: 16 }, (_, index) =>
+      seat({ number: index + 1, row: "A" })
+    ),
+    seat({ is_accessible: true, number: 17, row: "A" }),
+  ]);
+  const accessiblePairs = [
+    ...layout.accessibleLeftPairs,
+    ...layout.accessibleRightPairs,
+  ];
+
+  assert.equal(accessiblePairs.length, 6);
+  assert.ok(
+    accessiblePairs.every(
+      (accessiblePair) => accessiblePair.accessibleSeat.seat.seat_id
+    )
+  );
+  assert.ok(
+    accessiblePairs.every(
+      (accessiblePair) => accessiblePair.accessibleSeat.seat.is_accessible
+    )
+  );
+  assert.deepEqual(
+    accessiblePairs.map(
+      (accessiblePair) => accessiblePair.accessibleSeat.displayNumber
+    ),
+    [1, 2, 3, 4, 5, 6]
+  );
+  assert.ok(accessiblePairs.every((accessiblePair) => accessiblePair.companionSeat));
+  assert.equal(layout.rows[0].seats.length, 5);
+});
+
+test("seat map center aisle keeps rows with two extra seats symmetric", () => {
+  assert.equal(getCenterAisleAfterIndex(4), -1);
+  assert.equal(getCenterAisleAfterIndex(10), 4);
+  assert.equal(getCenterAisleAfterIndex(12), 5);
+});
+
+test("seat map row split puts two extra seats one on each side", () => {
+  const layout = buildSeatMapLayout([
+    ...Array.from({ length: 12 }, (_, index) =>
+      seat({ is_accessible: true, number: index + 1, row: "P" })
+    ),
+    ...Array.from({ length: 12 }, (_, index) =>
+      seat({ number: index + 1, row: "Z" })
+    ),
+    ...Array.from({ length: 9 }, (_, index) =>
+      seat({ number: index + 1, row: "A" })
+    ),
+    ...Array.from({ length: 11 }, (_, index) =>
+      seat({ number: index + 1, row: "B" })
+    ),
+  ]);
+  const rowB = layout.rows.find((row) => row.rowLabel === "B");
+
+  assert.ok(rowB);
+  assert.deepEqual(
+    rowB.leftSeats.map((rowSeat) => rowSeat.displayNumber),
+    [1, 2, 3, 4, 5, 6]
+  );
+  assert.deepEqual(
+    rowB.rightSeats.map((rowSeat) => rowSeat.displayNumber),
+    [7, 8, 9, 10, 11]
+  );
 });
 
 test("seat legend explains every state in pt-BR", () => {

--- a/frontend/src/components/seats/seat-map.test.ts
+++ b/frontend/src/components/seats/seat-map.test.ts
@@ -125,6 +125,7 @@ test("seat map renders screen, row labels, seat numbers, and semantic states", (
   assert.match(html, />AC</);
   assert.match(html, /Acompanhante/);
   assert.doesNotMatch(html, /seat-map__seat-marker">L/);
+  assert.doesNotMatch(html, /seat-map__seat-marker">S/);
   assert.doesNotMatch(html, /accessible-placeholder/);
 });
 
@@ -248,6 +249,10 @@ test("seat legend explains every state in pt-BR", () => {
   assert.match(html, /Reservado ou indisponível/);
   assert.match(html, /Comprado/);
   assert.match(html, /Acessível/);
+  assert.doesNotMatch(
+    html,
+    /seat-map__legend-swatch seat-map__legend-swatch--selected">S/
+  );
 });
 
 test("seat accessible labels expose row, number, state, and accessible marker", () => {

--- a/frontend/src/integration/purchase-flow.integration.test.ts
+++ b/frontend/src/integration/purchase-flow.integration.test.ts
@@ -306,7 +306,8 @@ test("mocked integration covers home to confirmation purchase journey", async ()
       );
 
       assert.match(seatHtml, /Mapa de assentos/);
-      assert.match(seatHtml, /Assento B7/);
+      assert.match(seatHtml, /Assento B1/);
+      assert.match(seatHtml, /assento original B7/);
       assert.match(seatHtml, /seat-map__seat--purchased/);
 
       setApiAuthController({


### PR DESCRIPTION
## Objective

Correct the frontend seat map layout so the room, screen, row labels, extra seats, accessible seats, companion seats, and legend are visually centered, symmetrical, and aligned with the expected room structure.

## What was done

### 1. Seat map centering

Updated the seat map rendering so the full layout stays centered within the room container:

- Main seat rows are split into left and right groups around a stable center aisle.
- The screen and back-of-room label remain aligned with the same central axis as the seat grid.
- Row labels continue to render on both sides and align vertically with their corresponding row.

### 2. Full-width screen layout

Adjusted the screen styling so it spans the full usable width of the rendered seat map while remaining centered with the room.

### 3. Symmetric extra seat distribution

Reworked row splitting so rows with extra seats distribute around the center aisle instead of drifting to one side.

For the current layout, the last row with two extra seats renders with one additional seat on each side.

### 4. Accessible and companion seats

Moved accessible/priority seats out of the back rows and into a dedicated front area before the first row:

- Renders exactly 6 accessible/priority seats total.
- Splits them into 3 on the left and 3 on the right.
- Preserves real `seat_id` and `session_seat_id` values so accessible seats remain selectable and purchasable.
- Adds adjacent companion seats when available.
- Labels companion seats as `AC`.

### 5. Seat numbering and real seat preservation

Separated visual seat numbering from the real backend seat identity:

- Accessible seats display `1-6` in the front accessible area.
- Rows are visually renumbered after accessible and companion seats are moved out.
- Reservation and checkout still use the original backend seat identifiers.

### 6. Seat tile and legend styling

Updated the visual presentation of seat tiles and legend items:

- Seat tiles are slightly smaller.
- Available/free seats no longer display the `L` marker.
- Available/free legend item uses only the white square indicator.
- Companion seats have a dedicated `AC / Acompanhante` legend item.
- Accessible seats keep wheelchair visual/semantic indication.

### 7. Test coverage

Expanded frontend seat-map coverage for the updated layout rules:

- Accessible seats render before the first row.
- Companion seats are present and labeled `AC`.
- Accessible seats are balanced 3 left / 3 right.
- Companion seats are selectable real seats, not placeholders.
- Extra seats split symmetrically around the center aisle.
- Visual numbering stays stable after accessible/companion seats are moved.
- Available seats no longer render the `L` marker.

## How to test

### Automated validation

Run the frontend lint and tests:

```bash
cd frontend
npm run lint
npm test
```

### Build validation

Because the local workspace currently has an ignored `.next/` directory owned by `root`, validate the build from a clean copy or remove the local `.next/` with administrative permissions first.

Clean-copy build used for this PR:

```bash
NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 npm run build
```

### Browser flow validation

Run the mocked critical frontend flows:

```bash
cd frontend
NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:40123 npm run e2e:ci
```

## Expected Result

- The seat map renders centered and balanced within the room container.
- The screen spans the room front and aligns with the seat grid.
- Accessible/priority seats appear before the first row and remain selectable.
- Companion seats appear adjacent to accessible seats and are labeled `AC`.
- Rows with extra seats distribute symmetrically around the center aisle.
- Available seats and the legend match the updated visual requirements.
- Existing reservation, release, countdown, and checkout flows continue to work.

closes #154
