### PR TITLE
feat: expose admin capabilities to the frontend

### DIFF
--- a/backend/tests/integration/test_current_user.py
+++ b/backend/tests/integration/test_current_user.py
@@ -40,6 +40,30 @@ class TestCurrentUserView:
         assert response.data["username"] == user.username
         assert "created_at" in response.data
 
+    def test_current_user_returns_is_staff_false_for_regular_user(self, api_client, user):
+        refresh = RefreshToken.for_user(user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(refresh.access_token)}")
+
+        response = api_client.get("/api/v1/users/me/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_staff"] is False
+
+    def test_current_user_returns_is_staff_true_for_admin_user(self, api_client):
+        admin = User.objects.create_user(
+            email="admin@gmail.com",
+            username="adminuser",
+            password="Soueu123*A",
+            is_staff=True,
+        )
+        refresh = RefreshToken.for_user(admin)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(refresh.access_token)}")
+
+        response = api_client.get("/api/v1/users/me/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_staff"] is True
+
     def test_current_user_returns_401_with_invalid_token(self, api_client):
         api_client.credentials(HTTP_AUTHORIZATION="Bearer invalid-token")
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -40,6 +40,7 @@ class CurrentUserResponseSerializer(serializers.Serializer):
     email = serializers.EmailField()
     username = serializers.CharField()
     created_at = serializers.DateTimeField()
+    is_staff = serializers.BooleanField()
 
 
 @extend_schema_view(
@@ -129,6 +130,7 @@ class CurrentUserView(APIView):
                 "email": request.user.email,
                 "username": request.user.username,
                 "created_at": request.user.created_at,
+                "is_staff": request.user.is_staff,
             },
             status=status.HTTP_200_OK,
         )

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -27,6 +27,7 @@ export type CurrentUserResponse = {
   created_at: string;
   email: string;
   id: string;
+  is_staff: boolean;
   username: string;
 };
 

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,16 @@
+import { AdminRoute } from "@/components/auth/AdminRoute";
+import { PageSection } from "@/components/ui/PageSection";
+
+export default function AdminPage() {
+  return (
+    <AdminRoute>
+      <PageSection
+        description="Gerencie usuários, sessões e configurações do sistema."
+        eyebrow="Administração"
+        title="Painel Admin"
+      >
+        <p className="text-white/60">Em construção.</p>
+      </PageSection>
+    </AdminRoute>
+  );
+}

--- a/frontend/src/components/auth/AdminRoute.tsx
+++ b/frontend/src/components/auth/AdminRoute.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { buildLoginRedirectUrl } from "@/api/client";
+import { StateMessage } from "@/components/ui/StateMessage";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getBrowserCurrentPath,
+  getAdminRouteDecision,
+} from "./route-guards";
+
+type AdminRouteProps = {
+  children: ReactNode;
+};
+
+export function AdminRoute({ children }: AdminRouteProps) {
+  const router = useRouter();
+  const { isAuthenticated, status, user } = useAuth();
+  const isAdmin = Boolean(user?.is_staff);
+  const decision = getAdminRouteDecision({ isAdmin, isAuthenticated, status });
+
+  useEffect(() => {
+    if (decision.redirectToLogin) {
+      router.replace(buildLoginRedirectUrl(getBrowserCurrentPath()));
+    }
+  }, [decision.redirectToLogin, router]);
+
+  if (decision.renderContent) {
+    return children;
+  }
+
+  if (decision.redirectToForbidden) {
+    return (
+      <StateMessage tone="error" title="Acesso restrito">
+        Você não tem permissão para acessar esta página.
+      </StateMessage>
+    );
+  }
+
+  return (
+    <StateMessage tone="loading" title="Verificando acesso">
+      Aguarde enquanto confirmamos sua sessão.
+    </StateMessage>
+  );
+}

--- a/frontend/src/components/auth/route-guards.test.ts
+++ b/frontend/src/components/auth/route-guards.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 
 import {
   buildCurrentInternalPath,
+  getAdminRouteDecision,
   getGuardedActionDecision,
   getProtectedRouteDecision,
+  isAdminRoute,
   isProtectedRoute,
 } from "./route-guards";
 
@@ -100,6 +102,41 @@ test("guarded actions wait during auth resolution and allow authenticated users"
       loginUrl: null,
       pending: false,
     }
