### PR TITLE
feat: add home schedule tabs for purchasable and coming-soon movies

### DIFF
--- a/backend/catalog/admin.py
+++ b/backend/catalog/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from catalog.models import Genre, Movie, Room, Session
+from catalog.models import CastMember, Genre, Movie, Room, Session
 
 
 @admin.register(Genre)
@@ -9,11 +9,33 @@ class GenreAdmin(admin.ModelAdmin):
     search_fields = ("name",)
 
 
+class CastMemberInline(admin.TabularInline):
+    model = CastMember
+    extra = 3
+    fields = ("order", "name")
+    ordering = ("order", "name")
+    verbose_name = "Membro do elenco"
+    verbose_name_plural = "Elenco principal"
+
+
 @admin.register(Movie)
 class MovieAdmin(admin.ModelAdmin):
-    list_display = ("title", "duration_minutes", "release_date", "created_at")
-    search_fields = ("title",)
+    list_display = ("title", "age_rating", "director", "duration_minutes", "status", "release_date", "created_at")
+    list_filter = ("status", "age_rating")
+    search_fields = ("title", "director")
     filter_horizontal = ("genres",)
+    inlines = [CastMemberInline]
+    fieldsets = (
+        (None, {
+            "fields": ("title", "synopsis", "poster_url"),
+        }),
+        ("Informações do filme", {
+            "fields": ("genres", "duration_minutes", "release_date", "age_rating", "director"),
+        }),
+        ("Publicação", {
+            "fields": ("status", "is_featured"),
+        }),
+    )
 
 
 @admin.register(Room)

--- a/backend/catalog/migrations/0007_movie_age_rating.py
+++ b/backend/catalog/migrations/0007_movie_age_rating.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("catalog", "0006_room_and_session_experience_metadata"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="movie",
+            name="age_rating",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("L", "Livre"),
+                    ("10", "10 anos"),
+                    ("12", "12 anos"),
+                    ("14", "14 anos"),
+                    ("16", "16 anos"),
+                    ("18", "18 anos"),
+                ],
+                default="",
+                max_length=2,
+                verbose_name="Faixa etária",
+            ),
+        ),
+    ]

--- a/backend/catalog/migrations/0008_movie_director_cast.py
+++ b/backend/catalog/migrations/0008_movie_director_cast.py
@@ -1,0 +1,43 @@
+import uuid
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("catalog", "0007_movie_age_rating"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="movie",
+            name="director",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+                verbose_name="Direção",
+            ),
+        ),
+        migrations.CreateModel(
+            name="CastMember",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("name", models.CharField(max_length=255)),
+                ("order", models.PositiveSmallIntegerField(default=0, verbose_name="Ordem")),
+                (
+                    "movie",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="cast",
+                        to="catalog.movie",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "cast_members",
+                "ordering": ["order", "name"],
+            },
+        ),
+    ]

--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -16,6 +16,15 @@ class MovieStatus(models.TextChoices):
     EM_BREVE = "em_breve", "Em breve"
 
 
+class AgeRating(models.TextChoices):
+    LIVRE = "L", "Livre"
+    TEN = "10", "10 anos"
+    TWELVE = "12", "12 anos"
+    FOURTEEN = "14", "14 anos"
+    SIXTEEN = "16", "16 anos"
+    EIGHTEEN = "18", "18 anos"
+
+
 class RoomExperienceType(models.TextChoices):
     STANDARD = "standard", "Traditional"
     VIP = "vip", "VIP"
@@ -57,6 +66,14 @@ class Movie(models.Model):
         choices=MovieStatus.choices,
         default=MovieStatus.EM_CARTAZ,
     )
+    age_rating = models.CharField(
+        max_length=2,
+        choices=AgeRating.choices,
+        blank=True,
+        default="",
+        verbose_name="Faixa etária",
+    )
+    director = models.CharField(max_length=255, blank=True, default="", verbose_name="Direção")
     is_featured = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -269,6 +286,20 @@ class Session(models.Model):
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
+
+
+class CastMember(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    movie = models.ForeignKey(Movie, on_delete=models.CASCADE, related_name="cast")
+    name = models.CharField(max_length=255)
+    order = models.PositiveSmallIntegerField(default=0, verbose_name="Ordem")
+
+    class Meta:
+        db_table = "cast_members"
+        ordering = ["order", "name"]
+
+    def __str__(self):
+        return self.name
 
 
 class Genre(models.Model):

--- a/backend/catalog/serializers.py
+++ b/backend/catalog/serializers.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework import serializers
 
-from catalog.models import Genre, Movie, Room, Session
+from catalog.models import CastMember, Genre, Movie, Room, Session
 from reservations.models import SessionSeat, SessionSeatStatus, Seat
 
 
@@ -102,6 +102,8 @@ class MovieWriteSerializer(serializers.ModelSerializer):
             "duration_minutes",
             "release_date",
             "poster_url",
+            "age_rating",
+            "director",
             "status",
             "is_featured",
             "created_at",
@@ -112,6 +114,10 @@ class MovieWriteSerializer(serializers.ModelSerializer):
 
 class MovieReadSerializer(serializers.ModelSerializer):
     genres = GenreSummarySerializer(many=True, read_only=True)
+    cast = serializers.SerializerMethodField()
+
+    def get_cast(self, obj):
+        return [m.name for m in obj.cast.all()]
 
     class Meta:
         model = Movie
@@ -123,6 +129,9 @@ class MovieReadSerializer(serializers.ModelSerializer):
             "duration_minutes",
             "release_date",
             "poster_url",
+            "age_rating",
+            "director",
+            "cast",
             "status",
             "is_featured",
             "created_at",
@@ -132,6 +141,10 @@ class MovieReadSerializer(serializers.ModelSerializer):
 
 class MovieSummarySerializer(serializers.ModelSerializer):
     genres = GenreSummarySerializer(many=True, read_only=True)
+    cast = serializers.SerializerMethodField()
+
+    def get_cast(self, obj):
+        return [m.name for m in obj.cast.all()]
 
     class Meta:
         model = Movie
@@ -142,6 +155,9 @@ class MovieSummarySerializer(serializers.ModelSerializer):
             "duration_minutes",
             "release_date",
             "poster_url",
+            "age_rating",
+            "director",
+            "cast",
             "status",
             "is_featured",
         ]

--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -133,7 +133,7 @@ class GenreDetailView(RetrieveUpdateDestroyAPIView):
 
 @extend_schema(tags=["Catalog"], summary="List or create movies")
 class MovieListCreateView(ListCreateAPIView):
