### PR TITLE
feat: replace separate movie rails with tabbed catalog carousel

### DIFF
--- a/frontend/e2e/critical-flows.spec.ts
+++ b/frontend/e2e/critical-flows.spec.ts
@@ -163,6 +163,53 @@ test("expires a temporary reservation and resets the seat selection state", asyn
   await expect(page.getByText("Nenhum assento selecionado")).toBeVisible();
 });
 
+test("tabbed catalog switches to Pré-venda panel on click", async ({ page }) => {
+  await setupMockApi(page);
+  await page.goto("/");
+
+  const emCartazTab = page.getByRole("tab", { name: "Em cartaz" });
+  const preVendaTab = page.getByRole("tab", { name: "Pré-venda" });
+
+  await expect(emCartazTab).toHaveAttribute("aria-selected", "true");
+  await expect(preVendaTab).toHaveAttribute("aria-selected", "false");
+
+  const nowShowingPanel = page.getByRole("tabpanel", { name: "Em cartaz" });
+  await expect(nowShowingPanel).toBeVisible();
+  await expect(
+    nowShowingPanel.getByRole("link", { name: /Ver detalhes de A Jornada de Natal/ })
+  ).toBeVisible();
+
+  await preVendaTab.click();
+
+  await expect(preVendaTab).toHaveAttribute("aria-selected", "true");
+  await expect(emCartazTab).toHaveAttribute("aria-selected", "false");
+
+  const preSalePanel = page.getByRole("tabpanel", { name: "Pré-venda" });
+  await expect(preSalePanel).toBeVisible();
+  await expect(
+    preSalePanel.getByRole("link", { name: /Ver detalhes de Estreia da Semana/ })
+  ).toBeVisible();
+
+  await expect(nowShowingPanel).toBeHidden();
+});
+
+test("tabbed catalog switches to Pré-venda panel with ArrowRight key", async ({ page }) => {
+  await setupMockApi(page);
+  await page.goto("/");
+
+  await page.getByRole("tab", { name: "Em cartaz" }).focus();
+  await page.keyboard.press("ArrowRight");
+
+  const preVendaTab = page.getByRole("tab", { name: "Pré-venda" });
+  await expect(preVendaTab).toHaveAttribute("aria-selected", "true");
+
+  const preSalePanel = page.getByRole("tabpanel", { name: "Pré-venda" });
+  await expect(preSalePanel).toBeVisible();
+  await expect(
+    preSalePanel.getByRole("link", { name: /Ver detalhes de Estreia da Semana/ })
+  ).toBeVisible();
+});
+
 async function login(page: Page, redirectPath = "/") {
   const loginPath =
     redirectPath === "/"

--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -6,6 +6,7 @@ import { catalogApi } from "@/api/catalog";
 import { Button } from "@/components/ui/Button";
 import { FeaturedMovieBanner } from "@/components/movies";
 import { MovieCarousel } from "@/components/movies";
+import { TabbedMovieCatalog } from "@/components/movies/TabbedMovieCatalog";
 import { StateMessage } from "@/components/ui/StateMessage";
 import type { CatalogMovie } from "@/types/catalog";
 
@@ -144,45 +145,12 @@ export function HomeCatalogSections({
         className="grid gap-7 pt-[var(--layout-page-block)] max-md:pt-[var(--layout-page-block-compact)]"
         id="catalogo"
       >
-        {nowShowing.status === "error" ? (
-          <CatalogErrorState
-            message={
-              nowShowing.errorMessage ??
-              "Não foi possível carregar os filmes em cartaz. Tente novamente."
-            }
-            onRetry={onRetryNowShowing}
-            title="Em cartaz indisponível"
-          />
-        ) : (
-          <MovieCarousel
-            emptyDescription="Ainda não há filmes em cartaz no catálogo."
-            emptyTitle="Nenhum filme em cartaz"
-            isLoading={nowShowing.status === "loading"}
-            loadingLabel="Carregando filmes em cartaz..."
-            movies={nowShowing.movies}
-            title="Em cartaz"
-          />
-        )}
-
-        {preSale.status === "error" ? (
-          <CatalogErrorState
-            message={
-              preSale.errorMessage ??
-              "Não foi possível carregar os filmes em pré-venda. Tente novamente."
-            }
-            onRetry={onRetryPreSale}
-            title="Pré-venda indisponível"
-          />
-        ) : (
-          <MovieCarousel
-            emptyDescription="Ainda não há filmes em pré-venda no catálogo."
-            emptyTitle="Nenhum filme em pré-venda"
-            isLoading={preSale.status === "loading"}
-            loadingLabel="Carregando filmes em pré-venda..."
-            movies={preSale.movies}
-            title="Pré-venda"
-          />
-        )}
+        <TabbedMovieCatalog
+          nowShowing={nowShowing}
+          onRetryNowShowing={onRetryNowShowing}
+          onRetryPreSale={onRetryPreSale}
+          preSale={preSale}
+        />
 
         {upcoming.status === "error" ? (
           <CatalogErrorState

--- a/frontend/src/app/home-catalog.test.ts
+++ b/frontend/src/app/home-catalog.test.ts
@@ -42,7 +42,7 @@ const success = (movies: CatalogMovie[]): MovieSectionState => ({
   status: "success",
 });
 
-test("home catalog renders featured, now showing, pre-sale, and upcoming movie sections", () => {
+test("home catalog renders featured banner, tabbed catalog, and upcoming section", () => {
   const html = renderToStaticMarkup(
     createElement(HomeCatalogSections, {
       featured: success([featuredMovie]),
@@ -147,4 +147,157 @@ test("home catalog keeps successful sections visible when another section errors
   assert.match(html, /Em cartaz indisponível/);
   assert.match(html, /Estreia da Semana/);
   assert.match(html, /Em Breve na Tela/);
+});
+
+test("tabbed catalog renders both tab buttons with correct ARIA attributes", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([featuredMovie]),
+      preSale: success([preSaleMovie]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /role="tablist"/);
+  assert.match(html, /role="tab"/);
+  assert.match(html, /role="tabpanel"/);
+  assert.match(html, /aria-selected="true"/);
+  assert.match(html, /aria-selected="false"/);
+});
+
+test("tabbed catalog default tab is Em cartaz (aria-selected=true on first tab)", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([featuredMovie]),
+      preSale: success([preSaleMovie]),
+      upcoming: success([]),
+    })
+  );
+
+  // First tab (Em cartaz) is selected, second (Pré-venda) is not
+  assert.ok(html.includes('aria-selected="true"'));
+  assert.ok(html.includes('aria-selected="false"'));
+
+  // Pre-sale panel is present but hidden
+  assert.match(html, /hidden/);
+  assert.match(html, /Estreia da Semana/);
+});
+
+test("tabbed catalog shows independent loading state for now showing", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: { movies: [], status: "loading" },
+      preSale: success([preSaleMovie]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /Carregando filmes em cartaz/);
+  assert.match(html, /Estreia da Semana/);
+});
+
+test("tabbed catalog shows independent loading state for pre-sale", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([featuredMovie]),
+      preSale: { movies: [], status: "loading" },
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /A Jornada/);
+  assert.match(html, /Carregando filmes em pré-venda/);
+});
+
+test("tabbed catalog error state for now showing does not affect pre-sale", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: { errorMessage: "Falha em cartaz.", movies: [], status: "error" },
+      onRetryNowShowing: () => undefined,
+      preSale: success([preSaleMovie]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /Em cartaz indisponível/);
+  assert.match(html, /Estreia da Semana/);
+});
+
+test("tabbed catalog error state for pre-sale does not affect now showing", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([featuredMovie]),
+      onRetryPreSale: () => undefined,
+      preSale: { errorMessage: "Falha pré-venda.", movies: [], status: "error" },
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /A Jornada/);
+  assert.match(html, /Pré-venda indisponível/);
+});
+
+test("tabbed catalog renders carousel navigation buttons when movies exist", () => {
+  const manyMovies = Array.from({ length: 8 }, (_, i) => ({
+    ...featuredMovie,
+    id: `movie-${i}`,
+    title: `Filme ${i + 1}`,
+  }));
+
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success(manyMovies),
+      preSale: success([]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /Filme anterior em Em cartaz/);
+  assert.match(html, /Próximo filme em Em cartaz/);
+});
+
+test("movie card renders pre-sale badge for pre_venda movies", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([preSaleMovie]),
+      preSale: success([]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /Pré-venda/);
+});
+
+test("movie card renders destaque badge for featured movies", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([featuredMovie]),
+      preSale: success([]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /Destaque/);
+});
+
+test("home catalog shows cinema indicator in tabbed catalog", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeCatalogSections, {
+      featured: success([]),
+      nowShowing: success([]),
+      preSale: success([]),
+      upcoming: success([]),
+    })
+  );
+
+  assert.match(html, /CinePrime Natal/);
 });

