### PR TITLE
feat: build movie home carousels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - "3000:3000"
     environment:
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+      NEXT_IMAGE_REMOTE_HOSTNAMES: image.tmdb.org,m.media-amazon.com,encrypted-tbn0.gstatic.com,img1.ibxk.com.br
     depends_on:
       - backend
 

--- a/frontend/e2e/support/api-mocks.ts
+++ b/frontend/e2e/support/api-mocks.ts
@@ -141,6 +141,10 @@ async function handleApiRoute(route: Route, state: ApiRouteState) {
       return json(route, paginated([preSaleMovie]));
     }
 
+    if (url.searchParams.get("status") === "em_breve") {
+      return json(route, paginated([upcomingMovie]));
+    }
+
     return json(route, paginated([movie]));
   }
 
@@ -297,6 +301,14 @@ const preSaleMovie = {
   is_featured: false,
   status: "pre_venda",
   title: "Estreia da Semana",
+};
+
+const upcomingMovie = {
+  ...movie,
+  id: "movie-upcoming",
+  is_featured: false,
+  status: "em_breve",
+  title: "Em Breve em Natal",
 };
 
 const session = {

--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { catalogApi } from "@/api/catalog";
 import { FeaturedMovieBanner } from "@/components/movies";
-import { MovieGrid } from "@/components/movies";
+import { MovieCarousel } from "@/components/movies";
 import { StateMessage } from "@/components/ui/StateMessage";
 import type { CatalogMovie } from "@/types/catalog";
 
@@ -93,8 +93,6 @@ export function HomeCatalogSections({
   preSale,
   upcoming,
 }: HomeCatalogSectionsProps) {
-  const featuredMovie = featured.movies[0];
-
   return (
     <div className="home-catalog" id="catalogo">
       {featured.status === "loading" ? (
@@ -114,14 +112,17 @@ export function HomeCatalogSections({
         />
       ) : null}
 
-      {featured.status === "success" && !featuredMovie ? (
+      {featured.status === "success" && featured.movies.length === 0 ? (
         <StateMessage title="Nenhum destaque disponível">
           Ainda não há filme marcado como destaque no catálogo.
         </StateMessage>
       ) : null}
 
-      {featured.status === "success" && featuredMovie ? (
-        <FeaturedMovieBanner movie={featuredMovie} primaryActionLabel="Ver detalhes" />
+      {featured.status === "success" && featured.movies.length > 0 ? (
+        <FeaturedMovieBanner
+          movies={featured.movies}
+          primaryActionLabel="Ver detalhes"
+        />
       ) : null}
 
       {nowShowing.status === "error" ? (
@@ -134,7 +135,7 @@ export function HomeCatalogSections({
           title="Em cartaz indisponível"
         />
       ) : (
-        <MovieGrid
+        <MovieCarousel
           emptyDescription="Ainda não há filmes em cartaz no catálogo."
           emptyTitle="Nenhum filme em cartaz"
           isLoading={nowShowing.status === "loading"}
@@ -154,7 +155,7 @@ export function HomeCatalogSections({
           title="Pré-venda indisponível"
         />
       ) : (
-        <MovieGrid
+        <MovieCarousel
           emptyDescription="Ainda não há filmes em pré-venda no catálogo."
           emptyTitle="Nenhum filme em pré-venda"
           isLoading={preSale.status === "loading"}
@@ -174,7 +175,7 @@ export function HomeCatalogSections({
           title="Em breve indisponível"
         />
       ) : (
-        <MovieGrid
+        <MovieCarousel
           emptyDescription="Ainda não há filmes em breve no catálogo."
           emptyTitle="Nenhum filme em breve"
           isLoading={upcoming.status === "loading"}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -519,6 +519,7 @@ h1 {
 
 .movie-carousel-section__header {
   align-items: center;
+  display: flex;
   min-height: 40px;
 }
 
@@ -2242,8 +2243,7 @@ h1 {
   }
 
   .movie-carousel-section__header {
-    align-items: start;
-    grid-template-columns: 1fr;
+    align-items: flex-start;
     min-height: 0;
   }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -414,6 +414,38 @@ h1 {
   border-left-color: var(--color-error);
 }
 
+.featured-movie-carousel {
+  display: grid;
+  gap: 12px;
+}
+
+.featured-movie-carousel__header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.featured-movie-carousel__viewport {
+  border-radius: 8px;
+  overflow-x: auto;
+  scroll-padding-inline: 0;
+  scroll-snap-type: x mandatory;
+  scrollbar-gutter: stable;
+}
+
+.featured-movie-carousel__track {
+  display: grid;
+  grid-auto-columns: 100%;
+  grid-auto-flow: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.featured-movie-carousel__slide {
+  min-width: 0;
+  scroll-snap-align: start;
+}
+
 .featured-movie {
   align-items: stretch;
   background: #231f20;
@@ -445,7 +477,7 @@ h1 {
   padding: 36px;
 }
 
-.featured-movie__content h2 {
+.featured-movie__content h3 {
   color: #ffffff;
   font-size: clamp(2rem, 4vw, 3.5rem);
   line-height: 1.05;
@@ -470,10 +502,89 @@ h1 {
   gap: 16px;
 }
 
+.movie-carousel-section {
+  display: grid;
+  gap: 16px;
+}
+
 .movie-grid-section__header h2 {
   font-size: 24px;
   line-height: 1.2;
   margin: 0;
+}
+
+.movie-carousel-section__header {
+  align-items: center;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 40px;
+}
+
+.movie-carousel-section__header h2 {
+  font-size: 24px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.movie-carousel-controls {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.carousel-button {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text);
+  display: inline-flex;
+  font-size: 20px;
+  font-weight: 900;
+  height: 40px;
+  justify-content: center;
+  line-height: 1;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+  width: 40px;
+}
+
+.carousel-button:hover {
+  background: #fff8df;
+  border-color: #d8a907;
+}
+
+.carousel-button--on-dark {
+  background: rgb(255 255 255 / 92%);
+  border-color: rgb(255 255 255 / 80%);
+}
+
+.carousel-button--on-dark:hover {
+  background: #ffffff;
+}
+
+.movie-carousel {
+  display: grid;
+  gap: 18px;
+  grid-auto-columns: clamp(180px, 22vw, 220px);
+  grid-auto-flow: column;
+  list-style: none;
+  margin: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  padding: 0 0 12px;
+  scroll-padding-inline: 2px;
+  scroll-snap-type: x mandatory;
+  scrollbar-gutter: stable;
+}
+
+.movie-carousel__item {
+  display: grid;
+  min-width: 0;
+  scroll-snap-align: start;
 }
 
 .movie-grid {
@@ -551,7 +662,13 @@ h1 {
   gap: 12px;
 }
 
-.movie-grid-loading > span {
+.movie-carousel-loading {
+  display: grid;
+  gap: 12px;
+}
+
+.movie-grid-loading > span,
+.movie-carousel-loading > span {
   color: var(--color-muted);
   font-weight: 750;
 }
@@ -1939,6 +2056,10 @@ h1 {
     grid-template-columns: 1fr;
   }
 
+  .movie-carousel {
+    grid-auto-columns: clamp(180px, 44vw, 240px);
+  }
+
   .movie-detail__poster-frame,
   .movie-detail-loading__poster {
     max-width: 340px;
@@ -2037,6 +2158,16 @@ h1 {
 
   .movie-grid {
     grid-template-columns: 1fr;
+  }
+
+  .movie-carousel-section__header {
+    align-items: start;
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .movie-carousel {
+    grid-auto-columns: minmax(210px, 84vw);
   }
 
   .movie-detail__poster-frame,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -416,20 +416,24 @@ h1 {
 
 .featured-movie-carousel {
   display: grid;
-  gap: 12px;
 }
 
-.featured-movie-carousel__header {
-  display: flex;
-  justify-content: flex-end;
+.featured-movie-carousel__viewport-outer {
+  min-width: 0;
+  position: relative;
 }
 
 .featured-movie-carousel__viewport {
   border-radius: 8px;
+  cursor: grab;
   overflow-x: auto;
   scroll-padding-inline: 0;
   scroll-snap-type: x mandatory;
-  scrollbar-gutter: stable;
+  scrollbar-width: none;
+}
+
+.featured-movie-carousel__viewport::-webkit-scrollbar {
+  display: none;
 }
 
 .featured-movie-carousel__track {
@@ -515,9 +519,6 @@ h1 {
 
 .movie-carousel-section__header {
   align-items: center;
-  display: grid;
-  gap: 12px;
-  grid-template-columns: minmax(0, 1fr) auto;
   min-height: 40px;
 }
 
@@ -548,7 +549,8 @@ h1 {
   transition:
     background 160ms ease,
     border-color 160ms ease,
-    color 160ms ease;
+    color 160ms ease,
+    transform 160ms ease;
   width: 40px;
 }
 
@@ -566,7 +568,82 @@ h1 {
   background: #ffffff;
 }
 
+.movie-carousel-outer {
+  min-width: 0;
+  position: relative;
+}
+
+
+.carousel-button--side {
+  background: rgba(255, 255, 255, 0.55);
+  border-color: transparent;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 12%);
+  color: rgba(20, 20, 20, 0.65);
+  height: 52px;
+  position: absolute;
+  top: 42%;
+  transform: translateY(-50%);
+  transition:
+    background 180ms ease,
+    box-shadow 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+  width: 36px;
+  z-index: 2;
+}
+
+.carousel-button--side:hover {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: transparent;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 18%);
+  color: rgba(20, 20, 20, 0.9);
+  transform: translateY(-50%) scale(1.08);
+}
+
+.carousel-button--side > span {
+  display: none;
+}
+
+.carousel-button--side::before {
+  border-right: 2.5px solid currentColor;
+  border-top: 2.5px solid currentColor;
+  content: '';
+  display: block;
+  flex-shrink: 0;
+  height: 10px;
+  width: 10px;
+}
+
+.carousel-button--on-dark.carousel-button--side {
+  color: rgba(255, 255, 255, 0.45);
+  top: 50%;
+}
+
+.carousel-button--on-dark.carousel-button--side:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.carousel-button--prev {
+  left: 4px;
+}
+
+.carousel-button--prev::before {
+  transform: rotate(-135deg);
+}
+
+.carousel-button--next {
+  right: 4px;
+}
+
+.carousel-button--next::before {
+  transform: rotate(45deg);
+}
+
 .movie-carousel {
+  cursor: grab;
   display: grid;
   gap: 18px;
   grid-auto-columns: clamp(180px, 22vw, 220px);
@@ -578,7 +655,11 @@ h1 {
   padding: 0 0 12px;
   scroll-padding-inline: 2px;
   scroll-snap-type: x mandatory;
-  scrollbar-gutter: stable;
+  scrollbar-width: none;
+}
+
+.movie-carousel::-webkit-scrollbar {
+  display: none;
 }
 
 .movie-carousel__item {

--- a/frontend/src/app/home-catalog.test.ts
+++ b/frontend/src/app/home-catalog.test.ts
@@ -29,18 +29,26 @@ const preSaleMovie: CatalogMovie = {
   title: "Estreia da Semana",
 };
 
+const upcomingMovie: CatalogMovie = {
+  ...featuredMovie,
+  id: "upcoming-1",
+  is_featured: false,
+  status: "em_breve",
+  title: "Em Breve na Tela",
+};
+
 const success = (movies: CatalogMovie[]): MovieSectionState => ({
   movies,
   status: "success",
 });
 
-test("home catalog renders featured, now showing, and pre-sale movie sections", () => {
+test("home catalog renders featured, now showing, pre-sale, and upcoming movie sections", () => {
   const html = renderToStaticMarkup(
     createElement(HomeCatalogSections, {
       featured: success([featuredMovie]),
       nowShowing: success([featuredMovie]),
       preSale: success([preSaleMovie]),
-      upcoming: success([]),
+      upcoming: success([upcomingMovie]),
     })
   );
 
@@ -49,7 +57,32 @@ test("home catalog renders featured, now showing, and pre-sale movie sections", 
   assert.match(html, /Em cartaz/);
   assert.match(html, /Pré-venda/);
   assert.match(html, /Estreia da Semana/);
+  assert.match(html, /Em breve/);
+  assert.match(html, /Em Breve na Tela/);
   assert.doesNotMatch(html, /age_rating|room_type|audio_format/i);
+});
+
+test("home catalog renders controls for multiple featured movies", () => {
+  const secondFeaturedMovie: CatalogMovie = {
+    ...featuredMovie,
+    id: "featured-2",
+    title: "Outra Jornada",
+  };
+
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([featuredMovie, secondFeaturedMovie]),
+      nowShowing: success([]),
+      preSale: success([]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /Filme em destaque: A Jornada/);
+  assert.match(html, /Filme em destaque: Outra Jornada/);
+  assert.match(html, /Mostrar destaque anterior/);
+  assert.match(html, /Mostrar próximo destaque/);
+  assert.match(html, /href="\/movies\/featured-2"/);
 });
 
 test("home catalog renders pt-BR loading and empty states", () => {
@@ -65,6 +98,7 @@ test("home catalog renders pt-BR loading and empty states", () => {
   assert.match(html, /Carregando filme em destaque/);
   assert.match(html, /Nenhum filme em cartaz/);
   assert.match(html, /Ainda não há filmes em pré-venda no catálogo./);
+  assert.match(html, /Nenhum filme em breve/);
 });
 
 test("home catalog renders retry-oriented error states", () => {
@@ -90,5 +124,27 @@ test("home catalog renders retry-oriented error states", () => {
   assert.match(html, /Destaque indisponível/);
   assert.match(html, /Em cartaz indisponível/);
   assert.match(html, /Pré-venda indisponível/);
+  assert.match(html, /Em breve indisponível/);
   assert.match(html, /Tentar novamente/);
+});
+
+test("home catalog keeps successful sections visible when another section errors", () => {
+  const errorState: MovieSectionState = {
+    errorMessage: "Falha localizada.",
+    movies: [],
+    status: "error",
+  };
+
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([featuredMovie]),
+      nowShowing: errorState,
+      preSale: success([preSaleMovie]),
+      upcoming: success([upcomingMovie]),
+    })
+  );
+
+  assert.match(html, /Em cartaz indisponível/);
+  assert.match(html, /Estreia da Semana/);
+  assert.match(html, /Em Breve na Tela/);
 });

--- a/frontend/src/components/movies/FeaturedMovieBanner.tsx
+++ b/frontend/src/components/movies/FeaturedMovieBanner.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import type { KeyboardEvent } from "react";
-import { useRef } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import { useEffect, useRef } from "react";
 
 import { ResponsiveImage } from "@/components/ui/ResponsiveImage";
 import type { CatalogMovie } from "@/types/catalog";
@@ -26,23 +26,86 @@ export function FeaturedMovieBanner({
 }: FeaturedMovieBannerProps) {
   const featuredMovies = movies?.length ? movies : movie ? [movie] : [];
   const viewportRef = useRef<HTMLDivElement>(null);
+  const currentIndexRef = useRef(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isDragging = useRef(false);
+  const dragStartX = useRef(0);
+  const dragScrollLeft = useRef(0);
 
-  if (featuredMovies.length === 0) {
-    return null;
+  function scrollToIndex(index: number) {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    viewport.scrollTo({ behavior: "smooth", left: viewport.clientWidth * index });
+    currentIndexRef.current = index;
+  }
+
+  function clearAutoAdvance() {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }
+
+  function startAutoAdvance() {
+    if (featuredMovies.length <= 1) return;
+    intervalRef.current = setInterval(() => {
+      const next = (currentIndexRef.current + 1) % featuredMovies.length;
+      scrollToIndex(next);
+    }, 7000);
+  }
+
+  function resetAutoAdvance() {
+    clearAutoAdvance();
+    startAutoAdvance();
   }
 
   function scrollFeatured(direction: "next" | "previous") {
+    const next =
+      direction === "next"
+        ? (currentIndexRef.current + 1) % featuredMovies.length
+        : (currentIndexRef.current - 1 + featuredMovies.length) %
+          featuredMovies.length;
+    scrollToIndex(next);
+    resetAutoAdvance();
+  }
+
+  function handleMouseDown(e: MouseEvent<HTMLDivElement>) {
+    isDragging.current = true;
+    dragStartX.current = e.pageX;
+    dragScrollLeft.current = viewportRef.current?.scrollLeft ?? 0;
     const viewport = viewportRef.current;
-
-    if (!viewport) {
-      return;
+    if (viewport) {
+      viewport.style.cursor = "grabbing";
+      viewport.style.userSelect = "none";
     }
+  }
 
-    const scrollDistance = Math.max(viewport.clientWidth, 320);
-    viewport.scrollBy({
-      behavior: "smooth",
-      left: direction === "next" ? scrollDistance : -scrollDistance,
-    });
+  function handleMouseMove(e: MouseEvent<HTMLDivElement>) {
+    if (!isDragging.current || !viewportRef.current) return;
+    e.preventDefault();
+    viewportRef.current.scrollLeft =
+      dragScrollLeft.current - (e.pageX - dragStartX.current);
+  }
+
+  function handleDragEnd() {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    const viewport = viewportRef.current;
+    if (viewport) {
+      viewport.style.cursor = "";
+      viewport.style.userSelect = "";
+    }
+    resetAutoAdvance();
+  }
+
+  useEffect(() => {
+    startAutoAdvance();
+    return clearAutoAdvance;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [featuredMovies.length]);
+
+  if (featuredMovies.length === 0) {
+    return null;
   }
 
   return (
@@ -50,84 +113,87 @@ export function FeaturedMovieBanner({
       aria-labelledby="featured-movies-heading"
       className="featured-movie-carousel"
     >
-      <div className="featured-movie-carousel__header">
-        <h2 className="sr-only" id="featured-movies-heading">
-          Filmes em destaque
-        </h2>
+      <h2 className="sr-only" id="featured-movies-heading">
+        Filmes em destaque
+      </h2>
+      <div className="featured-movie-carousel__viewport-outer">
         {featuredMovies.length > 1 ? (
-          <div
-            aria-label="Controles dos filmes em destaque"
-            className="movie-carousel-controls"
-            role="group"
+          <button
+            aria-label="Mostrar destaque anterior"
+            className="carousel-button carousel-button--side carousel-button--prev carousel-button--on-dark"
+            onClick={() => scrollFeatured("previous")}
+            title="Mostrar destaque anterior"
+            type="button"
           >
-            <button
-              aria-label="Mostrar destaque anterior"
-              className="carousel-button carousel-button--on-dark"
-              onClick={() => scrollFeatured("previous")}
-              title="Mostrar destaque anterior"
-              type="button"
-            >
-              <span aria-hidden="true">{"<"}</span>
-            </button>
-            <button
-              aria-label="Mostrar próximo destaque"
-              className="carousel-button carousel-button--on-dark"
-              onClick={() => scrollFeatured("next")}
-              title="Mostrar próximo destaque"
-              type="button"
-            >
-              <span aria-hidden="true">{">"}</span>
-            </button>
-          </div>
+            <span aria-hidden="true">{"<"}</span>
+          </button>
         ) : null}
-      </div>
-
-      <div className="featured-movie-carousel__viewport" ref={viewportRef}>
-        <ul
-          className="featured-movie-carousel__track"
-          onKeyDown={handleFeaturedKeyDown}
-          role="list"
+        <div
+          className="featured-movie-carousel__viewport"
+          onDragStart={(e) => e.preventDefault()}
+          onMouseDown={handleMouseDown}
+          onMouseLeave={handleDragEnd}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleDragEnd}
+          ref={viewportRef}
         >
-          {featuredMovies.map((featuredMovie, index) => (
-            <li
-              className="featured-movie-carousel__slide"
-              key={featuredMovie.id}
-            >
-              <article
-                aria-label={`Filme em destaque: ${featuredMovie.title}`}
-                className="featured-movie"
+          <ul
+            className="featured-movie-carousel__track"
+            onKeyDown={handleFeaturedKeyDown}
+            role="list"
+          >
+            {featuredMovies.map((featuredMovie, index) => (
+              <li
+                className="featured-movie-carousel__slide"
+                key={featuredMovie.id}
               >
-                <div className="featured-movie__media">
-                  <ResponsiveImage
-                    alt={`Poster de ${featuredMovie.title}`}
-                    className="featured-movie__poster"
-                    height={720}
-                    priority={index === 0}
-                    src={featuredMovie.poster_url}
-                    sizes="(max-width: 820px) 100vw, 360px"
-                    unoptimized
-                    width={480}
-                  />
-                </div>
-                <div className="featured-movie__content">
-                  <p className="eyebrow">Destaque</p>
-                  <h3>{featuredMovie.title}</h3>
-                  <p className="featured-movie__meta">
-                    {formatMovieGenres(featuredMovie.genres)} |{" "}
-                    {formatMovieDuration(featuredMovie.duration_minutes)}
-                  </p>
-                  <Link
-                    aria-label={`${primaryActionLabel} de ${featuredMovie.title}`}
-                    className="button button-primary"
-                    href={getMovieDetailsHref(featuredMovie.id)}
-                  >
-                    {primaryActionLabel}
-                  </Link>
-                </div>
-              </article>
-            </li>
-          ))}
-        </ul>
+                <article
+                  aria-label={`Filme em destaque: ${featuredMovie.title}`}
+                  className="featured-movie"
+                >
+                  <div className="featured-movie__media">
+                    <ResponsiveImage
+                      alt={`Poster de ${featuredMovie.title}`}
+                      className="featured-movie__poster"
+                      height={720}
+                      priority={index === 0}
+                      src={featuredMovie.poster_url}
+                      sizes="(max-width: 820px) 100vw, 360px"
+                      unoptimized
+                      width={480}
+                    />
+                  </div>
+                  <div className="featured-movie__content">
+                    <p className="eyebrow">Destaque</p>
+                    <h3>{featuredMovie.title}</h3>
+                    <p className="featured-movie__meta">
+                      {formatMovieGenres(featuredMovie.genres)} |{" "}
+                      {formatMovieDuration(featuredMovie.duration_minutes)}
+                    </p>
+                    <Link
+                      aria-label={`${primaryActionLabel} de ${featuredMovie.title}`}
+                      className="button button-primary"
+                      href={getMovieDetailsHref(featuredMovie.id)}
+                    >
+                      {primaryActionLabel}
+                    </Link>
+                  </div>
+                </article>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {featuredMovies.length > 1 ? (
+          <button
+            aria-label="Mostrar próximo destaque"
+            className="carousel-button carousel-button--side carousel-button--next carousel-button--on-dark"
+            onClick={() => scrollFeatured("next")}
+            title="Mostrar próximo destaque"
+            type="button"
+          >
+            <span aria-hidden="true">{">"}</span>
+          </button>
+        ) : null}
       </div>
     </section>
   );

--- a/frontend/src/components/movies/FeaturedMovieBanner.tsx
+++ b/frontend/src/components/movies/FeaturedMovieBanner.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import Link from "next/link";
+import type { KeyboardEvent } from "react";
+import { useRef } from "react";
 
 import { ResponsiveImage } from "@/components/ui/ResponsiveImage";
 import type { CatalogMovie } from "@/types/catalog";
@@ -10,46 +14,168 @@ import {
 } from "./movie-formatters";
 
 type FeaturedMovieBannerProps = {
-  movie: CatalogMovie;
+  movie?: CatalogMovie;
+  movies?: CatalogMovie[];
   primaryActionLabel?: string;
 };
 
 export function FeaturedMovieBanner({
   movie,
+  movies,
   primaryActionLabel = "Ver sessões",
 }: FeaturedMovieBannerProps) {
+  const featuredMovies = movies?.length ? movies : movie ? [movie] : [];
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  if (featuredMovies.length === 0) {
+    return null;
+  }
+
+  function scrollFeatured(direction: "next" | "previous") {
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    const scrollDistance = Math.max(viewport.clientWidth, 320);
+    viewport.scrollBy({
+      behavior: "smooth",
+      left: direction === "next" ? scrollDistance : -scrollDistance,
+    });
+  }
+
   return (
     <section
-      aria-label={`Filme em destaque: ${movie.title}`}
-      className="featured-movie"
+      aria-labelledby="featured-movies-heading"
+      className="featured-movie-carousel"
     >
-      <div className="featured-movie__media">
-        <ResponsiveImage
-          alt={`Poster de ${movie.title}`}
-          className="featured-movie__poster"
-          height={720}
-          priority
-          src={movie.poster_url}
-          sizes="(max-width: 820px) 100vw, 360px"
-          unoptimized
-          width={480}
-        />
+      <div className="featured-movie-carousel__header">
+        <h2 className="sr-only" id="featured-movies-heading">
+          Filmes em destaque
+        </h2>
+        {featuredMovies.length > 1 ? (
+          <div
+            aria-label="Controles dos filmes em destaque"
+            className="movie-carousel-controls"
+            role="group"
+          >
+            <button
+              aria-label="Mostrar destaque anterior"
+              className="carousel-button carousel-button--on-dark"
+              onClick={() => scrollFeatured("previous")}
+              title="Mostrar destaque anterior"
+              type="button"
+            >
+              <span aria-hidden="true">{"<"}</span>
+            </button>
+            <button
+              aria-label="Mostrar próximo destaque"
+              className="carousel-button carousel-button--on-dark"
+              onClick={() => scrollFeatured("next")}
+              title="Mostrar próximo destaque"
+              type="button"
+            >
+              <span aria-hidden="true">{">"}</span>
+            </button>
+          </div>
+        ) : null}
       </div>
-      <div className="featured-movie__content">
-        <p className="eyebrow">Destaque</p>
-        <h2>{movie.title}</h2>
-        <p className="featured-movie__meta">
-          {formatMovieGenres(movie.genres)} |{" "}
-          {formatMovieDuration(movie.duration_minutes)}
-        </p>
-        <Link
-          aria-label={`${primaryActionLabel} de ${movie.title}`}
-          className="button button-primary"
-          href={getMovieDetailsHref(movie.id)}
+
+      <div className="featured-movie-carousel__viewport" ref={viewportRef}>
+        <ul
+          className="featured-movie-carousel__track"
+          onKeyDown={handleFeaturedKeyDown}
+          role="list"
         >
-          {primaryActionLabel}
-        </Link>
+          {featuredMovies.map((featuredMovie, index) => (
+            <li
+              className="featured-movie-carousel__slide"
+              key={featuredMovie.id}
+            >
+              <article
+                aria-label={`Filme em destaque: ${featuredMovie.title}`}
+                className="featured-movie"
+              >
+                <div className="featured-movie__media">
+                  <ResponsiveImage
+                    alt={`Poster de ${featuredMovie.title}`}
+                    className="featured-movie__poster"
+                    height={720}
+                    priority={index === 0}
+                    src={featuredMovie.poster_url}
+                    sizes="(max-width: 820px) 100vw, 360px"
+                    unoptimized
+                    width={480}
+                  />
+                </div>
+                <div className="featured-movie__content">
+                  <p className="eyebrow">Destaque</p>
+                  <h3>{featuredMovie.title}</h3>
+                  <p className="featured-movie__meta">
+                    {formatMovieGenres(featuredMovie.genres)} |{" "}
+                    {formatMovieDuration(featuredMovie.duration_minutes)}
+                  </p>
+                  <Link
+                    aria-label={`${primaryActionLabel} de ${featuredMovie.title}`}
+                    className="button button-primary"
+                    href={getMovieDetailsHref(featuredMovie.id)}
+                  >
+                    {primaryActionLabel}
+                  </Link>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );
+}
+
+function handleFeaturedKeyDown(event: KeyboardEvent<HTMLUListElement>) {
+  if (
+    event.key !== "ArrowLeft" &&
+    event.key !== "ArrowRight" &&
+    event.key !== "Home" &&
+    event.key !== "End"
+  ) {
+    return;
+  }
+
+  const links = Array.from(
+    event.currentTarget.querySelectorAll<HTMLAnchorElement>(".featured-movie a")
+  );
+
+  if (links.length === 0) {
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  const activeIndex = links.findIndex((link) => link === activeElement);
+  let nextIndex = activeIndex >= 0 ? activeIndex : 0;
+
+  if (event.key === "ArrowRight") {
+    nextIndex = Math.min(nextIndex + 1, links.length - 1);
+  }
+
+  if (event.key === "ArrowLeft") {
+    nextIndex = Math.max(nextIndex - 1, 0);
+  }
+
+  if (event.key === "Home") {
+    nextIndex = 0;
+  }
+
+  if (event.key === "End") {
+    nextIndex = links.length - 1;
+  }
+
+  event.preventDefault();
+  links[nextIndex].focus();
+  links[nextIndex].scrollIntoView({
+    behavior: "smooth",
+    block: "nearest",
+    inline: "nearest",
+  });
 }

--- a/frontend/src/components/movies/FeaturedMovieBanner.tsx
+++ b/frontend/src/components/movies/FeaturedMovieBanner.tsx
@@ -70,6 +70,7 @@ export function FeaturedMovieBanner({
   }
 
   function handleMouseDown(e: MouseEvent<HTMLDivElement>) {
+    if (e.button !== 0) return;
     isDragging.current = true;
     dragStartX.current = e.pageX;
     dragScrollLeft.current = viewportRef.current?.scrollLeft ?? 0;
@@ -94,6 +95,9 @@ export function FeaturedMovieBanner({
     if (viewport) {
       viewport.style.cursor = "";
       viewport.style.userSelect = "";
+      currentIndexRef.current = Math.round(
+        viewport.scrollLeft / Math.max(viewport.clientWidth, 1)
+      );
     }
     resetAutoAdvance();
   }

--- a/frontend/src/components/movies/MovieCarousel.tsx
+++ b/frontend/src/components/movies/MovieCarousel.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import type { KeyboardEvent } from "react";
+import { useRef } from "react";
+
+import type { CatalogMovie } from "@/types/catalog";
+
+import { StateMessage } from "@/components/ui/StateMessage";
+
+import { MovieCard } from "./MovieCard";
+
+type MovieCarouselProps = {
+  ariaLabel?: string;
+  emptyDescription?: string;
+  emptyTitle?: string;
+  isLoading?: boolean;
+  loadingLabel?: string;
+  movies: CatalogMovie[];
+  nextButtonLabel?: string;
+  previousButtonLabel?: string;
+  skeletonCount?: number;
+  title: string;
+};
+
+export function MovieCarousel({
+  ariaLabel,
+  emptyDescription = "Nenhum filme foi encontrado para esta seção.",
+  emptyTitle = "Nenhum filme disponível",
+  isLoading = false,
+  loadingLabel = "Carregando filmes...",
+  movies,
+  nextButtonLabel,
+  previousButtonLabel,
+  skeletonCount = 6,
+  title,
+}: MovieCarouselProps) {
+  const railRef = useRef<HTMLUListElement>(null);
+  const headingId = `movie-carousel-${slugify(title)}`;
+  const hasMultipleMovies = movies.length > 1;
+
+  function scrollRail(direction: "next" | "previous") {
+    const rail = railRef.current;
+
+    if (!rail) {
+      return;
+    }
+
+    const scrollDistance = Math.max(rail.clientWidth * 0.85, 220);
+    rail.scrollBy({
+      behavior: "smooth",
+      left: direction === "next" ? scrollDistance : -scrollDistance,
+    });
+  }
+
+  return (
+    <section
+      aria-busy={isLoading || undefined}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabel ? undefined : headingId}
+      className="movie-carousel-section"
+    >
+      <div className="movie-carousel-section__header">
+        <h2 id={headingId}>{title}</h2>
+        {hasMultipleMovies ? (
+          <div
+            aria-label={`Controles do carrossel ${title}`}
+            className="movie-carousel-controls"
+            role="group"
+          >
+            <button
+              aria-label={previousButtonLabel ?? `Filme anterior em ${title}`}
+              className="carousel-button"
+              onClick={() => scrollRail("previous")}
+              title={previousButtonLabel ?? `Filme anterior em ${title}`}
+              type="button"
+            >
+              <span aria-hidden="true">{"<"}</span>
+            </button>
+            <button
+              aria-label={nextButtonLabel ?? `Próximo filme em ${title}`}
+              className="carousel-button"
+              onClick={() => scrollRail("next")}
+              title={nextButtonLabel ?? `Próximo filme em ${title}`}
+              type="button"
+            >
+              <span aria-hidden="true">{">"}</span>
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="movie-carousel-loading" role="status">
+          <span>{loadingLabel}</span>
+          <ul aria-hidden="true" className="movie-carousel" role="list">
+            {Array.from({ length: skeletonCount }, (_, index) => (
+              <li className="movie-carousel__item" key={index}>
+                <div className="movie-card movie-card--skeleton">
+                  <div className="movie-card__poster movie-card__poster--skeleton" />
+                  <div className="movie-card__body">
+                    <span className="skeleton-line skeleton-line--title" />
+                    <span className="skeleton-line" />
+                    <span className="skeleton-line skeleton-line--short" />
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {!isLoading && movies.length === 0 ? (
+        <StateMessage title={emptyTitle}>{emptyDescription}</StateMessage>
+      ) : null}
+
+      {!isLoading && movies.length > 0 ? (
+        <ul
+          aria-label={`${title}: carrossel de filmes`}
+          className="movie-carousel"
+          onKeyDown={handleCarouselKeyDown}
+          ref={railRef}
+          role="list"
+        >
+          {movies.map((movie) => (
+            <li className="movie-carousel__item" key={movie.id}>
+              <MovieCard movie={movie} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function handleCarouselKeyDown(event: KeyboardEvent<HTMLUListElement>) {
+  if (
+    event.key !== "ArrowLeft" &&
+    event.key !== "ArrowRight" &&
+    event.key !== "Home" &&
+    event.key !== "End"
+  ) {
+    return;
+  }
+
+  const cards = Array.from(
+    event.currentTarget.querySelectorAll<HTMLAnchorElement>(".movie-card__link")
+  );
+
+  if (cards.length === 0) {
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  const activeIndex = cards.findIndex((card) => card === activeElement);
+  let nextIndex = activeIndex >= 0 ? activeIndex : 0;
+
+  if (event.key === "ArrowRight") {
+    nextIndex = Math.min(nextIndex + 1, cards.length - 1);
+  }
+
+  if (event.key === "ArrowLeft") {
+    nextIndex = Math.max(nextIndex - 1, 0);
+  }
+
+  if (event.key === "Home") {
+    nextIndex = 0;
+  }
+
+  if (event.key === "End") {
+    nextIndex = cards.length - 1;
+  }
+
+  event.preventDefault();
+  cards[nextIndex].focus();
+  cards[nextIndex].scrollIntoView({
+    behavior: "smooth",
+    block: "nearest",
+    inline: "nearest",
+  });
+}
+
+function slugify(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}

--- a/frontend/src/components/movies/MovieCarousel.tsx
+++ b/frontend/src/components/movies/MovieCarousel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { KeyboardEvent } from "react";
-import { useRef } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { CatalogMovie } from "@/types/catalog";
 
@@ -35,21 +35,69 @@ export function MovieCarousel({
   title,
 }: MovieCarouselProps) {
   const railRef = useRef<HTMLUListElement>(null);
+  const [canScroll, setCanScroll] = useState(movies.length > 1);
+  const isDragging = useRef(false);
+  const dragStartX = useRef(0);
+  const dragScrollLeft = useRef(0);
   const headingId = `movie-carousel-${slugify(title)}`;
-  const hasMultipleMovies = movies.length > 1;
+
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) return;
+    const check = () => setCanScroll(rail.scrollWidth > rail.clientWidth + 1);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(rail);
+    return () => ro.disconnect();
+  }, [movies.length]);
 
   function scrollRail(direction: "next" | "previous") {
     const rail = railRef.current;
+    if (!rail) return;
 
-    if (!rail) {
-      return;
+    const { scrollLeft, clientWidth, scrollWidth } = rail;
+    const maxScroll = scrollWidth - clientWidth;
+    const scrollDistance = Math.max(clientWidth * 0.85, 220);
+
+    if (direction === "next") {
+      rail.scrollTo({
+        behavior: "smooth",
+        left: scrollLeft + 10 >= maxScroll ? 0 : scrollLeft + scrollDistance,
+      });
+    } else {
+      rail.scrollTo({
+        behavior: "smooth",
+        left: scrollLeft <= 10 ? maxScroll : scrollLeft - scrollDistance,
+      });
     }
+  }
 
-    const scrollDistance = Math.max(rail.clientWidth * 0.85, 220);
-    rail.scrollBy({
-      behavior: "smooth",
-      left: direction === "next" ? scrollDistance : -scrollDistance,
-    });
+  function handleMouseDown(e: MouseEvent<HTMLUListElement>) {
+    isDragging.current = true;
+    dragStartX.current = e.pageX;
+    dragScrollLeft.current = railRef.current?.scrollLeft ?? 0;
+    const rail = railRef.current;
+    if (rail) {
+      rail.style.cursor = "grabbing";
+      rail.style.userSelect = "none";
+    }
+  }
+
+  function handleMouseMove(e: MouseEvent<HTMLUListElement>) {
+    if (!isDragging.current || !railRef.current) return;
+    e.preventDefault();
+    railRef.current.scrollLeft =
+      dragScrollLeft.current - (e.pageX - dragStartX.current);
+  }
+
+  function handleDragEnd() {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    const rail = railRef.current;
+    if (rail) {
+      rail.style.cursor = "";
+      rail.style.userSelect = "";
+    }
   }
 
   return (
@@ -61,32 +109,6 @@ export function MovieCarousel({
     >
       <div className="movie-carousel-section__header">
         <h2 id={headingId}>{title}</h2>
-        {hasMultipleMovies ? (
-          <div
-            aria-label={`Controles do carrossel ${title}`}
-            className="movie-carousel-controls"
-            role="group"
-          >
-            <button
-              aria-label={previousButtonLabel ?? `Filme anterior em ${title}`}
-              className="carousel-button"
-              onClick={() => scrollRail("previous")}
-              title={previousButtonLabel ?? `Filme anterior em ${title}`}
-              type="button"
-            >
-              <span aria-hidden="true">{"<"}</span>
-            </button>
-            <button
-              aria-label={nextButtonLabel ?? `Próximo filme em ${title}`}
-              className="carousel-button"
-              onClick={() => scrollRail("next")}
-              title={nextButtonLabel ?? `Próximo filme em ${title}`}
-              type="button"
-            >
-              <span aria-hidden="true">{">"}</span>
-            </button>
-          </div>
-        ) : null}
       </div>
 
       {isLoading ? (
@@ -114,19 +136,48 @@ export function MovieCarousel({
       ) : null}
 
       {!isLoading && movies.length > 0 ? (
-        <ul
-          aria-label={`${title}: carrossel de filmes`}
-          className="movie-carousel"
-          onKeyDown={handleCarouselKeyDown}
-          ref={railRef}
-          role="list"
-        >
-          {movies.map((movie) => (
-            <li className="movie-carousel__item" key={movie.id}>
-              <MovieCard movie={movie} />
-            </li>
-          ))}
-        </ul>
+        <div className="movie-carousel-outer">
+          {canScroll ? (
+            <button
+              aria-label={previousButtonLabel ?? `Filme anterior em ${title}`}
+              className="carousel-button carousel-button--side carousel-button--prev"
+              onClick={() => scrollRail("previous")}
+              title={previousButtonLabel ?? `Filme anterior em ${title}`}
+              type="button"
+            >
+              <span aria-hidden="true">{"<"}</span>
+            </button>
+          ) : null}
+          <ul
+            aria-label={`${title}: carrossel de filmes`}
+            className="movie-carousel"
+            onDragStart={(e) => e.preventDefault()}
+            onKeyDown={handleCarouselKeyDown}
+            onMouseDown={handleMouseDown}
+            onMouseLeave={handleDragEnd}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleDragEnd}
+            ref={railRef}
+            role="list"
+          >
+            {movies.map((movie) => (
+              <li className="movie-carousel__item" key={movie.id}>
+                <MovieCard movie={movie} />
+              </li>
+            ))}
+          </ul>
+          {canScroll ? (
+            <button
+              aria-label={nextButtonLabel ?? `Próximo filme em ${title}`}
+              className="carousel-button carousel-button--side carousel-button--next"
+              onClick={() => scrollRail("next")}
+              title={nextButtonLabel ?? `Próximo filme em ${title}`}
+              type="button"
+            >
+              <span aria-hidden="true">{">"}</span>
+            </button>
+          ) : null}
+        </div>
       ) : null}
     </section>
   );
@@ -182,7 +233,7 @@ function handleCarouselKeyDown(event: KeyboardEvent<HTMLUListElement>) {
 function slugify(value: string) {
   return value
     .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[̀-ͯ]/g, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");

--- a/frontend/src/components/movies/MovieCarousel.tsx
+++ b/frontend/src/components/movies/MovieCarousel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { KeyboardEvent, MouseEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import type { CatalogMovie } from "@/types/catalog";
 
@@ -39,7 +39,8 @@ export function MovieCarousel({
   const isDragging = useRef(false);
   const dragStartX = useRef(0);
   const dragScrollLeft = useRef(0);
-  const headingId = `movie-carousel-${slugify(title)}`;
+  const uid = useId();
+  const headingId = `movie-carousel-${uid}`;
 
   useEffect(() => {
     const rail = railRef.current;
@@ -73,6 +74,7 @@ export function MovieCarousel({
   }
 
   function handleMouseDown(e: MouseEvent<HTMLUListElement>) {
+    if (e.button !== 0) return;
     isDragging.current = true;
     dragStartX.current = e.pageX;
     dragScrollLeft.current = railRef.current?.scrollLeft ?? 0;

--- a/frontend/src/components/movies/index.ts
+++ b/frontend/src/components/movies/index.ts
@@ -1,6 +1,7 @@
 export { FeaturedMovieBanner } from "./FeaturedMovieBanner";
 export { MovieDetail, MovieDetailView, type MovieDetailState } from "./MovieDetail";
 export { MovieCard } from "./MovieCard";
+export { MovieCarousel } from "./MovieCarousel";
 export { MovieGrid } from "./MovieGrid";
 export {
   formatMovieDuration,

--- a/frontend/src/components/movies/movie-components.test.ts
+++ b/frontend/src/components/movies/movie-components.test.ts
@@ -9,6 +9,7 @@ import type { CatalogMovie } from "@/types/catalog";
 
 import { FeaturedMovieBanner } from "./FeaturedMovieBanner";
 import { MovieCard } from "./MovieCard";
+import { MovieCarousel } from "./MovieCarousel";
 import { MovieGrid } from "./MovieGrid";
 import {
   formatMovieDuration,
@@ -86,6 +87,59 @@ test("movie grid renders pt-BR empty and loading states", () => {
   assert.match(loadingHtml, /aria-busy="true"/);
 });
 
+test("movie carousel renders an accessible horizontal rail with controls", () => {
+  const html = renderToStaticMarkup(
+    createElement(MovieCarousel, {
+      movies: [
+        movie,
+        {
+          ...movie,
+          id: "movie-456",
+          title: "Interestelar",
+        },
+      ],
+      title: "Em breve",
+    })
+  );
+
+  assert.match(html, /movie-carousel-section/);
+  assert.match(html, /Em breve: carrossel de filmes/);
+  assert.match(html, /role="list"/);
+  assert.match(html, /Filme anterior em Em breve/);
+  assert.match(html, /Próximo filme em Em breve/);
+  assert.match(html, /Duna: Parte Dois/);
+  assert.match(html, /Interestelar/);
+});
+
+test("movie carousel preserves empty and loading states", () => {
+  const emptyHtml = renderToStaticMarkup(
+    createElement(MovieCarousel, {
+      emptyDescription: "Sem próximos lançamentos.",
+      emptyTitle: "Nada por aqui",
+      movies: [],
+      title: "Em breve",
+    })
+  );
+
+  assert.match(emptyHtml, /Nada por aqui/);
+  assert.match(emptyHtml, /Sem próximos lançamentos./);
+
+  const loadingHtml = renderToStaticMarkup(
+    createElement(MovieCarousel, {
+      isLoading: true,
+      loadingLabel: "Carregando próximos lançamentos...",
+      movies: [],
+      skeletonCount: 2,
+      title: "Em breve",
+    })
+  );
+
+  assert.match(loadingHtml, /role="status"/);
+  assert.match(loadingHtml, /Carregando próximos lançamentos.../);
+  assert.match(loadingHtml, /aria-busy="true"/);
+  assert.match(loadingHtml, /movie-card--skeleton/);
+});
+
 test("featured banner renders featured movie media and primary action", () => {
   const html = renderToStaticMarkup(
     createElement(FeaturedMovieBanner, { movie })
@@ -101,6 +155,29 @@ test("featured banner renders featured movie media and primary action", () => {
   assert.match(html, /Ver sessões/);
   assert.match(html, /href="\/movies\/movie-123"/);
   assert.match(html, /Ficção científica, Aventura \| 2h 46min/);
+});
+
+test("featured banner renders multiple featured movies as a navigable carousel", () => {
+  const html = renderToStaticMarkup(
+    createElement(FeaturedMovieBanner, {
+      movies: [
+        movie,
+        {
+          ...movie,
+          id: "movie-456",
+          title: "Interestelar",
+        },
+      ],
+      primaryActionLabel: "Ver detalhes",
+    })
+  );
+
+  assert.match(html, /featured-movie-carousel/);
+  assert.match(html, /Filme em destaque: Duna: Parte Dois/);
+  assert.match(html, /Filme em destaque: Interestelar/);
+  assert.match(html, /Mostrar destaque anterior/);
+  assert.match(html, /Mostrar próximo destaque/);
+  assert.match(html, /href="\/movies\/movie-456"/);
 });
 
 test("movie component helpers format API-shaped values", () => {

--- a/frontend/src/integration/purchase-flow.integration.test.ts
+++ b/frontend/src/integration/purchase-flow.integration.test.ts
@@ -85,6 +85,16 @@ const preSaleMovie: CatalogMovie = {
   title: "Estreia da Semana",
 };
 
+const upcomingMovie: CatalogMovie = {
+  duration_minutes: 96,
+  genres: [{ id: "genre-family", name: "Família" }],
+  id: "movie-789",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/em-breve.jpg",
+  status: "em_breve",
+  title: "Em Breve na Tela",
+};
+
 const session: CatalogSession = {
   base_price: "42.50",
   created_at: "2026-05-21T10:00:00-03:00",
@@ -252,6 +262,7 @@ test("mocked integration covers home to confirmation purchase journey", async ()
       route("GET", "/api/v1/catalog/movies/?is_featured=true", paginated([movie])),
       route("GET", "/api/v1/catalog/movies/?status=em_cartaz", paginated([movie])),
       route("GET", "/api/v1/catalog/movies/?status=pre_venda", paginated([preSaleMovie])),
+      route("GET", "/api/v1/catalog/movies/?status=em_breve", paginated([upcomingMovie])),
       route("GET", "/api/v1/catalog/movies/movie-123/", movie),
       route("GET", "/api/v1/catalog/sessions/?movie=movie-123&date=2026-05-25", paginated([session])),
       route("GET", "/api/v1/reservation/sessions/session-123/seats/", seatMap),
@@ -264,18 +275,20 @@ test("mocked integration covers home to confirmation purchase journey", async ()
       const featured = await catalogApi.listFeaturedMovies();
       const nowShowing = await catalogApi.listNowShowingMovies();
       const preSale = await catalogApi.listPreSaleMovies();
+      const upcoming = await catalogApi.listUpcomingMovies();
       const homeHtml = renderToStaticMarkup(
         createElement(HomeCatalogSections, {
           featured: { movies: featured.results, status: "success" },
           nowShowing: { movies: nowShowing.results, status: "success" },
           preSale: { movies: preSale.results, status: "success" },
-          upcoming: { movies: [], status: "success" },
+          upcoming: { movies: upcoming.results, status: "success" },
         })
       );
 
       assert.match(homeHtml, /Filme em destaque: A Jornada/);
       assert.match(homeHtml, /href="\/movies\/movie-123"/);
       assert.match(homeHtml, /Pré-venda/);
+      assert.match(homeHtml, /Em breve/);
 
       const movieDetail = await catalogApi.getMovie("movie-123");
       const movieHtml = renderToStaticMarkup(
@@ -399,6 +412,7 @@ test("mocked integration covers home to confirmation purchase journey", async ()
       { body: undefined, method: "GET", path: "/api/v1/catalog/movies/?is_featured=true" },
       { body: undefined, method: "GET", path: "/api/v1/catalog/movies/?status=em_cartaz" },
       { body: undefined, method: "GET", path: "/api/v1/catalog/movies/?status=pre_venda" },
+      { body: undefined, method: "GET", path: "/api/v1/catalog/movies/?status=em_breve" },
       { body: undefined, method: "GET", path: "/api/v1/catalog/movies/movie-123/" },
       {
         body: undefined,


### PR DESCRIPTION
## Objective

Replace the home page's static catalog grids with accessible responsive movie carousels for now showing, pre-sale, and coming soon, while allowing the featured area to handle multiple featured movies without losing the details/sessions CTA.

## What was done

### 1. Shared movie carousel component

Added a reusable `MovieCarousel` component for horizontal movie rails with:

- scroll snap behavior
- previous and next icon buttons
- native touch, mouse/trackpad, and horizontal scroll support
- keyboard support for cards through Arrow/Home/End navigation
- accessible labels and grouped controls
- stable skeleton/card rail dimensions

### 2. Home catalog sections

Updated the home catalog to render carousel rails for all required movie statuses:

- `em_cartaz` as **Em cartaz**
- `pre_venda` as **Pré-venda**
- `em_breve` as **Em breve**

Each section keeps its own loading, empty, error, and retry behavior.

### 3. Section isolation

Kept catalog requests and render states independent so an error in one section does not block the other sections from rendering successfully.

### 4. Multiple featured movie support

Updated the featured movie banner to accept multiple `is_featured` movies and render them as a navigable featured carousel, preserving the CTA to each movie's details/sessions route.

### 5. Responsive and accessible styling

Added carousel CSS for:

- responsive rail item widths
- scroll snapping
- visible focus behavior through existing global focus styles
- stable loading skeleton rails
- mobile-safe layouts without text overlap

### 6. Test and mock coverage

Expanded frontend coverage for:

- rendering all three home rails
- empty states
- error states and retry states
- isolated section failure behavior
- multiple featured movies
- shared carousel rendering and loading behavior
- E2E mocked `em_breve` catalog responses

## How to test

### Automated validation

Run from `frontend/`:

```bash
npm run test
npm run lint
NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm run build
NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:40123 npm run e2e:ci
```

## Expected Result

- The home page shows carousel rails for `em_cartaz`, `pre_venda`, and `em_breve`.
- Carousels support touch, mouse/trackpad scrolling, and previous/next buttons.
- Buttons and movie cards are keyboard-accessible.
- Loading skeletons and cards keep stable carousel dimensions.
- A failure in one catalog section does not block other sections.
- Multiple featured movies can be navigated while keeping their detail CTA.
- Frontend unit, integration, build, lint, and Playwright E2E checks pass.

closes #159