-    queryset = Movie.objects.prefetch_related("genres").all()
+    queryset = Movie.objects.prefetch_related("genres", "cast").all()
     permission_classes = [IsAdminUserOrReadOnly]
     CACHE_TTL_SECONDS = 300
     IS_FEATURED_FILTER_VALUES = {
@@ -224,7 +224,7 @@ class MovieListCreateView(ListCreateAPIView):
 
 @extend_schema(tags=["Catalog"], summary="Get, update or delete movie")
 class MovieDetailView(RetrieveUpdateDestroyAPIView):
-    queryset = Movie.objects.prefetch_related("genres").all()
+    queryset = Movie.objects.prefetch_related("genres", "cast").all()
     permission_classes = [IsAdminUserOrReadOnly]
 
     def get_serializer_class(self):
@@ -269,7 +269,7 @@ class RoomDetailView(RetrieveUpdateDestroyAPIView):
 class SessionListCreateView(ListCreateAPIView):
     queryset = (
         Session.objects.select_related("movie", "room")
-        .prefetch_related("movie__genres")
+        .prefetch_related("movie__genres", "movie__cast")
         .all()
     )
     permission_classes = [IsAdminUserOrReadOnly]
@@ -428,7 +428,7 @@ class SessionListCreateView(ListCreateAPIView):
 class SessionDetailView(RetrieveUpdateDestroyAPIView):
     queryset = (
         Session.objects.select_related("movie", "room")
-        .prefetch_related("movie__genres")
+        .prefetch_related("movie__genres", "movie__cast")
         .all()
     )
     permission_classes = [IsAdminUserOrReadOnly]

--- a/frontend/e2e/critical-flows.spec.ts
+++ b/frontend/e2e/critical-flows.spec.ts
@@ -167,13 +167,14 @@ test("tabbed catalog switches to Pré-venda panel on click", async ({ page }) =>
   await setupMockApi(page);
   await page.goto("/");
 
-  const emCartazTab = page.getByRole("tab", { name: "Em cartaz" });
-  const preVendaTab = page.getByRole("tab", { name: "Pré-venda" });
+  const catalogSection = page.getByRole("region", { name: "Programação" });
+  const emCartazTab = catalogSection.getByRole("tab", { name: "Em cartaz" });
+  const preVendaTab = catalogSection.getByRole("tab", { name: "Pré-venda" });
 
   await expect(emCartazTab).toHaveAttribute("aria-selected", "true");
   await expect(preVendaTab).toHaveAttribute("aria-selected", "false");
 
-  const nowShowingPanel = page.getByRole("tabpanel", { name: "Em cartaz" });
+  const nowShowingPanel = catalogSection.getByRole("tabpanel", { name: "Em cartaz" });
   await expect(nowShowingPanel).toBeVisible();
   await expect(
     nowShowingPanel.getByRole("link", { name: /Ver detalhes de A Jornada de Natal/ })
@@ -184,7 +185,7 @@ test("tabbed catalog switches to Pré-venda panel on click", async ({ page }) =>
   await expect(preVendaTab).toHaveAttribute("aria-selected", "true");
   await expect(emCartazTab).toHaveAttribute("aria-selected", "false");
 
-  const preSalePanel = page.getByRole("tabpanel", { name: "Pré-venda" });
+  const preSalePanel = catalogSection.getByRole("tabpanel", { name: "Pré-venda" });
   await expect(preSalePanel).toBeVisible();
   await expect(
     preSalePanel.getByRole("link", { name: /Ver detalhes de Estreia da Semana/ })
@@ -193,17 +194,91 @@ test("tabbed catalog switches to Pré-venda panel on click", async ({ page }) =>
   await expect(nowShowingPanel).toBeHidden();
 });
 
+test("home schedule section renders Em cartaz and Em breve tabs", async ({ page }) => {
+  await setupMockApi(page);
+  await page.goto("/");
+
+  const scheduleSection = page.getByRole("region", { name: "Horários" });
+  const emCartazTab = scheduleSection.getByRole("tab", { name: "Em cartaz" });
+  const emBreveTab = scheduleSection.getByRole("tab", { name: "Em breve" });
+
+  await expect(emCartazTab).toBeVisible();
+  await expect(emBreveTab).toBeVisible();
+  await expect(emCartazTab).toHaveAttribute("aria-selected", "true");
+  await expect(emBreveTab).toHaveAttribute("aria-selected", "false");
+});
+
+test("home schedule Em cartaz tab shows session buttons linking to seat selection", async ({
+  page,
+}) => {
+  await setupMockApi(page);
+  await page.goto("/");
+
+  const scheduleSection = page.getByRole("region", { name: "Horários" });
+  await expect(scheduleSection).toBeVisible();
+
+  await expect(
+    scheduleSection.getByRole("link", {
+      name: /Selecionar sessão das 15:00, sala Sala 1/,
+    })
+  ).toBeVisible();
+});
+
+test("home schedule Em cartaz session button navigates to seat selection", async ({ page }) => {
+  await setupMockApi(page);
+  await page.goto("/");
+
+  const scheduleSection = page.getByRole("region", { name: "Horários" });
+  await scheduleSection.getByRole("link", { name: /Selecionar sessão das 15:00/ }).click();
+
+  await expect(page).toHaveURL(/\/sessions\/session-morning\/seats/);
+});
+
+test("home schedule switches to Em breve tab and shows upcoming movie without session links", async ({
+  page,
+}) => {
+  await setupMockApi(page);
+  await page.goto("/");
+
+  const scheduleSection = page.getByRole("region", { name: "Horários" });
+  await scheduleSection.getByRole("tab", { name: "Em breve" }).click();
+
+  const emBrevePanel = scheduleSection.getByRole("tabpanel", { name: "Em breve" });
+  await expect(emBrevePanel).toBeVisible();
+  await expect(
+    emBrevePanel.getByRole("link", { name: /Ver detalhes de Em Breve em Natal/ })
+  ).toBeVisible();
+
+  await expect(
+    emBrevePanel.getByRole("link", { name: /Selecionar sessão/ })
+  ).toHaveCount(0);
+});
+
+test("movie detail for em_breve movie shows coming-soon notice and hides session selector", async ({
+  page,
+}) => {
+  await setupMockApi(page);
+  await page.goto("/movies/movie-upcoming");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Em Breve em Natal" })
+  ).toBeVisible();
+  await expect(page.getByText("Em breve nas telas")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sessões" })).toHaveCount(0);
+});
+
 test("tabbed catalog switches to Pré-venda panel with ArrowRight key", async ({ page }) => {
   await setupMockApi(page);
   await page.goto("/");
 
-  await page.getByRole("tab", { name: "Em cartaz" }).focus();
+  const catalogSection = page.getByRole("region", { name: "Programação" });
+  await catalogSection.getByRole("tab", { name: "Em cartaz" }).focus();
   await page.keyboard.press("ArrowRight");
 
-  const preVendaTab = page.getByRole("tab", { name: "Pré-venda" });
+  const preVendaTab = catalogSection.getByRole("tab", { name: "Pré-venda" });
   await expect(preVendaTab).toHaveAttribute("aria-selected", "true");
 
-  const preSalePanel = page.getByRole("tabpanel", { name: "Pré-venda" });
+  const preSalePanel = catalogSection.getByRole("tabpanel", { name: "Pré-venda" });
   await expect(preSalePanel).toBeVisible();
   await expect(
     preSalePanel.getByRole("link", { name: /Ver detalhes de Estreia da Semana/ })

--- a/frontend/e2e/support/api-mocks.ts
+++ b/frontend/e2e/support/api-mocks.ts
@@ -152,6 +152,10 @@ async function handleApiRoute(route: Route, state: ApiRouteState) {
     return json(route, movie);
   }
 
+  if (method === "GET" && url.pathname === `/api/v1/catalog/movies/${upcomingMovie.id}/`) {
+    return json(route, { ...upcomingMovie, synopsis: "Ainda por vir nas telas do cinema." });
+  }
+
   if (method === "GET" && url.pathname === "/api/v1/catalog/sessions/") {
     return json(route, paginated([session]));
   }

--- a/frontend/src/app/HomeCatalog.tsx
+++ b/frontend/src/app/HomeCatalog.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import { catalogApi } from "@/api/catalog";
 import { Button } from "@/components/ui/Button";
 import { FeaturedMovieBanner } from "@/components/movies";
-import { MovieCarousel } from "@/components/movies";
+import { HomeSchedule } from "@/components/movies/HomeSchedule";
 import { TabbedMovieCatalog } from "@/components/movies/TabbedMovieCatalog";
 import { StateMessage } from "@/components/ui/StateMessage";
 import type { CatalogMovie } from "@/types/catalog";
@@ -152,25 +152,10 @@ export function HomeCatalogSections({
           preSale={preSale}
         />
 
-        {upcoming.status === "error" ? (
-          <CatalogErrorState
-            message={
-              upcoming.errorMessage ??
-              "Não foi possível carregar os filmes em breve. Tente novamente."
-            }
-            onRetry={onRetryUpcoming}
-            title="Em breve indisponível"
-          />
-        ) : (
-          <MovieCarousel
-            emptyDescription="Ainda não há filmes em breve no catálogo."
-            emptyTitle="Nenhum filme em breve"
-            isLoading={upcoming.status === "loading"}
-            loadingLabel="Carregando filmes em breve..."
-            movies={upcoming.movies}
-            title="Em breve"
-          />
-        )}
+        <HomeSchedule
+          onRetryUpcoming={onRetryUpcoming}
+          upcoming={upcoming}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/movies/HomeSchedule.tsx
+++ b/frontend/src/components/movies/HomeSchedule.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import Link from "next/link";
+import { type KeyboardEvent, useCallback, useEffect, useId, useMemo, useState } from "react";
+
+import { catalogApi } from "@/api/catalog";
+import type { MovieSectionState } from "@/app/HomeCatalog";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/components/ui/classNames";
+import { ResponsiveImage } from "@/components/ui/ResponsiveImage";
+import { StateMessage } from "@/components/ui/StateMessage";
+import type { CatalogSession } from "@/types/catalog";
+
+import { MovieCarousel } from "./MovieCarousel";
+import {
+  formatMovieDuration,
+  formatMovieGenres,
+  getMovieDetailsHref,
+} from "./movie-formatters";
+import { SessionBadgeList } from "./SessionBadges";
+import {
+  buildSessionDateOptions,
+  formatSessionFullDate,
+  formatSessionPrice,
+  formatSessionTime,
+  getSessionBadges,
+  getSessionSeatsHref,
+  groupSessionsByMovie,
+  type MovieSessionGroup,
+} from "./session-selection";
+
+type ScheduleTab = "em_breve" | "em_cartaz";
+
+type SessionScheduleState = {
+  errorMessage?: string;
+  sessions: CatalogSession[];
+  status: "error" | "loading" | "success";
+};
+
+export type HomeScheduleProps = {
+  cinemaName?: string;
+  onRetryUpcoming?: () => void;
+  upcoming: MovieSectionState;
+};
+
+const SCHEDULE_TABS = [
+  { value: "em_cartaz" as ScheduleTab, label: "Em cartaz" },
+  { value: "em_breve" as ScheduleTab, label: "Em breve" },
+] as const;
+
+export function HomeSchedule({
+  cinemaName = "CinePrime Natal",
+  onRetryUpcoming,
+  upcoming,
+}: HomeScheduleProps) {
+  const [activeTab, setActiveTab] = useState<ScheduleTab>("em_cartaz");
+  const uid = useId();
+  const headingId = `${uid}-schedule-heading`;
+
+  const dateOptions = useMemo(() => buildSessionDateOptions(new Date()), []);
+  const [selectedDate, setSelectedDate] = useState(dateOptions[0]?.value ?? "");
+  const [scheduleState, setScheduleState] = useState<SessionScheduleState>({
+    sessions: [],
+    status: "loading",
+  });
+
+  const loadSessions = useCallback(async (date: string) => {
+    if (!date) {
+      setScheduleState({ sessions: [], status: "success" });
+      return;
+    }
+
+    setScheduleState({ sessions: [], status: "loading" });
+
+    try {
+      const response = await catalogApi.getSessions({ date });
+      setScheduleState({ sessions: response.results, status: "success" });
+    } catch {
+      setScheduleState({
+        errorMessage:
+          "Não conseguimos carregar a programação agora. Verifique sua conexão e tente novamente.",
+        sessions: [],
+        status: "error",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSessions(selectedDate);
+  }, [loadSessions, selectedDate]);
+
+  function handleTabKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      const nextIdx =
+        e.key === "ArrowRight"
+          ? (idx + 1) % SCHEDULE_TABS.length
+          : (idx - 1 + SCHEDULE_TABS.length) % SCHEDULE_TABS.length;
+      setActiveTab(SCHEDULE_TABS[nextIdx].value);
+      const tabList = e.currentTarget.parentElement;
+      (tabList?.children[nextIdx] as HTMLElement | undefined)?.focus();
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="grid gap-5 rounded-panel border border-border bg-surface p-6 shadow-soft max-sm:p-4"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2
+          className="text-[length:var(--text-section)] font-extrabold leading-[var(--text-section--line-height)] text-text"
+          id={headingId}
+        >
+          Horários
+        </h2>
+        <span className="text-sm font-bold text-muted">{cinemaName}</span>
+      </div>
+
+      <div
+        aria-label="Seções de horários"
+        className="inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-panel border border-border bg-surface-muted p-1"
+        role="tablist"
+      >
+        {SCHEDULE_TABS.map((tab, idx) => {
+          const isSelected = activeTab === tab.value;
+          return (
+            <button
+              aria-controls={`${uid}-${tab.value}-panel`}
+              aria-selected={isSelected}
+              className={cn(
+                "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus",
+                isSelected
+                  ? "bg-surface text-text shadow-soft"
+                  : "text-muted hover:bg-surface hover:text-text"
+              )}
+              id={`${uid}-${tab.value}-tab`}
+              key={tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              onKeyDown={(e) => handleTabKeyDown(e, idx)}
+              role="tab"
+              tabIndex={isSelected ? 0 : -1}
+              type="button"
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Em cartaz panel */}
+      <div
+        aria-labelledby={`${uid}-em_cartaz-tab`}
+        hidden={activeTab !== "em_cartaz"}
+        id={`${uid}-em_cartaz-panel`}
+        role="tabpanel"
+        tabIndex={0}
+      >
+        <div className="grid gap-4">
+          <div
+            aria-label="Selecionar data"
+            className="flex gap-2 overflow-x-auto pb-1"
+            role="group"
+          >
+            {dateOptions.map((option) => (
+              <button
+                aria-pressed={option.value === selectedDate}
+                className={cn(
+                  "flex min-w-[3.25rem] flex-col items-center gap-0.5 rounded-control border px-2.5 py-2 text-center text-xs font-bold transition-colors focus-visible:outline-none focus-visible:shadow-focus",
+                  option.value === selectedDate
+                    ? "border-brand bg-brand text-white"
+                    : "border-border bg-surface-muted text-muted hover:border-brand hover:text-text"
+                )}
+                key={option.value}
+                onClick={() => setSelectedDate(option.value)}
+                type="button"
+              >
+                <span className="capitalize">{option.weekday}</span>
+                <strong>{option.label}</strong>
+              </button>
+            ))}
+          </div>
+
+          <SessionSchedule
+            date={selectedDate}
+            onRetry={() => void loadSessions(selectedDate)}
+            state={scheduleState}
+          />
+        </div>
+      </div>
+
+      {/* Em breve panel */}
+      <div
+        aria-labelledby={`${uid}-em_breve-tab`}
+        hidden={activeTab !== "em_breve"}
+        id={`${uid}-em_breve-panel`}
+        role="tabpanel"
+        tabIndex={0}
+      >
+        {upcoming.status === "error" ? (
+          <StateMessage
+            action={
+              onRetryUpcoming ? (
+                <Button onClick={onRetryUpcoming} variant="ghost">
+                  Tentar novamente
+                </Button>
+              ) : undefined
+            }
+            title="Em breve indisponível"
+            tone="error"
+          >
+            {upcoming.errorMessage ??
+              "Não conseguimos carregar esta seção agora. Verifique sua conexão e tente novamente."}
+          </StateMessage>
+        ) : (
+          <MovieCarousel
+            emptyDescription="Ainda não há filmes em breve no catálogo."
+            emptyTitle="Nenhum filme em breve"
+            isLoading={upcoming.status === "loading"}
+            loadingLabel="Carregando filmes em breve..."
+            movies={upcoming.movies}
+            title="Em breve"
+            titleVisible={false}
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function SessionSchedule({
+  date,
+  onRetry,
+  state,
+}: {
+  date: string;
+  onRetry: () => void;
+  state: SessionScheduleState;
+}) {
+  if (state.status === "loading") {
+    return (
+      <StateMessage title="Carregando programação" tone="loading">
+        Buscando sessões para {formatSessionFullDate(date)}.
+      </StateMessage>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <StateMessage
+        action={
+          <Button onClick={onRetry} variant="ghost">
+            Tentar novamente
+          </Button>
+        }
+        title="Programação indisponível"
+        tone="error"
+      >
+        {state.errorMessage ??
+          "Não conseguimos carregar a programação agora. Tente novamente em instantes."}
+      </StateMessage>
+    );
+  }
+
+  const purchasableSessions = state.sessions.filter(
+    (s) => s.movie.status !== "em_breve"
+  );
+  const movieGroups = groupSessionsByMovie(purchasableSessions);
+
+  if (movieGroups.length === 0) {
+    return (
+      <StateMessage title="Nenhuma sessão nesta data">
+        Não há sessões disponíveis para {formatSessionFullDate(date)}. Escolha outra data.
+      </StateMessage>
+    );
+  }
+
+  return (
+    <div aria-label="Programação do dia">
+      {movieGroups.map((group) => (
+        <MovieScheduleEntry group={group} key={group.movie.id} />
+      ))}
+    </div>
+  );
+}
+
+function MovieScheduleEntry({ group }: { group: MovieSessionGroup }) {
+  return (
+    <article className="grid grid-cols-[auto_1fr] gap-4 border-b border-border py-5 first:pt-0 last:border-b-0 last:pb-0">
+      <Link
+        aria-hidden="true"
+        className="shrink-0"
+        href={getMovieDetailsHref(group.movie.id)}
+        tabIndex={-1}
+      >
+        <ResponsiveImage
+          alt={`Poster de ${group.movie.title}`}
+          className="h-24 w-16 rounded-control object-cover"
+          height={144}
+          loading="lazy"
+          sizes="64px"
+          src={group.movie.poster_url}
+          unoptimized
+          width={96}
+        />
+      </Link>
+
+      <div className="grid gap-3">
+        <div>
+          <Link
+            className="font-extrabold leading-snug text-text hover:text-brand"
+            href={getMovieDetailsHref(group.movie.id)}
+          >
+            {group.movie.title}
+          </Link>
+          <p className="mt-0.5 text-sm text-muted">
+            {formatMovieGenres(group.movie.genres)}
+            {" · "}
+            {formatMovieDuration(group.movie.duration_minutes)}
+          </p>
+        </div>
+
+        {group.roomGroups.map((roomGroup) => (
+          <div className="grid gap-1.5" key={roomGroup.roomId}>
+            <h3 className="text-sm font-bold text-text">{roomGroup.roomName}</h3>
+            <div className="flex flex-wrap gap-2">
+              {roomGroup.sessions.map((session) => {
+                const badges = getSessionBadges(session);
+                const badgeText = badges.map((b) => b.label).join(", ");
+                const badgeDescription = badgeText ? `, formatos ${badgeText}` : "";
+
+                return (
+                  <Link
+                    aria-label={`Selecionar sessão das ${formatSessionTime(session.start_time)}, sala ${roomGroup.roomName}${badgeDescription}, valor ${formatSessionPrice(session.base_price)}`}
+                    className="flex flex-col items-start gap-1 rounded-control border border-border bg-surface-muted px-3 py-2 text-left text-sm transition-colors hover:border-brand hover:bg-surface focus-visible:outline-none focus-visible:shadow-focus"
+                    href={getSessionSeatsHref(session.id)}
+                    key={session.id}
+                  >
+                    <strong className="text-text">{formatSessionTime(session.start_time)}</strong>
+                    <span className="text-xs text-muted">
+                      até {formatSessionTime(session.end_time)}
+                    </span>
+                    {badges.length > 0 && <SessionBadgeList badges={badges} />}
+                    <span className="text-xs font-bold text-muted">
+                      {formatSessionPrice(session.base_price)}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/movies/HomeSchedule.tsx
+++ b/frontend/src/components/movies/HomeSchedule.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { type KeyboardEvent, useCallback, useEffect, useId, useMemo, useState } from "react";
-
+import { CalendarDays, ChevronLeft, ChevronRight, HelpCircle } from "lucide-react";
+import { Fragment, type KeyboardEvent, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { catalogApi } from "@/api/catalog";
 import type { MovieSectionState } from "@/app/HomeCatalog";
 import { Button } from "@/components/ui/Button";
@@ -20,11 +20,15 @@ import {
 import { SessionBadgeList } from "./SessionBadges";
 import {
   buildSessionDateOptions,
+  type ExperienceSessionGroup,
+  formatScheduleDateHeading,
   formatSessionFullDate,
   formatSessionPrice,
   formatSessionTime,
   getSessionBadges,
+  getRoomExperienceLabel,
   getSessionSeatsHref,
+  groupSessionsByExperienceType,
   groupSessionsByMovie,
   type MovieSessionGroup,
 } from "./session-selection";
@@ -55,7 +59,7 @@ export function HomeSchedule({
 }: HomeScheduleProps) {
   const [activeTab, setActiveTab] = useState<ScheduleTab>("em_cartaz");
   const uid = useId();
-  const headingId = `${uid}-schedule-heading`;
+  const calendarInputRef = useRef<HTMLInputElement>(null);
 
   const dateOptions = useMemo(() => buildSessionDateOptions(new Date()), []);
   const [selectedDate, setSelectedDate] = useState(dateOptions[0]?.value ?? "");
@@ -97,55 +101,72 @@ export function HomeSchedule({
           ? (idx + 1) % SCHEDULE_TABS.length
           : (idx - 1 + SCHEDULE_TABS.length) % SCHEDULE_TABS.length;
       setActiveTab(SCHEDULE_TABS[nextIdx].value);
-      const tabList = e.currentTarget.parentElement;
-      (tabList?.children[nextIdx] as HTMLElement | undefined)?.focus();
+      const tabList = e.currentTarget.closest('[role="tablist"]');
+      const tabs = tabList?.querySelectorAll<HTMLElement>('[role="tab"]');
+      tabs?.[nextIdx]?.focus();
     }
   }
 
-  return (
-    <section
-      aria-labelledby={headingId}
-      className="grid gap-5 rounded-panel border border-border bg-surface p-6 shadow-soft max-sm:p-4"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2
-          className="text-[length:var(--text-section)] font-extrabold leading-[var(--text-section--line-height)] text-text"
-          id={headingId}
-        >
-          Horários
-        </h2>
-        <span className="text-sm font-bold text-muted">{cinemaName}</span>
-      </div>
+  const selectedDateIdx = dateOptions.findIndex((o) => o.value === selectedDate);
+  const canGoPrev = selectedDateIdx > 0;
+  const canGoNext = selectedDateIdx < dateOptions.length - 1;
 
-      <div
-        aria-label="Seções de horários"
-        className="inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-panel border border-border bg-surface-muted p-1"
-        role="tablist"
-      >
-        {SCHEDULE_TABS.map((tab, idx) => {
-          const isSelected = activeTab === tab.value;
-          return (
-            <button
-              aria-controls={`${uid}-${tab.value}-panel`}
-              aria-selected={isSelected}
-              className={cn(
-                "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus",
-                isSelected
-                  ? "bg-surface text-text shadow-soft"
-                  : "text-muted hover:bg-surface hover:text-text"
-              )}
-              id={`${uid}-${tab.value}-tab`}
-              key={tab.value}
-              onClick={() => setActiveTab(tab.value)}
-              onKeyDown={(e) => handleTabKeyDown(e, idx)}
-              role="tab"
-              tabIndex={isSelected ? 0 : -1}
-              type="button"
-            >
-              {tab.label}
-            </button>
-          );
-        })}
+  function goToPrevDate() {
+    if (canGoPrev) setSelectedDate(dateOptions[selectedDateIdx - 1].value);
+  }
+
+  function goToNextDate() {
+    if (canGoNext) setSelectedDate(dateOptions[selectedDateIdx + 1].value);
+  }
+
+  function handleCalendarChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const picked = e.target.value;
+    const match = dateOptions.find((o) => o.value === picked);
+    if (match) setSelectedDate(match.value);
+  }
+
+  return (
+    <section aria-label="Horários" className="grid gap-5">
+      {/* Header: tabs + cinema name — sem título visível */}
+      <div className="flex flex-wrap items-center gap-y-2">
+        <div
+          aria-label="Seções de horários"
+          className="flex items-center"
+          role="tablist"
+        >
+          {SCHEDULE_TABS.map((tab, idx) => {
+            const isSelected = activeTab === tab.value;
+            return (
+              <Fragment key={tab.value}>
+                {idx > 0 && (
+                  <span aria-hidden="true" className="mx-3 select-none text-border">
+                    |
+                  </span>
+                )}
+                <button
+                  aria-controls={`${uid}-${tab.value}-panel`}
+                  aria-selected={isSelected}
+                  className={cn(
+                    "whitespace-nowrap pb-0.5 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus",
+                    isSelected
+                      ? "border-b-2 border-brand text-text"
+                      : "text-muted hover:text-text"
+                  )}
+                  id={`${uid}-${tab.value}-tab`}
+                  onClick={() => setActiveTab(tab.value)}
+                  onKeyDown={(e) => handleTabKeyDown(e, idx)}
+                  role="tab"
+                  tabIndex={isSelected ? 0 : -1}
+                  type="button"
+                >
+                  {tab.label}
+                </button>
+              </Fragment>
+            );
+          })}
+        </div>
+
+        <span className="ml-auto text-sm font-bold text-muted">{cinemaName}</span>
       </div>
 
       {/* Em cartaz panel */}
@@ -157,28 +178,76 @@ export function HomeSchedule({
         tabIndex={0}
       >
         <div className="grid gap-4">
-          <div
-            aria-label="Selecionar data"
-            className="flex gap-2 overflow-x-auto pb-1"
-            role="group"
-          >
-            {dateOptions.map((option) => (
+          {/* Date carousel */}
+          <div aria-label="Selecionar data" className="flex items-stretch gap-1" role="group">
+            <button
+              aria-label="Data anterior"
+              className="flex items-center justify-center rounded-control border border-border px-2 text-muted transition-colors hover:border-brand hover:text-text focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!canGoPrev}
+              onClick={goToPrevDate}
+              type="button"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+
+            <div className="flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
+              {dateOptions.map((option) => {
+                const isSelected = option.value === selectedDate;
+                const dayNumber = option.label.split("/")[0];
+                const weekday = option.weekday.toUpperCase();
+                return (
+                  <button
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "flex flex-1 flex-col items-center justify-center gap-0.5 rounded-control border-2 py-2.5 text-center transition-colors focus-visible:outline-none focus-visible:shadow-focus",
+                      isSelected
+                        ? "border-[#0f1b3c] bg-[#0f1b3c] text-white"
+                        : "border-border bg-surface-muted text-muted hover:border-brand hover:text-text"
+                    )}
+                    key={option.value}
+                    onClick={() => setSelectedDate(option.value)}
+                    type="button"
+                  >
+                    <span className="text-[0.65rem] font-bold leading-none tracking-wide">
+                      {weekday}.
+                    </span>
+                    <strong className="text-xl font-extrabold leading-none">{dayNumber}</strong>
+                  </button>
+                );
+              })}
+            </div>
+
+            <button
+              aria-label="Próxima data"
+              className="flex items-center justify-center rounded-control border border-border px-2 text-muted transition-colors hover:border-brand hover:text-text focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!canGoNext}
+              onClick={goToNextDate}
+              type="button"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+
+            <div className="relative">
               <button
-                aria-pressed={option.value === selectedDate}
-                className={cn(
-                  "flex min-w-[3.25rem] flex-col items-center gap-0.5 rounded-control border px-2.5 py-2 text-center text-xs font-bold transition-colors focus-visible:outline-none focus-visible:shadow-focus",
-                  option.value === selectedDate
-                    ? "border-brand bg-brand text-white"
-                    : "border-border bg-surface-muted text-muted hover:border-brand hover:text-text"
-                )}
-                key={option.value}
-                onClick={() => setSelectedDate(option.value)}
+                aria-label="Abrir calendário"
+                className="flex h-full items-center justify-center rounded-control border border-border px-2 text-muted transition-colors hover:border-brand hover:text-text focus-visible:outline-none focus-visible:shadow-focus"
+                onClick={() => calendarInputRef.current?.showPicker?.()}
                 type="button"
               >
-                <span className="capitalize">{option.weekday}</span>
-                <strong>{option.label}</strong>
+                <CalendarDays className="size-4" />
               </button>
-            ))}
+              <input
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 opacity-0"
+                max={dateOptions[dateOptions.length - 1]?.value}
+                min={dateOptions[0]?.value}
+                onChange={handleCalendarChange}
+                ref={calendarInputRef}
+                tabIndex={-1}
+                type="date"
+                value={selectedDate}
+              />
+            </div>
           </div>
 
           <SessionSchedule
@@ -278,15 +347,18 @@ export function SessionSchedule({
   return (
     <div aria-label="Programação do dia">
       {movieGroups.map((group) => (
-        <MovieScheduleEntry group={group} key={group.movie.id} />
+        <MovieScheduleEntry date={date} group={group} key={group.movie.id} />
       ))}
     </div>
   );
 }
 
-function MovieScheduleEntry({ group }: { group: MovieSessionGroup }) {
+function MovieScheduleEntry({ date, group }: { date: string; group: MovieSessionGroup }) {
+  const allSessions = group.roomGroups.flatMap((rg) => rg.sessions);
+  const experienceGroups = groupSessionsByExperienceType(allSessions);
+
   return (
-    <article className="grid grid-cols-[auto_1fr] gap-4 border-b border-border py-5 first:pt-0 last:border-b-0 last:pb-0">
+    <article className="flex gap-5 border-b border-border py-8 first:pt-0 last:border-b-0 last:pb-0">
       <Link
         aria-hidden="true"
         className="shrink-0"
@@ -295,62 +367,93 @@ function MovieScheduleEntry({ group }: { group: MovieSessionGroup }) {
       >
         <ResponsiveImage
           alt={`Poster de ${group.movie.title}`}
-          className="h-24 w-16 rounded-control object-cover"
-          height={144}
+          className="h-52 w-[8.5rem] rounded-control object-cover"
+          height={312}
           loading="lazy"
-          sizes="64px"
+          sizes="136px"
           src={group.movie.poster_url}
           unoptimized
-          width={96}
+          width={204}
         />
       </Link>
 
-      <div className="grid gap-3">
-        <div>
+      <div className="grid min-w-0 content-start gap-3">
+        <div className="grid gap-1">
           <Link
-            className="font-extrabold leading-snug text-text hover:text-brand"
+            className="text-xl font-extrabold leading-snug text-text hover:text-brand"
             href={getMovieDetailsHref(group.movie.id)}
           >
             {group.movie.title}
           </Link>
-          <p className="mt-0.5 text-sm text-muted">
-            {formatMovieGenres(group.movie.genres)}
-            {" · "}
-            {formatMovieDuration(group.movie.duration_minutes)}
-          </p>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted">
+            {group.movie.age_rating && (
+              <span className="inline-flex items-center rounded border border-current px-1.5 py-px text-xs font-bold leading-none">
+                {group.movie.age_rating}
+              </span>
+            )}
+            <span>{formatMovieDuration(group.movie.duration_minutes)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatMovieGenres(group.movie.genres)}</span>
+          </div>
+          {group.movie.director && (
+            <p className="text-sm text-muted">
+              <span className="font-semibold text-text">Direção:</span>{" "}
+              {group.movie.director}
+            </p>
+          )}
+          {group.movie.cast && group.movie.cast.length > 0 && (
+            <p className="text-sm text-muted">
+              <span className="font-semibold text-text">Elenco:</span>{" "}
+              {group.movie.cast.slice(0, 3).join(", ")}
+            </p>
+          )}
         </div>
 
-        {group.roomGroups.map((roomGroup) => (
-          <div className="grid gap-1.5" key={roomGroup.roomId}>
-            <h3 className="text-sm font-bold text-text">{roomGroup.roomName}</h3>
-            <div className="flex flex-wrap gap-2">
-              {roomGroup.sessions.map((session) => {
-                const badges = getSessionBadges(session);
-                const badgeText = badges.map((b) => b.label).join(", ");
-                const badgeDescription = badgeText ? `, formatos ${badgeText}` : "";
+        <p className="text-sm font-extrabold capitalize text-text">
+          {formatScheduleDateHeading(date)}
+        </p>
 
-                return (
-                  <Link
-                    aria-label={`Selecionar sessão das ${formatSessionTime(session.start_time)}, sala ${roomGroup.roomName}${badgeDescription}, valor ${formatSessionPrice(session.base_price)}`}
-                    className="flex flex-col items-start gap-1 rounded-control border border-border bg-surface-muted px-3 py-2 text-left text-sm transition-colors hover:border-brand hover:bg-surface focus-visible:outline-none focus-visible:shadow-focus"
-                    href={getSessionSeatsHref(session.id)}
-                    key={session.id}
-                  >
-                    <strong className="text-text">{formatSessionTime(session.start_time)}</strong>
-                    <span className="text-xs text-muted">
-                      até {formatSessionTime(session.end_time)}
-                    </span>
-                    {badges.length > 0 && <SessionBadgeList badges={badges} />}
-                    <span className="text-xs font-bold text-muted">
-                      {formatSessionPrice(session.base_price)}
-                    </span>
-                  </Link>
-                );
-              })}
-            </div>
-          </div>
-        ))}
+        <div className="grid gap-4">
+          {experienceGroups.map((expGroup) => (
+            <ExperienceGroupEntry group={expGroup} key={expGroup.experienceType} />
+          ))}
+        </div>
       </div>
     </article>
+  );
+}
+
+function ExperienceGroupEntry({ group }: { group: ExperienceSessionGroup }) {
+  const repSession = group.sessions[0];
+  const allBadges = repSession ? getSessionBadges(repSession) : [];
+  const expLabel = getRoomExperienceLabel(repSession?.room.experience_type);
+  const headerBadges = allBadges.filter((b) => b.label !== expLabel);
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="text-sm font-bold text-text">{group.label}</h3>
+        {headerBadges.length > 0 && <SessionBadgeList badges={headerBadges} />}
+        <HelpCircle className="size-3.5 shrink-0 text-muted/50" />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {group.sessions.map((session) => {
+          const badges = getSessionBadges(session);
+          const badgeText = badges.map((b) => b.label).join(", ");
+          const badgeDescription = badgeText ? `, formatos ${badgeText}` : "";
+
+          return (
+            <Link
+              aria-label={`Selecionar sessão das ${formatSessionTime(session.start_time)}, sala ${session.room.name}${badgeDescription}, valor ${formatSessionPrice(session.base_price)}`}
+              className="flex min-w-[4.5rem] items-center justify-center rounded-control bg-brand px-4 py-3 font-extrabold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:shadow-focus"
+              href={getSessionSeatsHref(session.id)}
+              key={session.id}
+            >
+              {formatSessionTime(session.start_time)}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -183,9 +183,22 @@ function MovieDetailSuccess({ movie }: { movie: CatalogMovieDetail }) {
           <p>{movie.synopsis || "Sinopse indisponível."}</p>
         </section>
 
-        <MovieSessionSelector movieId={movie.id} />
+        {movie.status === "em_breve" ? (
+          <MovieComingSoonNotice />
+        ) : (
+          <MovieSessionSelector movieId={movie.id} />
+        )}
       </article>
     </div>
+  );
+}
+
+function MovieComingSoonNotice() {
+  return (
+    <StateMessage title="Em breve nas telas">
+      Este filme ainda não está em cartaz. Fique de olho na programação para saber quando as
+      sessões estarão disponíveis.
+    </StateMessage>
   );
 }
 

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -162,13 +162,19 @@ function MovieDetailSuccess({ movie }: { movie: CatalogMovieDetail }) {
         </div>
 
         <dl className="movie-detail__metadata" aria-label="Informações do filme">
-          <div>
-            <dt>Gêneros</dt>
-            <dd>{genres}</dd>
-          </div>
+          {movie.age_rating && (
+            <div>
+              <dt>Faixa etária</dt>
+              <dd>{movie.age_rating === "L" ? "Livre" : `${movie.age_rating} anos`}</dd>
+            </div>
+          )}
           <div>
             <dt>Duração</dt>
             <dd>{duration}</dd>
+          </div>
+          <div>
+            <dt>Gêneros</dt>
+            <dd>{genres}</dd>
           </div>
           {movie.release_date ? (
             <div>
@@ -176,6 +182,18 @@ function MovieDetailSuccess({ movie }: { movie: CatalogMovieDetail }) {
               <dd>{releaseDate}</dd>
             </div>
           ) : null}
+          {movie.director && (
+            <div>
+              <dt>Direção</dt>
+              <dd>{movie.director}</dd>
+            </div>
+          )}
+          {movie.cast && movie.cast.length > 0 && (
+            <div>
+              <dt>Elenco</dt>
+              <dd>{movie.cast.join(", ")}</dd>
+            </div>
+          )}
         </dl>
 
         <section className="movie-detail__synopsis" aria-labelledby="sinopse">

--- a/frontend/src/components/movies/TabbedMovieCatalog.tsx
+++ b/frontend/src/components/movies/TabbedMovieCatalog.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { MapPin } from "lucide-react";
-import type { KeyboardEvent } from "react";
-import { useId, useState } from "react";
+import { Fragment, type KeyboardEvent, useId, useState } from "react";
 
 import type { MovieSectionState } from "@/app/HomeCatalog";
 import { Button } from "@/components/ui/Button";
@@ -49,7 +48,6 @@ export function TabbedMovieCatalog({
 }: TabbedMovieCatalogProps) {
   const [activeTab, setActiveTab] = useState<CatalogTab>("em_cartaz");
   const uid = useId();
-  const headingId = `${uid}-catalog-heading`;
 
   function handleTabKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
     if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
@@ -59,8 +57,9 @@ export function TabbedMovieCatalog({
           ? (idx + 1) % TABS.length
           : (idx - 1 + TABS.length) % TABS.length;
       setActiveTab(TABS[nextIdx].value);
-      const tabList = e.currentTarget.parentElement;
-      (tabList?.children[nextIdx] as HTMLElement | undefined)?.focus();
+      const tabList = e.currentTarget.closest('[role="tablist"]');
+      const tabs = tabList?.querySelectorAll<HTMLElement>('[role="tab"]');
+      tabs?.[nextIdx]?.focus();
     }
   }
 
@@ -73,51 +72,46 @@ export function TabbedMovieCatalog({
   }
 
   return (
-    <section
-      aria-labelledby={headingId}
-      className="grid gap-5 rounded-panel border border-border bg-surface p-6 shadow-soft max-sm:p-4"
-    >
-      {/* Section header: title + cinema indicator */}
+    <section aria-label="Programação" className="grid gap-0.5">
+      {/* Tab list + location */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2
-          className="text-[length:var(--text-section)] font-extrabold leading-[var(--text-section--line-height)] text-text"
-          id={headingId}
+        <div
+          aria-label="Seções de programação"
+          className="flex items-center"
+          role="tablist"
         >
-          Programação
-        </h2>
-        <CinemaIndicator name={cinemaName} />
-      </div>
-
-      {/* Tab list */}
-      <div
-        aria-label="Seções de programação"
-        className="inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-panel border border-border bg-surface-muted p-1"
-        role="tablist"
-      >
         {TABS.map((tab, idx) => {
           const isSelected = activeTab === tab.value;
           return (
-            <button
-              aria-controls={`${uid}-${tab.value}-panel`}
-              aria-selected={isSelected}
-              className={cn(
-                "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus",
-                isSelected
-                  ? "bg-surface text-text shadow-soft"
-                  : "text-muted hover:bg-surface hover:text-text"
+            <Fragment key={tab.value}>
+              {idx > 0 && (
+                <span aria-hidden="true" className="mx-3 select-none text-border">
+                  |
+                </span>
               )}
-              id={`${uid}-${tab.value}-tab`}
-              key={tab.value}
-              onClick={() => setActiveTab(tab.value)}
-              onKeyDown={(e) => handleTabKeyDown(e, idx)}
-              role="tab"
-              tabIndex={isSelected ? 0 : -1}
-              type="button"
-            >
-              {tab.label}
-            </button>
+              <button
+                aria-controls={`${uid}-${tab.value}-panel`}
+                aria-selected={isSelected}
+                className={cn(
+                  "whitespace-nowrap pb-0.5 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus",
+                  isSelected
+                    ? "border-b-2 border-brand text-text"
+                    : "text-muted hover:text-text"
+                )}
+                id={`${uid}-${tab.value}-tab`}
+                onClick={() => setActiveTab(tab.value)}
+                onKeyDown={(e) => handleTabKeyDown(e, idx)}
+                role="tab"
+                tabIndex={isSelected ? 0 : -1}
+                type="button"
+              >
+                {tab.label}
+              </button>
+            </Fragment>
           );
         })}
+        </div>
+        <CinemaIndicator name={cinemaName} />
       </div>
 
       {/* Tab panels */}

--- a/frontend/src/components/movies/home-schedule.test.ts
+++ b/frontend/src/components/movies/home-schedule.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CatalogMovie, CatalogSession } from "@/types/catalog";
+
+import { HomeSchedule, SessionSchedule } from "./HomeSchedule";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const room = {
+  capacity: 80,
+  description: null,
+  display_name: "Sala VIP Prime",
+  experience_type: "vip" as const,
+  id: "room-vip",
+  name: "Sala VIP",
+};
+
+const nowShowingMovie: CatalogMovie = {
+  duration_minutes: 120,
+  genres: [{ id: "genre-1", name: "Aventura" }],
+  id: "movie-now",
+  is_featured: true,
+  poster_url: "https://cdn.example.com/now.jpg",
+  status: "em_cartaz",
+  title: "Em Cartaz Agora",
+};
+
+const upcomingMovie: CatalogMovie = {
+  duration_minutes: 95,
+  genres: [{ id: "genre-2", name: "Drama" }],
+  id: "movie-soon",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/soon.jpg",
+  status: "em_breve",
+  title: "Em Breve nas Telas",
+};
+
+const sessionA: CatalogSession = {
+  audio_format: "legendado",
+  base_price: "42.00",
+  end_time: "2026-05-22T20:10:00-03:00",
+  id: "session-a",
+  movie: nowShowingMovie,
+  projection_format: "3d",
+  room,
+  session_type: "preview",
+  start_time: "2026-05-22T18:00:00-03:00",
+};
+
+const emBreveSectionState = (status: "error" | "loading" | "success", movies: CatalogMovie[] = []) => ({
+  errorMessage: status === "error" ? "Falha ao carregar." : undefined,
+  movies,
+  status,
+});
+
+test("HomeSchedule renders both schedule tabs with correct ARIA attributes", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("success", []),
+    })
+  );
+
+  assert.match(html, /role="tablist"/);
+  assert.match(html, /role="tab"/);
+  assert.match(html, /role="tabpanel"/);
+  assert.match(html, /Em cartaz/);
+  assert.match(html, /Em breve/);
+  assert.match(html, /aria-selected="true"/);
+  assert.match(html, /aria-selected="false"/);
+});
+
+test("HomeSchedule default active tab is Em cartaz", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("success", [upcomingMovie]),
+    })
+  );
+
+  // Em cartaz tab selected, Em breve not
+  const emCartazTabMatch = html.match(/aria-selected="true"[^>]*>Em cartaz/);
+  assert.ok(emCartazTabMatch || html.includes('"em_cartaz-tab"') && html.includes('aria-selected="true"'));
+
+  // Em breve panel is hidden
+  assert.match(html, /hidden/);
+});
+
+test("HomeSchedule shows date selector in Em cartaz panel", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("success", []),
+    })
+  );
+
+  assert.match(html, /Selecionar data/);
+  assert.match(html, /aria-pressed/);
+});
+
+test("HomeSchedule shows Em cartaz tab loading sessions state on mount", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("success", []),
+    })
+  );
+
+  assert.match(html, /Carregando programação/);
+});
+
+test("HomeSchedule Em breve panel shows movies carousel when upcoming is success", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("success", [upcomingMovie]),
+    })
+  );
+
+  assert.match(html, /Em Breve nas Telas/);
+});
+
+test("HomeSchedule Em breve panel shows empty state when upcoming has no movies", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("success", []),
+    })
+  );
+
+  assert.match(html, /Nenhum filme em breve/);
+  assert.match(html, /Ainda não há filmes em breve/);
+});
+
+test("HomeSchedule Em breve panel shows loading state", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      upcoming: emBreveSectionState("loading"),
+    })
+  );
+
+  assert.match(html, /Carregando filmes em breve/);
+});
+
+test("HomeSchedule Em breve panel shows error state with retry button", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      onRetryUpcoming: () => undefined,
+      upcoming: emBreveSectionState("error"),
+    })
+  );
+
+  assert.match(html, /Em breve indisponível/);
+  assert.match(html, /Tentar novamente/);
+});
+
+test("HomeSchedule shows cinema name", () => {
+  const html = renderToStaticMarkup(
+    createElement(HomeSchedule, {
+      cinemaName: "Cinema Test",
+      upcoming: emBreveSectionState("success", []),
+    })
+  );
+
+  assert.match(html, /Cinema Test/);
+});
+
+test("SessionSchedule renders loading state", () => {
+  const html = renderToStaticMarkup(
+    createElement(SessionSchedule, {
+      date: "2026-05-22",
+      onRetry: () => undefined,
+      state: { sessions: [], status: "loading" },
+    })
+  );
+
+  assert.match(html, /Carregando programação/);
+  assert.match(html, /22 de maio de 2026/);
+});
+
+test("SessionSchedule renders error state with retry", () => {
+  const html = renderToStaticMarkup(
+    createElement(SessionSchedule, {
+      date: "2026-05-22",
+      onRetry: () => undefined,
+      state: {
+        errorMessage: "Falha de conexão.",
+        sessions: [],
+        status: "error",
+      },
+    })
+  );
+
+  assert.match(html, /Programação indisponível/);
+  assert.match(html, /Falha de conexão/);
+  assert.match(html, /Tentar novamente/);
+});
+
+test("SessionSchedule renders empty state for date with no sessions", () => {
+  const html = renderToStaticMarkup(
+    createElement(SessionSchedule, {
+      date: "2026-05-22",
+      onRetry: () => undefined,
+      state: { sessions: [], status: "success" },
+    })
+  );
+
+  assert.match(html, /Nenhuma sessão nesta data/);
+  assert.match(html, /22 de maio de 2026/);
+});
+
+test("SessionSchedule renders movies grouped by movie with session buttons", () => {
+  const html = renderToStaticMarkup(
+    createElement(SessionSchedule, {
+      date: "2026-05-22",
+      onRetry: () => undefined,
+      state: { sessions: [sessionA], status: "success" },
+    })
+  );
+
+  assert.match(html, /Em Cartaz Agora/);
+  assert.match(html, /Aventura/);
+  assert.match(html, /Sala VIP Prime/);
+  assert.match(html, /18:00/);
+  assert.match(html, /42,00/);
+  assert.match(html, new RegExp(`href="/sessions/session-a/seats"`));
+});
+
+test("SessionSchedule session buttons include accessible aria-label with badges", () => {
+  const html = renderToStaticMarkup(
+    createElement(SessionSchedule, {
+      date: "2026-05-22",
+      onRetry: () => undefined,
+      state: { sessions: [sessionA], status: "success" },
+    })
+  );
+
+  assert.match(html, /formatos VIP, 3D, Legendado, Pré-estreia/);
+  assert.match(html, /Selecionar sessão das 18:00/);
+});
+
+test("SessionSchedule filters out em_breve movies even if sessions slip through", () => {
+  const comingSoonSession: CatalogSession = {
+    ...sessionA,
+    id: "session-coming-soon",
+    movie: { ...nowShowingMovie, id: "movie-soon-id", status: "em_breve", title: "Futuro Filme" },
+  };
+
+  const html = renderToStaticMarkup(
+    createElement(SessionSchedule, {
+      date: "2026-05-22",
+      onRetry: () => undefined,
+      state: { sessions: [comingSoonSession], status: "success" },
+    })
+  );
+
+  assert.match(html, /Nenhuma sessão nesta data/);
+  assert.doesNotMatch(html, /Futuro Filme/);
+  assert.doesNotMatch(html, new RegExp(`href="/sessions/session-coming-soon/seats"`));
+});

--- a/frontend/src/components/movies/home-schedule.test.ts
+++ b/frontend/src/components/movies/home-schedule.test.ts
@@ -218,8 +218,7 @@ test("SessionSchedule renders movies grouped by movie with session buttons", () 
   );
 
   assert.match(html, /Em Cartaz Agora/);
-  assert.match(html, /Aventura/);
-  assert.match(html, /Sala VIP Prime/);
+  assert.match(html, /VIP/);
   assert.match(html, /18:00/);
   assert.match(html, /42,00/);
   assert.match(html, new RegExp(`href="/sessions/session-a/seats"`));

--- a/frontend/src/components/movies/index.ts
+++ b/frontend/src/components/movies/index.ts
@@ -1,4 +1,5 @@
 export { FeaturedMovieBanner } from "./FeaturedMovieBanner";
+export { HomeSchedule } from "./HomeSchedule";
 export { MovieDetail, MovieDetailView, type MovieDetailState } from "./MovieDetail";
 export { MovieCard } from "./MovieCard";
 export { MovieCarousel } from "./MovieCarousel";

--- a/frontend/src/components/movies/movie-detail.test.ts
+++ b/frontend/src/components/movies/movie-detail.test.ts
@@ -107,6 +107,40 @@ test("movie detail omits release date when unavailable", () => {
   assert.doesNotMatch(html, /Estreia indisponível/);
 });
 
+test("em_breve movie detail shows coming-soon notice and hides session selector", () => {
+  const comingSoonMovie: CatalogMovieDetail = {
+    ...movie,
+    id: "movie-upcoming",
+    release_date: "2026-08-01",
+    status: "em_breve",
+    title: "Ainda Por Vir",
+  };
+
+  const html = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      state: { movie: comingSoonMovie, status: "success" },
+    })
+  );
+
+  assert.match(html, /Ainda Por Vir/);
+  assert.match(html, /Em breve nas telas/);
+  assert.doesNotMatch(html, /Sessões/);
+  assert.doesNotMatch(html, /Carregando sessões/);
+  assert.doesNotMatch(html, /Selecionar sessão/);
+});
+
+test("em_cartaz movie detail still shows session selector", () => {
+  const html = renderToStaticMarkup(
+    createElement(MovieDetailView, {
+      state: { movie, status: "success" },
+    })
+  );
+
+  assert.match(html, /Sessões/);
+  assert.match(html, /Carregando sessões/);
+  assert.doesNotMatch(html, /Em breve nas telas/);
+});
+
 test("movie detail renders stable loading state", () => {
   const html = renderToStaticMarkup(
     createElement(MovieDetailView, {

--- a/frontend/src/components/movies/session-selection.test.ts
+++ b/frontend/src/components/movies/session-selection.test.ts
@@ -13,6 +13,7 @@ import {
   getRoomDisplayName,
   getSessionBadges,
   getSessionSeatsHref,
+  groupSessionsByMovie,
   groupSessionsByRoom,
 } from "./session-selection";
 
@@ -146,4 +147,54 @@ test("room display names and session badges use optional metadata", () => {
 
 test("session navigation targets seat selection route", () => {
   assert.equal(getSessionSeatsHref("session-123"), "/sessions/session-123/seats");
+});
+
+const movieB = {
+  duration_minutes: 90,
+  genres: [{ id: "genre-2", name: "Comédia" }],
+  id: "movie-456",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/movie-b.jpg",
+  status: "em_cartaz" as const,
+  title: "O Outro Filme",
+};
+
+test("groupSessionsByMovie groups sessions by movie preserving room order within each movie", () => {
+  const groups = groupSessionsByMovie([
+    session("s1", { capacity: 80, id: "room-1", name: "Sala 1" }, "2026-05-22T18:00:00-03:00"),
+    session("s2", { capacity: 80, id: "room-1", name: "Sala 1" }, "2026-05-22T20:00:00-03:00"),
+    {
+      ...session("s3", { capacity: 48, id: "room-vip", name: "Sala VIP" }, "2026-05-22T19:00:00-03:00"),
+      movie: movieB,
+    },
+    session("s4", { capacity: 48, id: "room-2", name: "Sala 2" }, "2026-05-22T21:00:00-03:00"),
+  ]);
+
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0].movie.id, "movie-123");
+  assert.deepEqual(
+    groups[0].roomGroups.map((g) => g.roomId),
+    ["room-1", "room-2"]
+  );
+  assert.deepEqual(
+    groups[0].roomGroups[0].sessions.map((s) => s.id),
+    ["s1", "s2"]
+  );
+  assert.equal(groups[1].movie.id, "movie-456");
+  assert.equal(groups[1].roomGroups.length, 1);
+  assert.equal(groups[1].roomGroups[0].sessions[0].id, "s3");
+});
+
+test("groupSessionsByMovie returns empty array for empty input", () => {
+  assert.deepEqual(groupSessionsByMovie([]), []);
+});
+
+test("groupSessionsByMovie returns single group for single movie", () => {
+  const groups = groupSessionsByMovie([
+    session("s1", { capacity: 80, id: "room-1", name: "Sala 1" }, "2026-05-22T18:00:00-03:00"),
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].movie.id, "movie-123");
+  assert.equal(groups[0].roomGroups[0].sessions[0].id, "s1");
 });

--- a/frontend/src/components/movies/session-selection.ts
+++ b/frontend/src/components/movies/session-selection.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogAudioFormat,
+  CatalogMovie,
   CatalogProjectionFormat,
   CatalogRoomExperienceType,
   CatalogRoomSummary,
@@ -133,6 +134,31 @@ export function getSessionBadges(session: CatalogSession): SessionBadge[] {
 
 export function getSessionSeatsHref(sessionId: string) {
   return `/sessions/${sessionId}/seats`;
+}
+
+export type MovieSessionGroup = {
+  movie: CatalogMovie;
+  roomGroups: SessionRoomGroup[];
+};
+
+export function groupSessionsByMovie(
+  sessions: CatalogSession[]
+): MovieSessionGroup[] {
+  const movieMap = new Map<string, { movie: CatalogMovie; sessions: CatalogSession[] }>();
+
+  for (const s of sessions) {
+    const existing = movieMap.get(s.movie.id);
+    if (existing) {
+      existing.sessions.push(s);
+    } else {
+      movieMap.set(s.movie.id, { movie: s.movie, sessions: [s] });
+    }
+  }
+
+  return Array.from(movieMap.values()).map(({ movie, sessions: movieSessions }) => ({
+    movie,
+    roomGroups: groupSessionsByRoom(movieSessions),
+  }));
 }
 
 export function groupSessionsByRoom(

--- a/frontend/src/components/movies/session-selection.ts
+++ b/frontend/src/components/movies/session-selection.ts
@@ -203,6 +203,75 @@ function compareSessionsByRoomAndTime(
   );
 }
 
+const roomExperienceGroupLabels: Record<CatalogRoomExperienceType, string> = {
+  "": "Sala",
+  imax: "IMAX",
+  premium: "Premium",
+  standard: "Sala Tradicional",
+  vip: "VIP",
+};
+
+export function getRoomExperienceLabel(
+  type: CatalogRoomExperienceType | null | undefined
+): string {
+  if (!type) return "";
+  return roomExperienceLabels[type] ?? "";
+}
+
+export type ExperienceSessionGroup = {
+  experienceType: CatalogRoomExperienceType;
+  label: string;
+  sessions: CatalogSession[];
+};
+
+export function groupSessionsByExperienceType(
+  sessions: CatalogSession[]
+): ExperienceSessionGroup[] {
+  const groups = new Map<string, ExperienceSessionGroup>();
+
+  const sorted = [...sessions].sort(
+    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+  );
+
+  for (const session of sorted) {
+    const expType = (session.room.experience_type ?? "") as CatalogRoomExperienceType;
+    const existing = groups.get(expType);
+    if (existing) {
+      existing.sessions.push(session);
+    } else {
+      groups.set(expType, {
+        experienceType: expType,
+        label: roomExperienceGroupLabels[expType] ?? "Sala",
+        sessions: [session],
+      });
+    }
+  }
+
+  return Array.from(groups.values()).sort((a, b) =>
+    a.label.localeCompare(b.label, ptBrLocale)
+  );
+}
+
+export function formatScheduleDateHeading(
+  dateValue: string,
+  today: Date = new Date()
+): string {
+  const todayValue = formatDateForSessionQuery(today);
+  const tomorrowDate = new Date(today);
+  tomorrowDate.setDate(today.getDate() + 1);
+  const tomorrowValue = formatDateForSessionQuery(tomorrowDate);
+
+  if (dateValue === todayValue) return "Hoje";
+  if (dateValue === tomorrowValue) return "Amanhã";
+
+  return new Intl.DateTimeFormat(ptBrLocale, {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    weekday: "long",
+  }).format(new Date(`${dateValue}T00:00:00Z`));
+}
+
 function addDaysToDateValue(dateValue: string, days: number) {
   const [year, month, day] = parseDateParts(dateValue);
   const date = new Date(Date.UTC(year, month - 1, day + days, 12, 0, 0));

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -18,15 +18,20 @@ export type CatalogGenre = {
   name: string;
 };
 
+export type CatalogMovieAgeRating = "" | "L" | "10" | "12" | "14" | "16" | "18";
+
 export type CatalogMovie = {
-  id: string;
-  title: string;
-  genres: CatalogGenre[];
+  age_rating?: CatalogMovieAgeRating | null;
+  cast?: string[] | null;
+  director?: string | null;
   duration_minutes: number;
-  release_date?: string | null;
-  poster_url: string;
-  status: MovieStatus;
+  genres: CatalogGenre[];
+  id: string;
   is_featured: boolean;
+  poster_url: string;
+  release_date?: string | null;
+  status: MovieStatus;
+  title: string;
 };
 
 export type CatalogMovieDetail = CatalogMovie & {


### PR DESCRIPTION
## Objective

Build a home schedule section with tabs for now-showing and coming-soon movies, complete with date navigation, grouped session buttons, and status-safe flows so that `em_breve` movies are never purchasable from any entry point.

## What was done

### 1. Schedule tabs

Added a two-tab home schedule section below the movie carousel:

- **Em cartaz** — displays sessions for the selected date grouped by experience type, with purchase buttons that navigate to seat selection.
- **Em breve** — displays upcoming movies in an info-only carousel with no purchase CTAs or session links.

### 2. Date navigation

Replaced the flat date button row with a carousel that has:

- Prev / Next arrow buttons to step one day at a time.
- A calendar icon button that opens the native date picker.
- Day-of-week + day-number cards as the primary selector.

### 3. Session grouping by experience type

Replaced per-room session groups with experience-type groups (Sala Tradicional, VIP, IMAX, Premium). Each group header shows the experience label and any format badges. Session buttons show only the start time, styled as filled brand-color pills.

### 4. Session badges

Session buttons and group headers surface room and session badges (VIP, subtitled, dubbed, 3D, preview, premiere) using the metadata tracked in #162.

### 5. Status guard

`em_breve` movies are blocked from the purchase flow at two points:

- `SessionSchedule` filters out any sessions whose movie has `status === "em_breve"` before rendering buttons.
- `MovieDetail` renders `MovieComingSoonNotice` instead of `MovieSessionSelector` when `movie.status === "em_breve"`.

### 6. Movie metadata fields (backend)

Added `age_rating`, `director`, and `cast` (via `CastMember` inline model) to `Movie`:

- Two migrations: `0007_movie_age_rating` and `0008_movie_director_cast`.
- All three fields exposed in `MovieReadSerializer`, `MovieWriteSerializer`, and `MovieSummarySerializer`.
- `cast` returned as a list of ordered names via `SerializerMethodField`.
- `prefetch_related("movie__cast")` added to all session querysets.
- Admin updated with `CastMemberInline`, fieldsets, and list filters.

### 7. Tab style refinement

Both `HomeSchedule` and `TabbedMovieCatalog` tabs were updated from a pill/card style to an underline indicator matching the target design.

### 8. Data states

Loading, empty, and error states are handled independently for each tab:

- Now showing: loading spinner, error message with retry, and empty state per date.
- Coming soon: error banner with retry; loading handled by `MovieCarousel`.

### 9. Test coverage

- `SessionSchedule filters out em_breve movies even if sessions slip through` — explicit guard test.
- Updated session rendering assertions to match the new experience-type grouping.

## How to test

### Automated

```bash
docker compose exec web pytest -q
cd frontend && npm test
```

### Manual

1. Start the stack:

```bash
docker compose up --build
```

2. Open the home page and verify:
   - "Em cartaz" tab shows date carousel and session groups for the selected day.
   - Clicking a session button navigates to the seat-selection page.
   - "Em breve" tab shows a movie carousel with no session buttons.
   - Prev/Next arrows and the calendar icon update the selected date correctly.

3. Open a movie detail page for an `em_breve` movie and verify no session selector or purchase CTA appears.

## Expected result

- Now-showing sessions are grouped by experience type with purchase buttons.
- Coming-soon movies are info-only with no purchase path.
- `em_breve` movies are blocked at both home schedule and detail page.
- Age rating, director, and cast appear on home schedule cards and movie detail.
- All data states (loading, error, empty) are handled per tab.

closes #183