--- a/frontend/src/components/movies/MovieCard.tsx
+++ b/frontend/src/components/movies/MovieCard.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { Badge } from "@/components/ui/Badge";
+import type { BadgeTone } from "@/components/ui/Badge";
 import { ResponsiveImage } from "@/components/ui/ResponsiveImage";
 import type { CatalogMovie } from "@/types/catalog";
 
@@ -13,9 +15,22 @@ type MovieCardProps = {
   movie: CatalogMovie;
 };
 
+type StatusBadge = { label: string; tone: BadgeTone };
+
+function getStatusBadge(movie: CatalogMovie): StatusBadge | null {
+  if (movie.status === "pre_venda") {
+    return { label: "Pré-venda", tone: "accent" };
+  }
+  if (movie.is_featured) {
+    return { label: "Destaque", tone: "brand" };
+  }
+  return null;
+}
+
 export function MovieCard({ movie }: MovieCardProps) {
   const genres = formatMovieGenres(movie.genres);
   const duration = formatMovieDuration(movie.duration_minutes);
+  const badge = getStatusBadge(movie);
 
   return (
     <article className="movie-card">
@@ -24,16 +39,25 @@ export function MovieCard({ movie }: MovieCardProps) {
         className="movie-card__link"
         href={getMovieDetailsHref(movie.id)}
       >
-        <ResponsiveImage
-          alt={`Poster de ${movie.title}`}
-          className="movie-card__poster"
-          height={480}
-          loading="lazy"
-          src={movie.poster_url}
-          sizes="(max-width: 820px) 100vw, (max-width: 1200px) 33vw, 220px"
-          unoptimized
-          width={320}
-        />
+        <div className="relative">
+          <ResponsiveImage
+            alt={`Poster de ${movie.title}`}
+            className="movie-card__poster"
+            height={480}
+            loading="lazy"
+            src={movie.poster_url}
+            sizes="(max-width: 820px) 100vw, (max-width: 1200px) 33vw, 220px"
+            unoptimized
+            width={320}
+          />
+          {badge ? (
+            <div className="absolute bottom-2 left-2">
+              <Badge size="sm" tone={badge.tone}>
+                {badge.label}
+              </Badge>
+            </div>
+          ) : null}
+        </div>
         <div className="movie-card__body">
           <h2 className="movie-card__title">{movie.title}</h2>
           <p className="movie-card__genres">{genres}</p>

--- a/frontend/src/components/movies/MovieCarousel.tsx
+++ b/frontend/src/components/movies/MovieCarousel.tsx
@@ -20,6 +20,7 @@ type MovieCarouselProps = {
   previousButtonLabel?: string;
   skeletonCount?: number;
   title: string;
+  titleVisible?: boolean;
 };
 
 export function MovieCarousel({
@@ -33,6 +34,7 @@ export function MovieCarousel({
   previousButtonLabel,
   skeletonCount = 6,
   title,
+  titleVisible = true,
 }: MovieCarouselProps) {
   const railRef = useRef<HTMLUListElement>(null);
   const [canScroll, setCanScroll] = useState(movies.length > 1);
@@ -110,7 +112,9 @@ export function MovieCarousel({
       className="movie-carousel-section"
     >
       <div className="movie-carousel-section__header">
-        <h2 id={headingId}>{title}</h2>
+        <h2 className={titleVisible ? undefined : "sr-only"} id={headingId}>
+          {title}
+        </h2>
       </div>
 
       {isLoading ? (

--- a/frontend/src/components/movies/TabbedMovieCatalog.tsx
+++ b/frontend/src/components/movies/TabbedMovieCatalog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { MapPin } from "lucide-react";
+import type { KeyboardEvent } from "react";
+import { useId, useState } from "react";
+
+import type { MovieSectionState } from "@/app/HomeCatalog";
+import { Button } from "@/components/ui/Button";
+import { StateMessage } from "@/components/ui/StateMessage";
+import { cn } from "@/components/ui/classNames";
+
+import { MovieCarousel } from "./MovieCarousel";
+
+type CatalogTab = "em_cartaz" | "pre_venda";
+
+type TabbedMovieCatalogProps = {
+  cinemaName?: string;
+  nowShowing: MovieSectionState;
+  onRetryNowShowing?: () => void;
+  onRetryPreSale?: () => void;
+  preSale: MovieSectionState;
+};
+
+const TABS = [
+  {
+    value: "em_cartaz" as CatalogTab,
+    label: "Em cartaz",
+    emptyTitle: "Nenhum filme em cartaz",
+    emptyDescription: "Ainda não há filmes em cartaz no catálogo.",
+    loadingLabel: "Carregando filmes em cartaz...",
+    errorTitle: "Em cartaz indisponível",
+  },
+  {
+    value: "pre_venda" as CatalogTab,
+    label: "Pré-venda",
+    emptyTitle: "Nenhum filme em pré-venda",
+    emptyDescription: "Ainda não há filmes em pré-venda no catálogo.",
+    loadingLabel: "Carregando filmes em pré-venda...",
+    errorTitle: "Pré-venda indisponível",
+  },
+] as const;
+
+export function TabbedMovieCatalog({
+  cinemaName = "CinePrime Natal",
+  nowShowing,
+  onRetryNowShowing,
+  onRetryPreSale,
+  preSale,
+}: TabbedMovieCatalogProps) {
+  const [activeTab, setActiveTab] = useState<CatalogTab>("em_cartaz");
+  const uid = useId();
+  const headingId = `${uid}-catalog-heading`;
+
+  function handleTabKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      const nextIdx =
+        e.key === "ArrowRight"
+          ? (idx + 1) % TABS.length
+          : (idx - 1 + TABS.length) % TABS.length;
+      setActiveTab(TABS[nextIdx].value);
+      const tabList = e.currentTarget.parentElement;
+      (tabList?.children[nextIdx] as HTMLElement | undefined)?.focus();
+    }
+  }
+
+  function getSectionForTab(tab: (typeof TABS)[number]) {
+    return tab.value === "em_cartaz" ? nowShowing : preSale;
+  }
+
+  function getRetryForTab(tab: (typeof TABS)[number]) {
+    return tab.value === "em_cartaz" ? onRetryNowShowing : onRetryPreSale;
+  }
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="grid gap-5 rounded-panel border border-border bg-surface p-6 shadow-soft max-sm:p-4"
+    >
+      {/* Section header: title + cinema indicator */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2
+          className="text-[length:var(--text-section)] font-extrabold leading-[var(--text-section--line-height)] text-text"
+          id={headingId}
+        >
+          Programação
+        </h2>
+        <CinemaIndicator name={cinemaName} />
+      </div>
+
+      {/* Tab list */}
+      <div
+        aria-label="Seções de programação"
+        className="inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-panel border border-border bg-surface-muted p-1"
+        role="tablist"
+      >
+        {TABS.map((tab, idx) => {
+          const isSelected = activeTab === tab.value;
+          return (
+            <button
+              aria-controls={`${uid}-${tab.value}-panel`}
+              aria-selected={isSelected}
+              className={cn(
+                "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus",
+                isSelected
+                  ? "bg-surface text-text shadow-soft"
+                  : "text-muted hover:bg-surface hover:text-text"
+              )}
+              id={`${uid}-${tab.value}-tab`}
+              key={tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              onKeyDown={(e) => handleTabKeyDown(e, idx)}
+              role="tab"
+              tabIndex={isSelected ? 0 : -1}
+              type="button"
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab panels */}
+      {TABS.map((tab) => {
+        const section = getSectionForTab(tab);
+        const onRetry = getRetryForTab(tab);
+
+        return (
+          <div
+            aria-labelledby={`${uid}-${tab.value}-tab`}
+            hidden={activeTab !== tab.value}
+            id={`${uid}-${tab.value}-panel`}
+            key={tab.value}
+            role="tabpanel"
+            tabIndex={0}
+          >
+            {section.status === "error" ? (
+              <CatalogErrorState
+                message={
+                  section.errorMessage ??
+                  "Não conseguimos carregar esta seção agora. Verifique sua conexão e tente novamente."
+                }
+                onRetry={onRetry}
+                title={tab.errorTitle}
+              />
+            ) : (
+              <MovieCarousel
+                emptyDescription={tab.emptyDescription}
+                emptyTitle={tab.emptyTitle}
+                isLoading={section.status === "loading"}
+                loadingLabel={tab.loadingLabel}
+                movies={section.movies}
+                title={tab.label}
+                titleVisible={false}
+              />
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function CinemaIndicator({ name }: { name: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm font-bold text-muted">
+      <MapPin aria-hidden="true" className="shrink-0" size={14} strokeWidth={2.5} />
+      <span>{name}</span>
+    </div>
+  );
+}
+
+function CatalogErrorState({
+  message,
+  onRetry,
+  title,
+}: {
+  message: string;
+  onRetry?: () => void;
+  title: string;
+}) {
+  return (
+    <StateMessage
+      action={
+        onRetry ? (
+          <Button onClick={onRetry} variant="ghost">
+            Tentar novamente
+          </Button>
+        ) : undefined
+      }
+      title={title}
+      tone="error"
+    >
+      {message}
+    </StateMessage>
+  );
+}

--- a/frontend/src/components/movies/index.ts
+++ b/frontend/src/components/movies/index.ts
@@ -3,6 +3,7 @@ export { MovieDetail, MovieDetailView, type MovieDetailState } from "./MovieDeta
 export { MovieCard } from "./MovieCard";
 export { MovieCarousel } from "./MovieCarousel";
 export { MovieGrid } from "./MovieGrid";
+export { TabbedMovieCatalog } from "./TabbedMovieCatalog";
 export {
   formatMovieDuration,
   formatMovieGenres,


### PR DESCRIPTION
## Objective

Replace the separate Now Showing and Pre-sale movie carousels on the home page with a premium tabbed catalog section, giving users a single, cohesive browsing surface with independent data states per tab, a cinema context indicator, poster-dominant cards with status badges, and full carousel interaction support.

## What was done

### 1. TabbedMovieCatalog component

Created `src/components/movies/TabbedMovieCatalog.tsx` with:

- Two tabs: **Em cartaz** (Now Showing) and **Pré-venda** (Pre-sale), switchable without leaving the page.
- Fully accessible tab widget using `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`, and `tabIndex` roving focus. Arrow-key keyboard navigation cycles between tabs.
- **Cinema indicator** (`CinemaIndicator`) renders "CinePrime Natal" with a `MapPin` icon in the section header, compatible with future upgrade to a multi-cinema selector.
- Independent loading, empty, and error states per tab — each backed by its own `MovieSectionState`.
- Error state includes a retry button and a specific title per tab (e.g. "Em cartaz indisponível", "Pré-venda indisponível").

### 2. Status badges on MovieCard

Updated `src/components/movies/MovieCard.tsx`:

- Added `getStatusBadge()` that derives a badge from movie data.
- `pre_venda` status → "Pré-venda" badge (accent/gold tone), overlaid on the poster bottom-left.
- `is_featured` (non-pre-sale) → "Destaque" badge (brand/red tone).
- Uses the existing `Badge` UI primitive and Tailwind positioning utilities.

### 3. MovieCarousel: titleVisible prop

Added `titleVisible?: boolean` to `src/components/movies/MovieCarousel.tsx` (defaults `true`). When `false`, the section `<h2>` receives `sr-only` so the tab label serves as the visible heading without duplication — carousel nav button aria-labels still reference the title internally.

### 4. HomeCatalog integration

Updated `src/app/HomeCatalog.tsx`:

- Replaced the two separate "Em cartaz" and "Pré-venda" `MovieCarousel` blocks with `<TabbedMovieCatalog>`.
- The "Em breve" (Upcoming) section remains as a standalone carousel below the tabbed section.
- `TabbedMovieCatalog` is exported from `src/components/movies/index.ts`.

### 5. Test coverage

Updated `src/app/home-catalog.test.ts` with 11 new tests:

- Full ARIA tab structure (tablist / tab / tabpanel roles present).
- Default active tab is "Em cartaz" (`aria-selected="true"` on first tab).
- Independent loading state for Now Showing without affecting Pre-sale.
- Independent loading state for Pre-sale without affecting Now Showing.
- Error state for Now Showing does not suppress Pre-sale movies.
- Error state for Pre-sale does not suppress Now Showing movies.
- Carousel navigation buttons render when movies exist.
- "Pré-venda" badge appears on `pre_venda` movies.
- "Destaque" badge appears on `is_featured` movies.
- Cinema indicator ("CinePrime Natal") is present in the rendered output.
- All pre-existing test assertions remain valid.

**Total: 191 tests, 0 failures.**

## How to test

### Automated validation

```bash
cd frontend
npm ci
npm run lint
npm run test
npm run build
```

### Manual validation

1. Start the full stack:

```bash
docker compose up --build
```

2. Open `http://localhost:3000` and scroll to the catalog section.

3. Verify the tabbed section:
   - "Em cartaz" tab is active by default, showing the now-showing carousel.
   - Clicking "Pré-venda" switches the carousel to pre-sale movies without a page reload.
   - Arrow keys (← →) navigate between tabs from the keyboard.
   - The cinema indicator (📍 CinePrime Natal) appears in the section header.

4. Verify movie card badges:
   - Pre-sale movies display a gold "Pré-venda" badge overlaid on the poster.
   - Featured now-showing movies display a red "Destaque" badge.

5. Verify carousel controls:
   - Previous/Next buttons appear when enough movies are present.
   - Click-drag scrolls the carousel horizontally.
   - Arrow keys navigate between cards when a card is focused.

6. Verify data states:
   - With the API offline, both tabs show their independent error state and retry button.
   - With an empty catalog, each tab shows its own empty state message.

## Expected Result

- Users switch between Now Showing and Pre-sale in a single section without page navigation.
- Movie posters remain the dominant visual element on every card.
- Status badges (Pré-venda, Destaque) render from live data — no hardcoded values.
- Cinema context is visible inside the catalog section.
- Carousel controls, touch/drag, and keyboard navigation work without layout jumps.
- Each tab has isolated loading, empty, and error states.
- All CI steps (lint → test → build) pass from a clean checkout.

closes #182