+  );
+});
+
+test("admin route list matches /admin and nested paths", () => {
+  assert.equal(isAdminRoute("/admin"), true);
+  assert.equal(isAdminRoute("/admin/users"), true);
+  assert.equal(isAdminRoute("/my-tickets"), false);
+  assert.equal(isAdminRoute("/checkout"), false);
+});
+
+test("admin route decision waits during auth resolution", () => {
+  assert.deepEqual(
+    getAdminRouteDecision({ isAdmin: false, isAuthenticated: false, status: "loading" }),
+    { redirectToForbidden: false, redirectToLogin: false, renderContent: false }
+  );
+});
+
+test("admin route decision redirects unauthenticated users to login", () => {
+  assert.deepEqual(
+    getAdminRouteDecision({ isAdmin: false, isAuthenticated: false, status: "unauthenticated" }),
+    { redirectToForbidden: false, redirectToLogin: true, renderContent: false }
+  );
+});
+
+test("admin route decision shows forbidden for authenticated non-admin users", () => {
+  assert.deepEqual(
+    getAdminRouteDecision({ isAdmin: false, isAuthenticated: true, status: "authenticated" }),
+    { redirectToForbidden: true, redirectToLogin: false, renderContent: false }
+  );
+});
+
+test("admin route decision renders content for authenticated admin users", () => {
+  assert.deepEqual(
+    getAdminRouteDecision({ isAdmin: true, isAuthenticated: true, status: "authenticated" }),
+    { redirectToForbidden: false, redirectToLogin: false, renderContent: true }
   );
 });
 

--- a/frontend/src/components/auth/route-guards.ts
+++ b/frontend/src/components/auth/route-guards.ts
@@ -8,6 +8,8 @@ export const PROTECTED_ROUTES = [
   "/my-tickets",
 ] as const;
 
