### PR TITLE
feat: rebuild public header and cinematic hero

### DIFF
--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { catalogApi } from "@/api/catalog";
+import { Button } from "@/components/ui/Button";
 import { FeaturedMovieBanner } from "@/components/movies";
 import { MovieCarousel } from "@/components/movies";
 import { StateMessage } from "@/components/ui/StateMessage";
@@ -94,39 +95,41 @@ export function HomeCatalogSections({
   upcoming,
 }: HomeCatalogSectionsProps) {
   return (
-    <div className="home-catalog">
+    <div>
       {/* Cinematic hero area — full-bleed, full-height */}
       {featured.status === "loading" ? (
-        <div className="cinematic-hero cinematic-hero--skeleton" aria-busy="true">
-          <div className="cinematic-hero__stage">
-            <div className="shell-container cinematic-hero__inner">
-              <StateMessage title="Carregando filme em destaque" tone="loading">
-                Buscando os destaques do catálogo.
-              </StateMessage>
-            </div>
+        <div
+          aria-busy="true"
+          className="relative overflow-hidden text-white ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] w-screen mt-[calc(-1_*_var(--layout-page-block))] bg-[rgb(8_10_16)] h-[75svh] min-h-[400px] flex items-center justify-center"
+        >
+          <div className="shell-container">
+            <StateMessage title="Carregando filme em destaque" tone="loading">
+              Buscando os destaques do catálogo.
+            </StateMessage>
           </div>
         </div>
       ) : null}
 
       {featured.status === "error" ? (
-        <div className="cinematic-hero cinematic-hero--empty">
-          <div className="cinematic-hero__stage">
-            <div className="shell-container cinematic-hero__inner">
-              <CatalogErrorState
-                message={
-                  featured.errorMessage ??
-                  "Não foi possível carregar o filme em destaque. Tente novamente."
-                }
-                onRetry={onRetryFeatured}
-                title="Destaque indisponível"
-              />
-            </div>
+        <div className="relative overflow-hidden text-white ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] w-screen mt-[calc(-1_*_var(--layout-page-block))] bg-[rgb(8_10_16)] h-[75svh] min-h-[400px] flex items-center justify-center">
+          <div className="shell-container">
+            <CatalogErrorState
+              message={
+                featured.errorMessage ??
+                "Não foi possível carregar o filme em destaque. Tente novamente."
+              }
+              onRetry={onRetryFeatured}
+              title="Destaque indisponível"
+            />
           </div>
         </div>
       ) : null}
 
       {featured.status === "success" && featured.movies.length === 0 ? (
-        <div className="cinematic-hero cinematic-hero--empty" aria-hidden="true" />
+        <div
+          aria-hidden="true"
+          className="ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] w-screen mt-[calc(-1_*_var(--layout-page-block))] bg-[rgb(8_10_16)] min-h-[320px]"
+        />
       ) : null}
 
       {featured.status === "success" && featured.movies.length > 0 ? (
@@ -137,7 +140,10 @@ export function HomeCatalogSections({
       ) : null}
 
       {/* Catalog sections — anchored for scroll-to-catalog links */}
-      <div className="home-catalog__sections" id="catalogo">
+      <div
+        className="grid gap-7 pt-[var(--layout-page-block)] max-md:pt-[var(--layout-page-block-compact)]"
+        id="catalogo"
+      >
         {nowShowing.status === "error" ? (
           <CatalogErrorState
             message={
@@ -237,9 +243,9 @@ function CatalogErrorState({
     <StateMessage
       action={
         onRetry ? (
-          <button className="button button-ghost" onClick={onRetry} type="button">
+          <Button onClick={onRetry} variant="ghost">
             Tentar novamente
-          </button>
+          </Button>
         ) : undefined
       }
       title={title}

--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -94,28 +94,39 @@ export function HomeCatalogSections({
   upcoming,
 }: HomeCatalogSectionsProps) {
   return (
-    <div className="home-catalog" id="catalogo">
+    <div className="home-catalog">
+      {/* Cinematic hero area — full-bleed, full-height */}
       {featured.status === "loading" ? (
-        <StateMessage title="Carregando filme em destaque" tone="loading">
-          Buscando os destaques do catálogo.
-        </StateMessage>
+        <div className="cinematic-hero cinematic-hero--skeleton" aria-busy="true">
+          <div className="cinematic-hero__stage">
+            <div className="shell-container cinematic-hero__inner">
+              <StateMessage title="Carregando filme em destaque" tone="loading">
+                Buscando os destaques do catálogo.
+              </StateMessage>
+            </div>
+          </div>
+        </div>
       ) : null}
 
       {featured.status === "error" ? (
-        <CatalogErrorState
-          message={
-            featured.errorMessage ??
-            "Não foi possível carregar o filme em destaque. Tente novamente."
-          }
-          onRetry={onRetryFeatured}
-          title="Destaque indisponível"
-        />
+        <div className="cinematic-hero cinematic-hero--empty">
+          <div className="cinematic-hero__stage">
+            <div className="shell-container cinematic-hero__inner">
+              <CatalogErrorState
+                message={
+                  featured.errorMessage ??
+                  "Não foi possível carregar o filme em destaque. Tente novamente."
+                }
+                onRetry={onRetryFeatured}
+                title="Destaque indisponível"
+              />
+            </div>
+          </div>
+        </div>
       ) : null}
 
       {featured.status === "success" && featured.movies.length === 0 ? (
-        <StateMessage title="Nenhum destaque disponível">
-          Ainda não há filme marcado como destaque no catálogo.
-        </StateMessage>
+        <div className="cinematic-hero cinematic-hero--empty" aria-hidden="true" />
       ) : null}
 
       {featured.status === "success" && featured.movies.length > 0 ? (
@@ -125,65 +136,68 @@ export function HomeCatalogSections({
         />
       ) : null}
 
-      {nowShowing.status === "error" ? (
-        <CatalogErrorState
-          message={
-            nowShowing.errorMessage ??
-            "Não foi possível carregar os filmes em cartaz. Tente novamente."
-          }
-          onRetry={onRetryNowShowing}
-          title="Em cartaz indisponível"
-        />
-      ) : (
-        <MovieCarousel
-          emptyDescription="Ainda não há filmes em cartaz no catálogo."
-          emptyTitle="Nenhum filme em cartaz"
-          isLoading={nowShowing.status === "loading"}
-          loadingLabel="Carregando filmes em cartaz..."
-          movies={nowShowing.movies}
-          title="Em cartaz"
-        />
-      )}
+      {/* Catalog sections — anchored for scroll-to-catalog links */}
+      <div className="home-catalog__sections" id="catalogo">
+        {nowShowing.status === "error" ? (
+          <CatalogErrorState
+            message={
+              nowShowing.errorMessage ??
+              "Não foi possível carregar os filmes em cartaz. Tente novamente."
+            }
+            onRetry={onRetryNowShowing}
+            title="Em cartaz indisponível"
+          />
+        ) : (
+          <MovieCarousel
+            emptyDescription="Ainda não há filmes em cartaz no catálogo."
+            emptyTitle="Nenhum filme em cartaz"
+            isLoading={nowShowing.status === "loading"}
+            loadingLabel="Carregando filmes em cartaz..."
+            movies={nowShowing.movies}
+            title="Em cartaz"
+          />
+        )}
 
-      {preSale.status === "error" ? (
-        <CatalogErrorState
-          message={
-            preSale.errorMessage ??
-            "Não foi possível carregar os filmes em pré-venda. Tente novamente."
-          }
-          onRetry={onRetryPreSale}
-          title="Pré-venda indisponível"
-        />
-      ) : (
-        <MovieCarousel
-          emptyDescription="Ainda não há filmes em pré-venda no catálogo."
-          emptyTitle="Nenhum filme em pré-venda"
-          isLoading={preSale.status === "loading"}
-          loadingLabel="Carregando filmes em pré-venda..."
-          movies={preSale.movies}
-          title="Pré-venda"
-        />
-      )}
+        {preSale.status === "error" ? (
+          <CatalogErrorState
+            message={
+              preSale.errorMessage ??
+              "Não foi possível carregar os filmes em pré-venda. Tente novamente."
+            }
+            onRetry={onRetryPreSale}
+            title="Pré-venda indisponível"
+          />
+        ) : (
+          <MovieCarousel
+            emptyDescription="Ainda não há filmes em pré-venda no catálogo."
+            emptyTitle="Nenhum filme em pré-venda"
+            isLoading={preSale.status === "loading"}
+            loadingLabel="Carregando filmes em pré-venda..."
+            movies={preSale.movies}
+            title="Pré-venda"
+          />
+        )}
 
-      {upcoming.status === "error" ? (
-        <CatalogErrorState
-          message={
-            upcoming.errorMessage ??
-            "Não foi possível carregar os filmes em breve. Tente novamente."
-          }
-          onRetry={onRetryUpcoming}
-          title="Em breve indisponível"
-        />
-      ) : (
-        <MovieCarousel
-          emptyDescription="Ainda não há filmes em breve no catálogo."
-          emptyTitle="Nenhum filme em breve"
-          isLoading={upcoming.status === "loading"}
-          loadingLabel="Carregando filmes em breve..."
-          movies={upcoming.movies}
-          title="Em breve"
-        />
-      )}
+        {upcoming.status === "error" ? (
+          <CatalogErrorState
+            message={
+              upcoming.errorMessage ??
+              "Não foi possível carregar os filmes em breve. Tente novamente."
+            }
+            onRetry={onRetryUpcoming}
+            title="Em breve indisponível"
+          />
+        ) : (
+          <MovieCarousel
+            emptyDescription="Ainda não há filmes em breve no catálogo."
+            emptyTitle="Nenhum filme em breve"
+            isLoading={upcoming.status === "loading"}
+            loadingLabel="Carregando filmes em breve..."
+            movies={upcoming.movies}
+            title="Em breve"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -103,6 +103,11 @@
   }
 }
 
+@keyframes scroll-bounce {
+  0%, 100% { transform: rotate(45deg) translateY(0); opacity: 0.55; }
+  50% { transform: rotate(45deg) translateY(4px); opacity: 1; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,25 +1,10 @@
 import { HomeCatalog } from "./HomeCatalog";
-import { ButtonLink } from "@/components/ui/Button";
-import { PageSection } from "@/components/ui/PageSection";
 
 export default function HomePage() {
   return (
-    <PageSection
-      actions={
-        <>
-          <ButtonLink href="#catalogo">
-            Ver catálogo
-          </ButtonLink>
-          <ButtonLink href="/login" variant="ghost">
-            Entrar
-          </ButtonLink>
-        </>
-      }
-      description="Encontre sessões em Natal, escolha seus assentos e avance para a compra de ingressos com uma experiência preparada para celular e desktop."
-      eyebrow="Catálogo"
-      title="CinePrime"
-    >
+    <>
+      <h1 className="sr-only">CinePrime – Ingressos de Cinema em Natal</h1>
       <HomeCatalog />
-    </PageSection>
+    </>
   );
 }

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -8,7 +8,6 @@ import { useAuth } from "@/contexts/AuthContext";
 const navigationItems = [
   { href: "/", label: "Início" },
   { href: "/#catalogo", label: "Catálogo" },
-  { href: "/ticket-types", label: "Ingressos" },
 ];
 
 function isActiveLink(pathname: string, href: string) {
@@ -30,12 +29,18 @@ export function AppHeader() {
   return (
     <header className="site-header">
       <div className="shell-container header-container">
-        <Link className="brand-link" href="/" aria-label="CinePrime, início">
-          <span className="brand-mark" aria-hidden="true">
-            CP
+        <div className="header-brand">
+          <Link className="brand-link" href="/" aria-label="CinePrime, início">
+            <span className="brand-mark" aria-hidden="true">
+              CP
+            </span>
+            <span>CinePrime</span>
+          </Link>
+          <span className="cinema-context" aria-label="Cinema selecionado: CinePrime Natal">
+            <span aria-hidden="true">&#x1F4CD;</span>
+            Natal
           </span>
-          <span>CinePrime</span>
-        </Link>
+        </div>
 
         <nav className="primary-nav" aria-label="Navegação principal">
           {navigationItems.map((item) => {

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { useAuth } from "@/contexts/AuthContext";
+import { Button, ButtonLink } from "@/components/ui/Button";
+import { cn } from "@/components/ui/classNames";
 
 const navigationItems = [
   { href: "/", label: "Início" },
@@ -27,29 +29,61 @@ export function AppHeader() {
   const { isAuthenticated, signOut } = useAuth();
 
   return (
-    <header className="site-header">
-      <div className="shell-container header-container">
-        <div className="header-brand">
-          <Link className="brand-link" href="/" aria-label="CinePrime, início">
-            <span className="brand-mark" aria-hidden="true">
+    <header className="sticky top-0 z-10 border-b border-white/[0.07] bg-[rgb(10_13_20/0.97)] [backdrop-filter:blur(20px)]">
+      <div
+        className={cn(
+          "w-full px-[var(--layout-gutter)] grid items-center gap-4",
+          "grid-cols-[auto_minmax(0,1fr)_auto] min-h-[var(--header-height)]",
+          "max-md:grid-cols-[1fr_auto] max-md:grid-rows-[auto_auto] max-md:gap-x-4 max-md:gap-y-0 max-md:min-h-0"
+        )}
+      >
+        {/* Brand */}
+        <div className="inline-flex items-center gap-2.5 min-w-max max-md:py-3 max-md:col-start-1 max-md:row-start-1">
+          <Link
+            aria-label="CinePrime, início"
+            className="inline-flex items-center gap-2.5 text-[18px] font-[850] text-white"
+            href="/"
+          >
+            <span
+              aria-hidden="true"
+              className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-[6px] bg-brand text-[12px] font-[850] text-white"
+            >
               CP
             </span>
             <span>CinePrime</span>
           </Link>
-          <span className="cinema-context" aria-label="Cinema selecionado: CinePrime Natal">
+          <span
+            aria-label="Cinema selecionado: CinePrime Natal"
+            className="inline-flex items-center gap-1.5 rounded-pill border border-white/10 bg-white/[0.08] px-2.5 py-1.5 text-[12px] font-[750] leading-none text-white/60 whitespace-nowrap transition-colors hover:bg-white/[0.12] hover:text-white/80 max-[420px]:hidden"
+          >
             <span aria-hidden="true">&#x1F4CD;</span>
             Natal
           </span>
         </div>
 
-        <nav className="primary-nav" aria-label="Navegação principal">
+        {/* Nav */}
+        <nav
+          aria-label="Navegação principal"
+          className={cn(
+            "flex flex-wrap items-center gap-2 justify-center min-w-0",
+            "max-md:col-span-full max-md:row-start-2",
+            "max-md:border-t max-md:border-white/[0.06]",
+            "max-md:overflow-x-auto max-md:flex-nowrap max-md:justify-start",
+            "max-md:py-1 max-md:[scrollbar-width:none]"
+          )}
+        >
           {navigationItems.map((item) => {
             const isActive = isActiveLink(pathname, item.href);
 
             return (
               <Link
                 aria-current={isActive ? "page" : undefined}
-                className={isActive ? "nav-link nav-link-active" : "nav-link"}
+                className={cn(
+                  "rounded-[6px] px-3 py-2.5 text-sm font-bold leading-none whitespace-nowrap transition-colors",
+                  isActive
+                    ? "bg-white/[0.08] text-white"
+                    : "text-white/60 hover:bg-white/[0.08] hover:text-white"
+                )}
                 href={item.href}
                 key={item.href}
               >
@@ -59,24 +93,41 @@ export function AppHeader() {
           })}
         </nav>
 
-        <div className="header-actions" aria-label="Ações da conta" role="group">
+        {/* Actions */}
+        <div
+          aria-label="Ações da conta"
+          className="flex flex-wrap items-center justify-end gap-2 max-md:py-3 max-md:col-start-2 max-md:row-start-1"
+          role="group"
+        >
           {isAuthenticated ? (
             <>
-              <Link className="button button-secondary" href="/my-tickets">
+              <ButtonLink
+                className="border-white/[0.16] text-white/80 hover:bg-white/10 hover:border-white/[0.24] hover:text-white"
+                href="/my-tickets"
+                variant="ghost"
+              >
                 Meus ingressos
-              </Link>
-              <button className="button button-ghost" onClick={signOut} type="button">
+              </ButtonLink>
+              <Button
+                className="border-white/[0.16] text-white/80 hover:bg-white/10 hover:border-white/[0.24] hover:text-white"
+                onClick={signOut}
+                variant="ghost"
+              >
                 Sair
-              </button>
+              </Button>
             </>
           ) : (
             <>
-              <Link className="button button-ghost" href="/login">
+              <ButtonLink
+                className="border-white/[0.16] text-white/80 hover:bg-white/10 hover:border-white/[0.24] hover:text-white"
+                href="/login"
+                variant="ghost"
+              >
                 Entrar
-              </Link>
-              <Link className="button button-primary" href="/register">
+              </ButtonLink>
+              <ButtonLink href="/register" variant="primary">
                 Criar conta
-              </Link>
+              </ButtonLink>
             </>
           )}
         </div>

--- a/frontend/src/components/movies/FeaturedMovieBanner.tsx
+++ b/frontend/src/components/movies/FeaturedMovieBanner.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { KeyboardEvent, MouseEvent } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ResponsiveImage } from "@/components/ui/ResponsiveImage";
 import type { CatalogMovie } from "@/types/catalog";
@@ -25,19 +24,8 @@ export function FeaturedMovieBanner({
   primaryActionLabel = "Ver sessões",
 }: FeaturedMovieBannerProps) {
   const featuredMovies = movies?.length ? movies : movie ? [movie] : [];
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const currentIndexRef = useRef(0);
+  const [activeIndex, setActiveIndex] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const isDragging = useRef(false);
-  const dragStartX = useRef(0);
-  const dragScrollLeft = useRef(0);
-
-  function scrollToIndex(index: number) {
-    const viewport = viewportRef.current;
-    if (!viewport) return;
-    viewport.scrollTo({ behavior: "smooth", left: viewport.clientWidth * index });
-    currentIndexRef.current = index;
-  }
 
   function clearAutoAdvance() {
     if (intervalRef.current) {
@@ -49,8 +37,7 @@ export function FeaturedMovieBanner({
   function startAutoAdvance() {
     if (featuredMovies.length <= 1) return;
     intervalRef.current = setInterval(() => {
-      const next = (currentIndexRef.current + 1) % featuredMovies.length;
-      scrollToIndex(next);
+      setActiveIndex((i) => (i + 1) % featuredMovies.length);
     }, 7000);
   }
 
@@ -60,45 +47,11 @@ export function FeaturedMovieBanner({
   }
 
   function scrollFeatured(direction: "next" | "previous") {
-    const next =
+    setActiveIndex((i) =>
       direction === "next"
-        ? (currentIndexRef.current + 1) % featuredMovies.length
-        : (currentIndexRef.current - 1 + featuredMovies.length) %
-          featuredMovies.length;
-    scrollToIndex(next);
-    resetAutoAdvance();
-  }
-
-  function handleMouseDown(e: MouseEvent<HTMLDivElement>) {
-    if (e.button !== 0) return;
-    isDragging.current = true;
-    dragStartX.current = e.pageX;
-    dragScrollLeft.current = viewportRef.current?.scrollLeft ?? 0;
-    const viewport = viewportRef.current;
-    if (viewport) {
-      viewport.style.cursor = "grabbing";
-      viewport.style.userSelect = "none";
-    }
-  }
-
-  function handleMouseMove(e: MouseEvent<HTMLDivElement>) {
-    if (!isDragging.current || !viewportRef.current) return;
-    e.preventDefault();
-    viewportRef.current.scrollLeft =
-      dragScrollLeft.current - (e.pageX - dragStartX.current);
-  }
-
-  function handleDragEnd() {
-    if (!isDragging.current) return;
-    isDragging.current = false;
-    const viewport = viewportRef.current;
-    if (viewport) {
-      viewport.style.cursor = "";
-      viewport.style.userSelect = "";
-      currentIndexRef.current = Math.round(
-        viewport.scrollLeft / Math.max(viewport.clientWidth, 1)
-      );
-    }
+        ? (i + 1) % featuredMovies.length
+        : (i - 1 + featuredMovies.length) % featuredMovies.length
+    );
     resetAutoAdvance();
   }
 
@@ -115,137 +68,122 @@ export function FeaturedMovieBanner({
   return (
     <section
       aria-labelledby="featured-movies-heading"
-      className="featured-movie-carousel"
+      className="featured-movie-carousel cinematic-hero"
     >
       <h2 className="sr-only" id="featured-movies-heading">
         Filmes em destaque
       </h2>
-      <div className="featured-movie-carousel__viewport-outer">
-        {featuredMovies.length > 1 ? (
+
+      {/* Full-bleed backdrop with per-slide images */}
+      <div className="cinematic-hero__backdrop" aria-hidden="true">
+        {featuredMovies.map((fm, i) => (
+          <div
+            key={fm.id}
+            className={`cinematic-hero__slide-bg${
+              i === activeIndex ? " cinematic-hero__slide-bg--active" : ""
+            }`}
+          >
+            <ResponsiveImage
+              alt={`Poster de ${fm.title}`}
+              className="cinematic-hero__bg-img"
+              height={1080}
+              priority={i === 0}
+              src={fm.poster_url}
+              sizes="100vw"
+              unoptimized
+              width={1920}
+            />
+          </div>
+        ))}
+        <div className="cinematic-hero__overlay" />
+      </div>
+
+      {/* Content stage — shell-container constrains the text width */}
+      <div className="cinematic-hero__stage">
+        <div className="shell-container cinematic-hero__inner">
+          {featuredMovies.map((fm, i) => (
+            <article
+              key={fm.id}
+              aria-label={`Filme em destaque: ${fm.title}`}
+              aria-hidden={i !== activeIndex || undefined}
+              className={`cinematic-hero__content${
+                i === activeIndex ? " cinematic-hero__content--active" : ""
+              }`}
+            >
+              <p className="eyebrow cinematic-hero__eyebrow">Destaque</p>
+              <h3 className="cinematic-hero__title">{fm.title}</h3>
+              <p className="cinematic-hero__meta">
+                {formatMovieGenres(fm.genres)} |{" "}
+                {formatMovieDuration(fm.duration_minutes)}
+              </p>
+              <Link
+                aria-label={`${primaryActionLabel} de ${fm.title}`}
+                className="button button-primary cinematic-hero__cta"
+                href={getMovieDetailsHref(fm.id)}
+              >
+                {primaryActionLabel}
+              </Link>
+            </article>
+          ))}
+
+          {featuredMovies.length > 1 ? (
+            <div
+              aria-label="Destaques"
+              className="cinematic-hero__dots"
+              role="tablist"
+            >
+              {featuredMovies.map((fm, i) => (
+                <button
+                  key={fm.id}
+                  aria-label={`Destaque ${i + 1}: ${fm.title}`}
+                  aria-selected={i === activeIndex}
+                  className={`cinematic-hero__dot${
+                    i === activeIndex ? " cinematic-hero__dot--active" : ""
+                  }`}
+                  onClick={() => {
+                    setActiveIndex(i);
+                    resetAutoAdvance();
+                  }}
+                  role="tab"
+                  type="button"
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Directional controls — only rendered when more than one featured movie */}
+      {featuredMovies.length > 1 ? (
+        <>
           <button
             aria-label="Mostrar destaque anterior"
             className="carousel-button carousel-button--side carousel-button--prev carousel-button--on-dark"
             onClick={() => scrollFeatured("previous")}
-            title="Mostrar destaque anterior"
             type="button"
           >
-            <span aria-hidden="true">{"<"}</span>
+            <span aria-hidden="true" />
           </button>
-        ) : null}
-        <div
-          className="featured-movie-carousel__viewport"
-          onDragStart={(e) => e.preventDefault()}
-          onMouseDown={handleMouseDown}
-          onMouseLeave={handleDragEnd}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleDragEnd}
-          ref={viewportRef}
-        >
-          <ul
-            className="featured-movie-carousel__track"
-            onKeyDown={handleFeaturedKeyDown}
-            role="list"
-          >
-            {featuredMovies.map((featuredMovie, index) => (
-              <li
-                className="featured-movie-carousel__slide"
-                key={featuredMovie.id}
-              >
-                <article
-                  aria-label={`Filme em destaque: ${featuredMovie.title}`}
-                  className="featured-movie"
-                >
-                  <div className="featured-movie__media">
-                    <ResponsiveImage
-                      alt={`Poster de ${featuredMovie.title}`}
-                      className="featured-movie__poster"
-                      height={720}
-                      priority={index === 0}
-                      src={featuredMovie.poster_url}
-                      sizes="(max-width: 820px) 100vw, 360px"
-                      unoptimized
-                      width={480}
-                    />
-                  </div>
-                  <div className="featured-movie__content">
-                    <p className="eyebrow">Destaque</p>
-                    <h3>{featuredMovie.title}</h3>
-                    <p className="featured-movie__meta">
-                      {formatMovieGenres(featuredMovie.genres)} |{" "}
-                      {formatMovieDuration(featuredMovie.duration_minutes)}
-                    </p>
-                    <Link
-                      aria-label={`${primaryActionLabel} de ${featuredMovie.title}`}
-                      className="button button-primary"
-                      href={getMovieDetailsHref(featuredMovie.id)}
-                    >
-                      {primaryActionLabel}
-                    </Link>
-                  </div>
-                </article>
-              </li>
-            ))}
-          </ul>
-        </div>
-        {featuredMovies.length > 1 ? (
           <button
             aria-label="Mostrar próximo destaque"
             className="carousel-button carousel-button--side carousel-button--next carousel-button--on-dark"
             onClick={() => scrollFeatured("next")}
-            title="Mostrar próximo destaque"
             type="button"
           >
-            <span aria-hidden="true">{">"}</span>
+            <span aria-hidden="true" />
           </button>
-        ) : null}
-      </div>
+        </>
+      ) : null}
+
+      {/* Scroll hint to catalog */}
+      <a
+        aria-label="Rolar para o catálogo de filmes"
+        className="cinematic-hero__scroll-hint"
+        href="#catalogo"
+      >
+        <span aria-hidden="true" className="cinematic-hero__scroll-arrow" />
+        <span className="sr-only">Ver catálogo</span>
+      </a>
     </section>
   );
-}
-
-function handleFeaturedKeyDown(event: KeyboardEvent<HTMLUListElement>) {
-  if (
-    event.key !== "ArrowLeft" &&
-    event.key !== "ArrowRight" &&
-    event.key !== "Home" &&
-    event.key !== "End"
-  ) {
-    return;
-  }
-
-  const links = Array.from(
-    event.currentTarget.querySelectorAll<HTMLAnchorElement>(".featured-movie a")
-  );
-
-  if (links.length === 0) {
-    return;
-  }
-
-  const activeElement = document.activeElement;
-  const activeIndex = links.findIndex((link) => link === activeElement);
-  let nextIndex = activeIndex >= 0 ? activeIndex : 0;
-
-  if (event.key === "ArrowRight") {
-    nextIndex = Math.min(nextIndex + 1, links.length - 1);
-  }
-
-  if (event.key === "ArrowLeft") {
-    nextIndex = Math.max(nextIndex - 1, 0);
-  }
-
-  if (event.key === "Home") {
-    nextIndex = 0;
-  }
-
-  if (event.key === "End") {
-    nextIndex = links.length - 1;
-  }
-
-  event.preventDefault();
-  links[nextIndex].focus();
-  links[nextIndex].scrollIntoView({
-    behavior: "smooth",
-    block: "nearest",
-    inline: "nearest",
-  });
 }

--- a/frontend/src/components/movies/FeaturedMovieBanner.tsx
+++ b/frontend/src/components/movies/FeaturedMovieBanner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
+import { Badge } from "@/components/ui/Badge";
+import { ButtonLink } from "@/components/ui/Button";
 import { ResponsiveImage } from "@/components/ui/ResponsiveImage";
 import type { CatalogMovie } from "@/types/catalog";
 
@@ -68,24 +69,24 @@ export function FeaturedMovieBanner({
   return (
     <section
       aria-labelledby="featured-movies-heading"
-      className="featured-movie-carousel cinematic-hero"
+      className="featured-movie-carousel relative overflow-hidden text-white ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)] w-screen h-[75svh] min-h-[400px] mt-[calc(-1_*_var(--layout-page-block))]"
     >
       <h2 className="sr-only" id="featured-movies-heading">
         Filmes em destaque
       </h2>
 
       {/* Full-bleed backdrop with per-slide images */}
-      <div className="cinematic-hero__backdrop" aria-hidden="true">
+      <div aria-hidden="true" className="absolute inset-0">
         {featuredMovies.map((fm, i) => (
           <div
             key={fm.id}
-            className={`cinematic-hero__slide-bg${
-              i === activeIndex ? " cinematic-hero__slide-bg--active" : ""
+            className={`absolute inset-0 transition-opacity duration-700 [will-change:opacity] ${
+              i === activeIndex ? "opacity-100" : "opacity-0"
             }`}
           >
             <ResponsiveImage
               alt={`Poster de ${fm.title}`}
-              className="cinematic-hero__bg-img"
+              className="block h-full w-full object-cover object-top"
               height={1080}
               priority={i === 0}
               src={fm.poster_url}
@@ -95,41 +96,62 @@ export function FeaturedMovieBanner({
             />
           </div>
         ))}
-        <div className="cinematic-hero__overlay" />
+        {/* Cinematic gradient overlay */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{
+            background: [
+              "linear-gradient(to right, rgb(5 8 16 / 90%) 0%, rgb(5 8 16 / 72%) 35%, rgb(5 8 16 / 42%) 60%, rgb(5 8 16 / 18%) 100%)",
+              "linear-gradient(to top, rgb(5 8 16 / 60%) 0%, transparent 40%)",
+            ].join(", "),
+          }}
+        />
       </div>
 
-      {/* Content stage — shell-container constrains the text width */}
-      <div className="cinematic-hero__stage">
-        <div className="shell-container cinematic-hero__inner">
+      {/* Content stage — anchored to bottom */}
+      <div className="absolute inset-0 flex items-end pb-20">
+        <div className="shell-container relative z-[2] grid gap-5">
           {featuredMovies.map((fm, i) => (
             <article
               key={fm.id}
               aria-label={`Filme em destaque: ${fm.title}`}
               aria-hidden={i !== activeIndex || undefined}
-              className={`cinematic-hero__content${
-                i === activeIndex ? " cinematic-hero__content--active" : ""
+              className={`grid gap-4 max-w-[580px] transition-opacity duration-[600ms] ${
+                i === activeIndex
+                  ? "opacity-100 pointer-events-auto static"
+                  : "opacity-0 pointer-events-none absolute top-0"
               }`}
             >
-              <p className="eyebrow cinematic-hero__eyebrow">Destaque</p>
-              <h3 className="cinematic-hero__title">{fm.title}</h3>
-              <p className="cinematic-hero__meta">
+              <Badge className="w-fit" tone="accent">
+                Destaque
+              </Badge>
+              <h3
+                className="m-0 text-[clamp(2rem,5vw,3.5rem)] font-extrabold leading-[1.05] text-white"
+                style={{ textShadow: "0 2px 20px rgb(0 0 0 / 50%)" }}
+              >
+                {fm.title}
+              </h3>
+              <p className="m-0 text-base font-semibold text-white/75">
                 {formatMovieGenres(fm.genres)} |{" "}
                 {formatMovieDuration(fm.duration_minutes)}
               </p>
-              <Link
+              <ButtonLink
                 aria-label={`${primaryActionLabel} de ${fm.title}`}
-                className="button button-primary cinematic-hero__cta"
+                className="w-fit min-h-[48px] px-7"
                 href={getMovieDetailsHref(fm.id)}
+                size="lg"
+                variant="primary"
               >
                 {primaryActionLabel}
-              </Link>
+              </ButtonLink>
             </article>
           ))}
 
           {featuredMovies.length > 1 ? (
             <div
               aria-label="Destaques"
-              className="cinematic-hero__dots"
+              className="flex gap-2 pt-2"
               role="tablist"
             >
               {featuredMovies.map((fm, i) => (
@@ -137,8 +159,10 @@ export function FeaturedMovieBanner({
                   key={fm.id}
                   aria-label={`Destaque ${i + 1}: ${fm.title}`}
                   aria-selected={i === activeIndex}
-                  className={`cinematic-hero__dot${
-                    i === activeIndex ? " cinematic-hero__dot--active" : ""
+                  className={`h-1.5 rounded-pill border-0 cursor-pointer p-0 transition-all duration-200 ${
+                    i === activeIndex
+                      ? "w-10 bg-white"
+                      : "w-6 bg-white/35 hover:bg-white/60"
                   }`}
                   onClick={() => {
                     setActiveIndex(i);
@@ -158,19 +182,25 @@ export function FeaturedMovieBanner({
         <>
           <button
             aria-label="Mostrar destaque anterior"
-            className="carousel-button carousel-button--side carousel-button--prev carousel-button--on-dark"
+            className="absolute left-1 top-1/2 z-[3] -translate-y-1/2 flex h-[52px] w-9 items-center justify-center rounded-[6px] bg-white/55 text-[rgb(20_20_20/0.65)] transition-all hover:bg-white/[0.92] hover:scale-[1.08] focus-visible:outline-none focus-visible:shadow-focus"
             onClick={() => scrollFeatured("previous")}
             type="button"
           >
-            <span aria-hidden="true" />
+            <span
+              aria-hidden="true"
+              className="block h-2.5 w-2.5 -rotate-[135deg] border-r-2 border-t-2 border-current"
+            />
           </button>
           <button
             aria-label="Mostrar próximo destaque"
-            className="carousel-button carousel-button--side carousel-button--next carousel-button--on-dark"
+            className="absolute right-1 top-1/2 z-[3] -translate-y-1/2 flex h-[52px] w-9 items-center justify-center rounded-[6px] bg-white/55 text-[rgb(20_20_20/0.65)] transition-all hover:bg-white/[0.92] hover:scale-[1.08] focus-visible:outline-none focus-visible:shadow-focus"
             onClick={() => scrollFeatured("next")}
             type="button"
           >
-            <span aria-hidden="true" />
+            <span
+              aria-hidden="true"
+              className="block h-2.5 w-2.5 rotate-45 border-r-2 border-t-2 border-current"
+            />
           </button>
         </>
       ) : null}
@@ -178,10 +208,13 @@ export function FeaturedMovieBanner({
       {/* Scroll hint to catalog */}
       <a
         aria-label="Rolar para o catálogo de filmes"
-        className="cinematic-hero__scroll-hint"
+        className="absolute bottom-6 left-1/2 z-[3] flex -translate-x-1/2 flex-col items-center gap-1 text-white/55 transition-colors hover:text-white focus-visible:outline-none"
         href="#catalogo"
       >
-        <span aria-hidden="true" className="cinematic-hero__scroll-arrow" />
+        <span
+          aria-hidden="true"
+          className="block h-2.5 w-2.5 rotate-45 border-b-2 border-r-2 border-current animate-scroll-bounce"
+        />
         <span className="sr-only">Ver catálogo</span>
       </a>
     </section>

--- a/frontend/src/styles/public-legacy.css
+++ b/frontend/src/styles/public-legacy.css
@@ -1,6 +1,10 @@
+/* ── Site header: dark cinematic ───────────────────────────────────── */
+
 .site-header {
-  background: rgb(255 255 255 / 96%);
-  border-bottom: 1px solid var(--color-border);
+  background: rgb(10 13 20 / 97%);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgb(255 255 255 / 7%);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -11,17 +15,23 @@
   display: grid;
   gap: 16px;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  min-height: 72px;
+  min-height: var(--header-height, 72px);
+}
+
+.header-brand {
+  align-items: center;
+  display: inline-flex;
+  gap: 10px;
+  min-width: max-content;
 }
 
 .brand-link {
   align-items: center;
-  color: var(--color-brand);
+  color: #ffffff;
   display: inline-flex;
   font-size: 18px;
   font-weight: 850;
   gap: 10px;
-  min-width: max-content;
 }
 
 .brand-mark {
@@ -35,6 +45,27 @@
   justify-content: center;
   line-height: 1;
   width: 34px;
+}
+
+.cinema-context {
+  align-items: center;
+  background: rgb(255 255 255 / 8%);
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 999px;
+  color: rgb(255 255 255 / 60%);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 750;
+  gap: 5px;
+  line-height: 1;
+  padding: 5px 10px;
+  transition: background var(--duration-fast) var(--ease-standard);
+  white-space: nowrap;
+}
+
+.cinema-context:hover {
+  background: rgb(255 255 255 / 12%);
+  color: rgb(255 255 255 / 80%);
 }
 
 .primary-nav,
@@ -57,18 +88,42 @@
 
 .nav-link {
   border-radius: 6px;
-  color: var(--color-muted);
+  color: rgb(255 255 255 / 60%);
   font-size: 14px;
   font-weight: 700;
   line-height: 1;
   padding: 10px 12px;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
   white-space: nowrap;
 }
 
 .nav-link:hover,
 .nav-link-active {
-  background: #fff2bf;
-  color: var(--color-text);
+  background: rgb(255 255 255 / 8%);
+  color: #ffffff;
+}
+
+.site-header .button-ghost {
+  border-color: rgb(255 255 255 / 16%);
+  color: rgb(255 255 255 / 80%);
+}
+
+.site-header .button-ghost:hover {
+  background: rgb(255 255 255 / 10%);
+  border-color: rgb(255 255 255 / 24%);
+  color: #ffffff;
+}
+
+.site-header .button-secondary {
+  background: rgb(255 255 255 / 10%);
+  border-color: rgb(255 255 255 / 16%);
+  color: #ffffff;
+}
+
+.site-header .button-secondary:hover {
+  background: rgb(255 255 255 / 16%);
 }
 
 .main-content {
@@ -418,7 +473,248 @@ h1 {
 
 .home-catalog {
   display: grid;
+  gap: 0;
+}
+
+.home-catalog__sections {
+  display: grid;
   gap: 28px;
+  padding-top: var(--layout-page-block);
+}
+
+/* ── Cinematic hero ─────────────────────────────────────────────────── */
+
+.cinematic-hero {
+  color: #ffffff;
+  height: calc(100svh - var(--header-height, 72px));
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  /* Cancel main-content top padding so hero starts immediately below header */
+  margin-top: calc(-1 * var(--layout-page-block));
+  min-height: 480px;
+  overflow: hidden;
+  position: relative;
+  width: 100vw;
+}
+
+/* Skeleton / empty hero variants */
+.cinematic-hero--skeleton,
+.cinematic-hero--empty {
+  background: rgb(8 10 16);
+  min-height: 320px;
+}
+
+.cinematic-hero--skeleton {
+  height: auto;
+}
+
+/* Backdrop — fills the hero, sits behind content */
+.cinematic-hero__backdrop {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+/* Per-slide background images with fade transition */
+.cinematic-hero__slide-bg {
+  bottom: 0;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: opacity 700ms ease;
+  will-change: opacity;
+}
+
+.cinematic-hero__slide-bg--active {
+  opacity: 1;
+}
+
+.cinematic-hero__bg-img {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  width: 100%;
+}
+
+/* Cinematic gradient overlay — strong on the left, fades right */
+.cinematic-hero__overlay {
+  background:
+    linear-gradient(
+      to right,
+      rgb(5 8 16 / 90%) 0%,
+      rgb(5 8 16 / 72%) 35%,
+      rgb(5 8 16 / 42%) 60%,
+      rgb(5 8 16 / 18%) 100%
+    ),
+    linear-gradient(
+      to top,
+      rgb(5 8 16 / 60%) 0%,
+      transparent 40%
+    );
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+/* Stage — sits above backdrop, positions content */
+.cinematic-hero__stage {
+  align-items: flex-end;
+  bottom: 0;
+  display: flex;
+  left: 0;
+  padding-bottom: 80px;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+/* shell-container overrides for the inner stage */
+.cinematic-hero__inner {
+  display: grid;
+  gap: 20px;
+  position: relative;
+  z-index: 2;
+}
+
+/* Content slides — fade in/out with the active state */
+.cinematic-hero__content {
+  display: grid;
+  gap: 18px;
+  max-width: 580px;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  transition: opacity 600ms ease;
+}
+
+.cinematic-hero__content--active {
+  opacity: 1;
+  pointer-events: auto;
+  position: static;
+}
+
+.cinematic-hero__eyebrow {
+  color: var(--color-cinema-gold);
+  margin: 0;
+}
+
+.cinematic-hero__title {
+  color: #ffffff;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.05;
+  margin: 0;
+  text-shadow: 0 2px 20px rgb(0 0 0 / 50%);
+}
+
+.cinematic-hero__meta {
+  color: rgb(255 255 255 / 75%);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.cinematic-hero__cta {
+  background: var(--color-brand);
+  border-color: transparent;
+  color: #ffffff;
+  font-size: 15px;
+  min-height: 48px;
+  padding: 0 28px;
+  width: fit-content;
+}
+
+.cinematic-hero__cta:hover {
+  background: var(--color-brand-strong);
+}
+
+/* Dot indicators */
+.cinematic-hero__dots {
+  display: flex;
+  gap: 8px;
+  padding-top: 8px;
+}
+
+.cinematic-hero__dot {
+  background: rgb(255 255 255 / 35%);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  height: 6px;
+  padding: 0;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    width var(--duration-medium) var(--ease-standard);
+  width: 24px;
+}
+
+.cinematic-hero__dot--active {
+  background: #ffffff;
+  width: 40px;
+}
+
+.cinematic-hero__dot:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+/* Scroll hint at the bottom center */
+.cinematic-hero__scroll-hint {
+  align-items: center;
+  bottom: 24px;
+  color: rgb(255 255 255 / 55%);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  transition: color var(--duration-fast) var(--ease-standard);
+  z-index: 3;
+}
+
+.cinematic-hero__scroll-hint:hover {
+  color: #ffffff;
+}
+
+.cinematic-hero__scroll-hint:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 6px;
+}
+
+.cinematic-hero__scroll-arrow {
+  animation: scroll-bounce 2000ms ease-in-out infinite;
+  border-bottom: 2px solid currentColor;
+  border-right: 2px solid currentColor;
+  display: block;
+  height: 10px;
+  transform: rotate(45deg);
+  width: 10px;
+}
+
+@keyframes scroll-bounce {
+  0%, 100% { transform: rotate(45deg) translateY(0); opacity: 0.55; }
+  50% { transform: rotate(45deg) translateY(4px); opacity: 1; }
+}
+
+/* Override carousel-button positioning for the cinematic hero */
+.cinematic-hero .carousel-button--side {
+  top: 50%;
+}
+
+/* Skeleton/empty states inside the hero */
+.cinematic-hero--skeleton .cinematic-hero__stage,
+.cinematic-hero--empty .cinematic-hero__stage {
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 0;
 }
 
 .movie-grid-section {
@@ -2013,23 +2309,56 @@ h1 {
 }
 
 @media (max-width: 820px) {
+  /* Header: brand+actions on first row, nav on second row */
   .header-container {
-    align-items: stretch;
-    grid-template-columns: 1fr;
-    padding-bottom: 14px;
-    padding-top: 14px;
+    align-items: center;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    padding-bottom: 0;
+    padding-top: 0;
+    row-gap: 0;
   }
 
-  .primary-nav,
+  .header-brand {
+    grid-column: 1;
+    grid-row: 1;
+    padding-bottom: 12px;
+    padding-top: 12px;
+  }
+
   .header-actions {
-    justify-content: flex-start;
-    width: 100%;
+    grid-column: 2;
+    grid-row: 1;
+    justify-content: flex-end;
+    padding-bottom: 12px;
+    padding-top: 12px;
+    width: auto;
   }
 
   .primary-nav {
+    border-top: 1px solid rgb(255 255 255 / 6%);
     flex-wrap: nowrap;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: flex-start;
     overflow-x: auto;
-    padding-bottom: 2px;
+    padding-bottom: 4px;
+    padding-top: 4px;
+    scrollbar-width: none;
+    width: 100%;
+  }
+
+  .primary-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Hero: adjust stage padding for smaller screens */
+  .cinematic-hero__stage {
+    padding-bottom: 60px;
+  }
+
+  .home-catalog__sections {
+    padding-top: var(--layout-page-block-compact);
   }
 
   .page-heading {
@@ -2137,6 +2466,15 @@ h1 {
     padding: 32px 0 56px;
   }
 
+  /* Cancel mobile top padding for hero */
+  .cinematic-hero {
+    margin-top: calc(-1 * var(--layout-page-block-compact));
+  }
+
+  .cinema-context {
+    display: none;
+  }
+
   .brand-link {
     font-size: 17px;
   }
@@ -2147,11 +2485,24 @@ h1 {
   }
 
   .header-actions .button {
-    flex: 1 1 132px;
+    flex: 1 0 auto;
   }
 
   .panel {
     padding: 18px;
+  }
+
+  .cinematic-hero__title {
+    font-size: clamp(1.75rem, 8vw, 2.5rem);
+  }
+
+  .cinematic-hero__stage {
+    align-items: center;
+    padding-bottom: 80px;
+  }
+
+  .home-catalog__sections {
+    padding-top: var(--layout-page-block-compact);
   }
 
   .featured-movie__media {

--- a/frontend/src/styles/public-legacy.css
+++ b/frontend/src/styles/public-legacy.css
@@ -1,10 +1,6 @@
-/* ── Site header: dark cinematic ───────────────────────────────────── */
-
 .site-header {
-  background: rgb(10 13 20 / 97%);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-bottom: 1px solid rgb(255 255 255 / 7%);
+  background: rgb(255 255 255 / 96%);
+  border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -15,23 +11,17 @@
   display: grid;
   gap: 16px;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  min-height: var(--header-height, 72px);
-}
-
-.header-brand {
-  align-items: center;
-  display: inline-flex;
-  gap: 10px;
-  min-width: max-content;
+  min-height: 72px;
 }
 
 .brand-link {
   align-items: center;
-  color: #ffffff;
+  color: var(--color-brand);
   display: inline-flex;
   font-size: 18px;
   font-weight: 850;
   gap: 10px;
+  min-width: max-content;
 }
 
 .brand-mark {
@@ -45,27 +35,6 @@
   justify-content: center;
   line-height: 1;
   width: 34px;
-}
-
-.cinema-context {
-  align-items: center;
-  background: rgb(255 255 255 / 8%);
-  border: 1px solid rgb(255 255 255 / 10%);
-  border-radius: 999px;
-  color: rgb(255 255 255 / 60%);
-  display: inline-flex;
-  font-size: 12px;
-  font-weight: 750;
-  gap: 5px;
-  line-height: 1;
-  padding: 5px 10px;
-  transition: background var(--duration-fast) var(--ease-standard);
-  white-space: nowrap;
-}
-
-.cinema-context:hover {
-  background: rgb(255 255 255 / 12%);
-  color: rgb(255 255 255 / 80%);
 }
 
 .primary-nav,
@@ -88,42 +57,18 @@
 
 .nav-link {
   border-radius: 6px;
-  color: rgb(255 255 255 / 60%);
+  color: var(--color-muted);
   font-size: 14px;
   font-weight: 700;
   line-height: 1;
   padding: 10px 12px;
-  transition:
-    background var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
   white-space: nowrap;
 }
 
 .nav-link:hover,
 .nav-link-active {
-  background: rgb(255 255 255 / 8%);
-  color: #ffffff;
-}
-
-.site-header .button-ghost {
-  border-color: rgb(255 255 255 / 16%);
-  color: rgb(255 255 255 / 80%);
-}
-
-.site-header .button-ghost:hover {
-  background: rgb(255 255 255 / 10%);
-  border-color: rgb(255 255 255 / 24%);
-  color: #ffffff;
-}
-
-.site-header .button-secondary {
-  background: rgb(255 255 255 / 10%);
-  border-color: rgb(255 255 255 / 16%);
-  color: #ffffff;
-}
-
-.site-header .button-secondary:hover {
-  background: rgb(255 255 255 / 16%);
+  background: #fff2bf;
+  color: var(--color-text);
 }
 
 .main-content {
@@ -473,248 +418,7 @@ h1 {
 
 .home-catalog {
   display: grid;
-  gap: 0;
-}
-
-.home-catalog__sections {
-  display: grid;
   gap: 28px;
-  padding-top: var(--layout-page-block);
-}
-
-/* ── Cinematic hero ─────────────────────────────────────────────────── */
-
-.cinematic-hero {
-  color: #ffffff;
-  height: calc(100svh - var(--header-height, 72px));
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-  /* Cancel main-content top padding so hero starts immediately below header */
-  margin-top: calc(-1 * var(--layout-page-block));
-  min-height: 480px;
-  overflow: hidden;
-  position: relative;
-  width: 100vw;
-}
-
-/* Skeleton / empty hero variants */
-.cinematic-hero--skeleton,
-.cinematic-hero--empty {
-  background: rgb(8 10 16);
-  min-height: 320px;
-}
-
-.cinematic-hero--skeleton {
-  height: auto;
-}
-
-/* Backdrop — fills the hero, sits behind content */
-.cinematic-hero__backdrop {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-
-/* Per-slide background images with fade transition */
-.cinematic-hero__slide-bg {
-  bottom: 0;
-  left: 0;
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  transition: opacity 700ms ease;
-  will-change: opacity;
-}
-
-.cinematic-hero__slide-bg--active {
-  opacity: 1;
-}
-
-.cinematic-hero__bg-img {
-  display: block;
-  height: 100%;
-  object-fit: cover;
-  object-position: center top;
-  width: 100%;
-}
-
-/* Cinematic gradient overlay — strong on the left, fades right */
-.cinematic-hero__overlay {
-  background:
-    linear-gradient(
-      to right,
-      rgb(5 8 16 / 90%) 0%,
-      rgb(5 8 16 / 72%) 35%,
-      rgb(5 8 16 / 42%) 60%,
-      rgb(5 8 16 / 18%) 100%
-    ),
-    linear-gradient(
-      to top,
-      rgb(5 8 16 / 60%) 0%,
-      transparent 40%
-    );
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-
-/* Stage — sits above backdrop, positions content */
-.cinematic-hero__stage {
-  align-items: flex-end;
-  bottom: 0;
-  display: flex;
-  left: 0;
-  padding-bottom: 80px;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-
-/* shell-container overrides for the inner stage */
-.cinematic-hero__inner {
-  display: grid;
-  gap: 20px;
-  position: relative;
-  z-index: 2;
-}
-
-/* Content slides — fade in/out with the active state */
-.cinematic-hero__content {
-  display: grid;
-  gap: 18px;
-  max-width: 580px;
-  opacity: 0;
-  pointer-events: none;
-  position: absolute;
-  transition: opacity 600ms ease;
-}
-
-.cinematic-hero__content--active {
-  opacity: 1;
-  pointer-events: auto;
-  position: static;
-}
-
-.cinematic-hero__eyebrow {
-  color: var(--color-cinema-gold);
-  margin: 0;
-}
-
-.cinematic-hero__title {
-  color: #ffffff;
-  font-size: clamp(2rem, 5vw, 3.5rem);
-  line-height: 1.05;
-  margin: 0;
-  text-shadow: 0 2px 20px rgb(0 0 0 / 50%);
-}
-
-.cinematic-hero__meta {
-  color: rgb(255 255 255 / 75%);
-  font-size: 16px;
-  font-weight: 600;
-  margin: 0;
-}
-
-.cinematic-hero__cta {
-  background: var(--color-brand);
-  border-color: transparent;
-  color: #ffffff;
-  font-size: 15px;
-  min-height: 48px;
-  padding: 0 28px;
-  width: fit-content;
-}
-
-.cinematic-hero__cta:hover {
-  background: var(--color-brand-strong);
-}
-
-/* Dot indicators */
-.cinematic-hero__dots {
-  display: flex;
-  gap: 8px;
-  padding-top: 8px;
-}
-
-.cinematic-hero__dot {
-  background: rgb(255 255 255 / 35%);
-  border: 0;
-  border-radius: 999px;
-  cursor: pointer;
-  height: 6px;
-  padding: 0;
-  transition:
-    background var(--duration-fast) var(--ease-standard),
-    width var(--duration-medium) var(--ease-standard);
-  width: 24px;
-}
-
-.cinematic-hero__dot--active {
-  background: #ffffff;
-  width: 40px;
-}
-
-.cinematic-hero__dot:focus-visible {
-  outline: var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-}
-
-/* Scroll hint at the bottom center */
-.cinematic-hero__scroll-hint {
-  align-items: center;
-  bottom: 24px;
-  color: rgb(255 255 255 / 55%);
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  justify-content: center;
-  left: 50%;
-  position: absolute;
-  transform: translateX(-50%);
-  transition: color var(--duration-fast) var(--ease-standard);
-  z-index: 3;
-}
-
-.cinematic-hero__scroll-hint:hover {
-  color: #ffffff;
-}
-
-.cinematic-hero__scroll-hint:focus-visible {
-  outline: var(--focus-ring);
-  outline-offset: 6px;
-}
-
-.cinematic-hero__scroll-arrow {
-  animation: scroll-bounce 2000ms ease-in-out infinite;
-  border-bottom: 2px solid currentColor;
-  border-right: 2px solid currentColor;
-  display: block;
-  height: 10px;
-  transform: rotate(45deg);
-  width: 10px;
-}
-
-@keyframes scroll-bounce {
-  0%, 100% { transform: rotate(45deg) translateY(0); opacity: 0.55; }
-  50% { transform: rotate(45deg) translateY(4px); opacity: 1; }
-}
-
-/* Override carousel-button positioning for the cinematic hero */
-.cinematic-hero .carousel-button--side {
-  top: 50%;
-}
-
-/* Skeleton/empty states inside the hero */
-.cinematic-hero--skeleton .cinematic-hero__stage,
-.cinematic-hero--empty .cinematic-hero__stage {
-  align-items: center;
-  justify-content: center;
-  padding-bottom: 0;
 }
 
 .movie-grid-section {
@@ -2309,56 +2013,23 @@ h1 {
 }
 
 @media (max-width: 820px) {
-  /* Header: brand+actions on first row, nav on second row */
   .header-container {
-    align-items: center;
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-    padding-bottom: 0;
-    padding-top: 0;
-    row-gap: 0;
+    align-items: stretch;
+    grid-template-columns: 1fr;
+    padding-bottom: 14px;
+    padding-top: 14px;
   }
 
-  .header-brand {
-    grid-column: 1;
-    grid-row: 1;
-    padding-bottom: 12px;
-    padding-top: 12px;
-  }
-
+  .primary-nav,
   .header-actions {
-    grid-column: 2;
-    grid-row: 1;
-    justify-content: flex-end;
-    padding-bottom: 12px;
-    padding-top: 12px;
-    width: auto;
-  }
-
-  .primary-nav {
-    border-top: 1px solid rgb(255 255 255 / 6%);
-    flex-wrap: nowrap;
-    grid-column: 1 / -1;
-    grid-row: 2;
     justify-content: flex-start;
-    overflow-x: auto;
-    padding-bottom: 4px;
-    padding-top: 4px;
-    scrollbar-width: none;
     width: 100%;
   }
 
-  .primary-nav::-webkit-scrollbar {
-    display: none;
-  }
-
-  /* Hero: adjust stage padding for smaller screens */
-  .cinematic-hero__stage {
-    padding-bottom: 60px;
-  }
-
-  .home-catalog__sections {
-    padding-top: var(--layout-page-block-compact);
+  .primary-nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
   }
 
   .page-heading {
@@ -2466,15 +2137,6 @@ h1 {
     padding: 32px 0 56px;
   }
 
-  /* Cancel mobile top padding for hero */
-  .cinematic-hero {
-    margin-top: calc(-1 * var(--layout-page-block-compact));
-  }
-
-  .cinema-context {
-    display: none;
-  }
-
   .brand-link {
     font-size: 17px;
   }
@@ -2485,24 +2147,11 @@ h1 {
   }
 
   .header-actions .button {
-    flex: 1 0 auto;
+    flex: 1 1 132px;
   }
 
   .panel {
     padding: 18px;
-  }
-
-  .cinematic-hero__title {
-    font-size: clamp(1.75rem, 8vw, 2.5rem);
-  }
-
-  .cinematic-hero__stage {
-    align-items: center;
-    padding-bottom: 80px;
-  }
-
-  .home-catalog__sections {
-    padding-top: var(--layout-page-block-compact);
   }
 
   .featured-movie__media {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -71,4 +71,5 @@
   --layout-page-block-compact: 2rem;
   --control-height: 2.5rem;
   --control-height-lg: 2.875rem;
+  --header-height: 72px;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -71,5 +71,7 @@
   --layout-page-block-compact: 2rem;
   --control-height: 2.5rem;
   --control-height-lg: 2.875rem;
-  --header-height: 72px;
+  --header-height: 84px;
+
+  --animate-scroll-bounce: scroll-bounce 2s ease-in-out infinite;
 }


### PR DESCRIPTION
## Objective

Rebuild the public header and first viewport to make the site feel like a premium cinema product, with stronger brand presence, a clearly identified cinema location, and a cinematic full-bleed hero.

## What was done

### 1. Premium dark header

Redesigned the `AppHeader` component with a dark, semi-transparent background (`rgb(10 13 20 / 97%)`) and backdrop blur, making it visually distinct from the light content area below.

- Logo mark (CP) with brand color, full name, and a cinema context pill showing "📍 Natal"
- Navigation items: **Início** and **Catálogo**
- Account actions: **Entrar** / **Criar conta** for anonymous users; **Meus ingressos** / **Sair** for authenticated users
- Header is full-viewport width so the logo sits at the left screen edge and the actions at the right
- Header height increased to 84 px for better presence
- Responsive: two-row layout on mobile (brand + actions in row 1, nav in row 2) via `max-md:` utilities

All implementation uses Tailwind utilities and existing UI primitives (`Button`, `ButtonLink`) — no new CSS added to `public-legacy.css`.

### 2. Cinematic hero

Rebuilt `FeaturedMovieBanner` as a full-bleed cinematic hero:

- Full-viewport-width poster backdrop with a per-slide fade transition (`opacity` + `duration-700`)
- Cinematic gradient overlay (left-to-right darkness, bottom vignette) via inline `style` prop
- Eyebrow using `Badge tone="accent"` ("Destaque")
- Movie title, genre and duration meta (`Genres | Xh Ymin`)
- Primary CTA using `ButtonLink variant="primary" size="lg"`
- Dot indicators for multi-movie carousel
- Directional prev/next controls with correct `aria-label` values
- Bouncing scroll-hint arrow at the bottom center linking to `#catalogo`

### 3. First viewport composition and below-fold hint

Hero height set to `75svh` (down from full viewport), leaving roughly 25 % of the visible area for the first catalog row to peek below the fold on common desktop and mobile viewports.

### 4. Responsive behavior

- Header collapses to a two-row grid on screens narrower than `md` (768 px)
- Cinema context pill hidden on very small screens (`max-[420px]:hidden`)
- Hero `min-h: 400px` prevents collapse on short viewports

### 5. Tailwind migration compliance

All new UI lives in Tailwind arbitrary values — `public-legacy.css` is identical to `main`. New animation primitive (`scroll-bounce`) registered as `--animate-scroll-bounce` token in `tokens.css` with `@keyframes` in `globals.css`.

## How to test

### Automated

```bash
cd frontend && npm test && npm run lint
```

181 tests pass, lint clean.

### Manual

1. Start the frontend dev server and open the home page
2. Confirm the header is dark with the CP logo at the far left and buttons at the far right
3. Confirm "📍 Natal" is visible in the header
4. Confirm the hero fills roughly 75 % of the viewport height with a catalog peek below
5. If multiple featured movies exist, confirm prev/next arrows and dot indicators work
6. Confirm the bouncing arrow scrolls to the catalog
7. Resize to mobile and confirm the two-row header with no clipped or overlapping content

closes #181