### PR TITLE
fix: render upcoming movies section on home page

### DIFF
--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -22,7 +22,9 @@ type HomeCatalogSectionsProps = {
   onRetryFeatured?: () => void;
   onRetryNowShowing?: () => void;
   onRetryPreSale?: () => void;
+  onRetryUpcoming?: () => void;
   preSale: MovieSectionState;
+  upcoming: MovieSectionState;
 };
 
 const loadingSectionState: MovieSectionState = {
@@ -36,6 +38,7 @@ export function HomeCatalog() {
   const [nowShowing, setNowShowing] =
     useState<MovieSectionState>(loadingSectionState);
   const [preSale, setPreSale] = useState<MovieSectionState>(loadingSectionState);
+  const [upcoming, setUpcoming] = useState<MovieSectionState>(loadingSectionState);
 
   const loadFeatured = useCallback(async () => {
     await loadMovieSection(
@@ -55,11 +58,16 @@ export function HomeCatalog() {
     await loadMovieSection(() => catalogApi.listPreSaleMovies(), setPreSale);
   }, []);
 
+  const loadUpcoming = useCallback(async () => {
+    await loadMovieSection(() => catalogApi.listUpcomingMovies(), setUpcoming);
+  }, []);
+
   useEffect(() => {
     void loadFeatured();
     void loadNowShowing();
     void loadPreSale();
-  }, [loadFeatured, loadNowShowing, loadPreSale]);
+    void loadUpcoming();
+  }, [loadFeatured, loadNowShowing, loadPreSale, loadUpcoming]);
 
   return (
     <HomeCatalogSections
@@ -68,7 +76,9 @@ export function HomeCatalog() {
       onRetryFeatured={() => void loadFeatured()}
       onRetryNowShowing={() => void loadNowShowing()}
       onRetryPreSale={() => void loadPreSale()}
+      onRetryUpcoming={() => void loadUpcoming()}
       preSale={preSale}
+      upcoming={upcoming}
     />
   );
 }
@@ -79,7 +89,9 @@ export function HomeCatalogSections({
   onRetryFeatured,
   onRetryNowShowing,
   onRetryPreSale,
+  onRetryUpcoming,
   preSale,
+  upcoming,
 }: HomeCatalogSectionsProps) {
   const featuredMovie = featured.movies[0];
 
@@ -149,6 +161,26 @@ export function HomeCatalogSections({
           loadingLabel="Carregando filmes em pré-venda..."
           movies={preSale.movies}
           title="Pré-venda"
+        />
+      )}
+
+      {upcoming.status === "error" ? (
+        <CatalogErrorState
+          message={
+            upcoming.errorMessage ??
+            "Não foi possível carregar os filmes em breve. Tente novamente."
+          }
+          onRetry={onRetryUpcoming}
+          title="Em breve indisponível"
+        />
+      ) : (
+        <MovieGrid
+          emptyDescription="Ainda não há filmes em breve no catálogo."
+          emptyTitle="Nenhum filme em breve"
+          isLoading={upcoming.status === "loading"}
+          loadingLabel="Carregando filmes em breve..."
+          movies={upcoming.movies}
+          title="Em breve"
         />
       )}
     </div>

--- a/frontend/src/app/home-catalog.test.ts
+++ b/frontend/src/app/home-catalog.test.ts
@@ -40,6 +40,7 @@ test("home catalog renders featured, now showing, and pre-sale movie sections", 
       featured: success([featuredMovie]),
       nowShowing: success([featuredMovie]),
       preSale: success([preSaleMovie]),
+      upcoming: success([]),
     })
   );
 
@@ -57,6 +58,7 @@ test("home catalog renders pt-BR loading and empty states", () => {
       featured: { movies: [], status: "loading" },
       nowShowing: success([]),
       preSale: success([]),
+      upcoming: success([]),
     })
   );
 
@@ -79,7 +81,9 @@ test("home catalog renders retry-oriented error states", () => {
       onRetryFeatured: () => undefined,
       onRetryNowShowing: () => undefined,
       onRetryPreSale: () => undefined,
+      onRetryUpcoming: () => undefined,
       preSale: errorState,
+      upcoming: errorState,
     })
   );
 

--- a/frontend/src/integration/purchase-flow.integration.test.ts
+++ b/frontend/src/integration/purchase-flow.integration.test.ts
@@ -269,6 +269,7 @@ test("mocked integration covers home to confirmation purchase journey", async ()
           featured: { movies: featured.results, status: "success" },
           nowShowing: { movies: nowShowing.results, status: "success" },
           preSale: { movies: preSale.results, status: "success" },
+          upcoming: { movies: [], status: "success" },
         })
       );
 


### PR DESCRIPTION
## What was done

`HomeCatalog` was missing the upcoming movies section. Although `#173` added `MovieStatus.EM_BREVE` to the backend and the `catalogApi.listUpcomingMovies()` function to the API client, the `HomeCatalog` component was never updated to fetch or render the corresponding section. Added the `upcoming` state, wired `loadUpcoming` into the `useEffect`, and rendered the "Em breve" `MovieGrid` below the pre-sale section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)