+export const ADMIN_ROUTES = ["/admin"] as const;
+
 type ProtectedRouteDecision = {
   renderContent: boolean;
   redirectToLogin: boolean;
@@ -35,6 +37,12 @@ type AuthGateInput = {
   status: AuthStatus;
 };
 
+type AdminRouteDecision = {
+  renderContent: boolean;
+  redirectToLogin: boolean;
+  redirectToForbidden: boolean;
+};
+
 type LocationParts = {
   hash?: string;
   pathname: string;
@@ -45,6 +53,32 @@ export function isProtectedRoute(pathname: string) {
   return PROTECTED_ROUTES.some(
     (route) => pathname === route || pathname.startsWith(`${route}/`)
   );
+}
+
+export function isAdminRoute(pathname: string) {
+  return ADMIN_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}
+
+export function getAdminRouteDecision({
+  isAuthenticated,
+  isAdmin,
+  status,
+}: AuthGateInput & { isAdmin: boolean }): AdminRouteDecision {
+  if (status === "loading") {
+    return { redirectToForbidden: false, redirectToLogin: false, renderContent: false };
+  }
+
+  if (!isAuthenticated) {
+    return { redirectToForbidden: false, redirectToLogin: true, renderContent: false };
+  }
+
+  if (!isAdmin) {
+    return { redirectToForbidden: true, redirectToLogin: false, renderContent: false };
+  }
+
+  return { redirectToForbidden: false, redirectToLogin: false, renderContent: true };
 }
 
 export function getProtectedRouteDecision({

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -26,7 +26,8 @@ function isActiveLink(pathname: string, href: string) {
 
 export function AppHeader() {
   const pathname = usePathname();
-  const { isAuthenticated, signOut } = useAuth();
+  const { isAuthenticated, signOut, user } = useAuth();
+  const isAdmin = isAuthenticated && Boolean(user?.is_staff);
 
   return (
     <header className="sticky top-0 z-10 border-b border-white/[0.07] bg-[rgb(10_13_20/0.97)] [backdrop-filter:blur(20px)]">
@@ -101,6 +102,15 @@ export function AppHeader() {
         >
           {isAuthenticated ? (
             <>
+              {isAdmin && (
+                <ButtonLink
+                  className="border-white/[0.16] text-white/80 hover:bg-white/10 hover:border-white/[0.24] hover:text-white"
+                  href="/admin"
+                  variant="ghost"
+                >
+                  Admin
+                </ButtonLink>
+              )}
               <ButtonLink
                 className="border-white/[0.16] text-white/80 hover:bg-white/10 hover:border-white/[0.24] hover:text-white"
                 href="/my-tickets"

--- a/frontend/src/contexts/auth-state.test.ts
+++ b/frontend/src/contexts/auth-state.test.ts
@@ -15,7 +15,16 @@ const user = {
   created_at: "2026-05-21T10:00:00Z",
   email: "orlando@gmail.com",
   id: "user-1",
+  is_staff: false,
   username: "pablo2265",
+};
+
+const adminUser = {
+  ...user,
+  email: "admin@gmail.com",
+  id: "user-admin",
+  is_staff: true,
+  username: "adminuser",
 };
 
 test("auth state starts without persisted tokens or user data", () => {
@@ -83,4 +92,23 @@ test("logout clears tokens and protected identity state", () => {
 
 test("loading status can be represented without exposing protected content", () => {
   assert.equal(startAuthLoading(initialAuthState).status, "loading");
+});
+
+test("admin user carries is_staff true in authenticated state", () => {
+  const state = applyCurrentUser(
+    applyLogin(initialAuthState, { access: "access-token", refresh: "refresh-token" }),
+    adminUser
+  );
+
+  assert.equal(state.user?.is_staff, true);
+  assert.equal(isAuthenticated(state), true);
+});
+
+test("regular user carries is_staff false in authenticated state", () => {
+  const state = applyCurrentUser(
+    applyLogin(initialAuthState, { access: "access-token", refresh: "refresh-token" }),
+    user
+  );
+
+  assert.equal(state.user?.is_staff, false);
 });

--- a/frontend/src/contexts/auth-state.ts
+++ b/frontend/src/contexts/auth-state.ts
@@ -2,6 +2,7 @@ export type AuthUser = {
   created_at?: string;
   email: string;
   id?: string;
+  is_staff?: boolean;
   name?: string;
   username: string;
 };


### PR DESCRIPTION
## Objective

Allow the frontend to know when the authenticated user has administrative access, without relying on client-side assumptions. The backend remains the single source of authorization truth.

## What was done

### 1. Backend — user contract

Extended `/api/v1/users/me/` to include `is_staff` in the response payload:

- Added `is_staff` to `CurrentUserResponseSerializer`.
- Added `is_staff` to the `CurrentUserView` response dict.

This exposes administrative capability in a documented, safe way — `is_staff` is a read-only field derived from the stored user record.

### 2. Frontend — auth state

Propagated `is_staff` through the entire auth pipeline:

- Added `is_staff: boolean` to `CurrentUserResponse` in `api/auth.ts`.
- Added `is_staff?: boolean` to `AuthUser` in `contexts/auth-state.ts`.

The field flows automatically into `AuthContext` and is available to any component via `useAuth().user?.is_staff`.

### 3. Frontend — conditional admin link

Updated `AppHeader` to show an "Admin" navigation link exclusively for authenticated users whose `is_staff` flag is `true`.

Non-admins and unauthenticated users never see the link.

### 4. Frontend — admin route guard

Added route protection for `/admin` pages:

- `ADMIN_ROUTES` constant and `isAdminRoute()` helper in `route-guards.ts`.
- `getAdminRouteDecision()` function — returns one of three outcomes: wait (loading), redirect to login (unauthenticated), show forbidden message (authenticated non-admin), or render content (admin).
- `AdminRoute` component — wraps admin pages with this guard, shows a friendly "Acesso restrito" error for non-admins instead of silently redirecting.
- `/app/admin/page.tsx` — placeholder admin page using `AdminRoute`.

### 5. Tests

**Backend** (`tests/integration/test_current_user.py`):
- `test_current_user_returns_is_staff_false_for_regular_user`
- `test_current_user_returns_is_staff_true_for_admin_user`

**Frontend** (`contexts/auth-state.test.ts`):
- `admin user carries is_staff true in authenticated state`
- `regular user carries is_staff false in authenticated state`

**Frontend** (`components/auth/route-guards.test.ts`):
- `admin route list matches /admin and nested paths`
- `admin route decision waits during auth resolution`
- `admin route decision redirects unauthenticated users to login`
- `admin route decision shows forbidden for authenticated non-admin users`
- `admin route decision renders content for authenticated admin users`

## How to test

### Automated

```bash
# Backend (requires Docker stack running)
docker compose exec backend pytest -q

# Frontend
cd frontend && npm test
```

### Manual

1. Start the stack:

```bash
docker compose up --build
```

2. Log in as a regular user — verify the "Admin" link does **not** appear in the header.

3. Navigate to `/admin` as a regular user — verify the "Acesso restrito" message is shown.

4. Navigate to `/admin` while unauthenticated — verify redirect to `/login`.

5. Grant admin to a user:

```bash
POST /api/v1/users/<user_id>/admin/   # requires an existing admin token
```

6. Log in as the promoted user — verify the "Admin" link **does** appear in the header.

7. Navigate to `/admin` as the admin user — verify the page renders normally.

## Expected result

- `/api/v1/users/me/` returns `is_staff` for any authenticated user.
- The frontend stores `is_staff` in auth state and never derives it client-side.
- The "Admin" nav link is visible only to staff users.
- Non-admins hitting `/admin` see a friendly access-denied message.
- Unauthenticated users hitting `/admin` are redirected to login.
- Full backend test suite (237 tests) and frontend test suite (218 tests) pass.

closes #164