### PR TITLE
feat: build frontend admin console shell 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ __marimo__/
 node_modules/
 frontend/dist/
 frontend/.next/
+frontend/.next.*/
 frontend/out/
 frontend/.env
 frontend/.env.local

--- a/frontend/e2e/critical-flows.spec.ts
+++ b/frontend/e2e/critical-flows.spec.ts
@@ -285,6 +285,42 @@ test("tabbed catalog switches to Pré-venda panel with ArrowRight key", async ({
   ).toBeVisible();
 });
 
+test("blocks non-admin users from the admin area", async ({ page }) => {
+  await setupMockApi(page, { isAdmin: false });
+
+  await login(page);
+  await page.goto("/admin");
+
+  await expect(
+    page.getByText("Você não tem permissão para acessar esta página.")
+  ).toBeVisible();
+});
+
+test("shows admin dashboard to authenticated admin users", async ({ page }) => {
+  await setupMockApi(page, { isAdmin: true });
+
+  await login(page);
+  await page.goto("/admin");
+
+  await expect(
+    page.getByRole("heading", { name: "Dashboard" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("navigation", { name: "Navegação administrativa" }).first()
+  ).toBeVisible();
+});
+
+test("admin nav links are reachable from the dashboard", async ({ page }) => {
+  await setupMockApi(page, { isAdmin: true });
+
+  await login(page);
+  await page.goto("/admin");
+
+  await page.getByRole("link", { name: "Filmes" }).first().click();
+  await expect(page).toHaveURL("/admin/movies");
+  await expect(page.getByRole("heading", { name: "Filmes" })).toBeVisible();
+});
+
 async function login(page: Page, redirectPath = "/") {
   const loginPath =
     redirectPath === "/"

--- a/frontend/e2e/critical-flows.spec.ts
+++ b/frontend/e2e/critical-flows.spec.ts
@@ -288,8 +288,7 @@ test("tabbed catalog switches to Pré-venda panel with ArrowRight key", async ({
 test("blocks non-admin users from the admin area", async ({ page }) => {
   await setupMockApi(page, { isAdmin: false });
 
-  await login(page);
-  await page.goto("/admin");
+  await login(page, "/admin");
 
   await expect(
     page.getByText("Você não tem permissão para acessar esta página.")
@@ -299,8 +298,7 @@ test("blocks non-admin users from the admin area", async ({ page }) => {
 test("shows admin dashboard to authenticated admin users", async ({ page }) => {
   await setupMockApi(page, { isAdmin: true });
 
-  await login(page);
-  await page.goto("/admin");
+  await login(page, "/admin");
 
   await expect(
     page.getByRole("heading", { name: "Dashboard" })
@@ -313,8 +311,7 @@ test("shows admin dashboard to authenticated admin users", async ({ page }) => {
 test("admin nav links are reachable from the dashboard", async ({ page }) => {
   await setupMockApi(page, { isAdmin: true });
 
-  await login(page);
-  await page.goto("/admin");
+  await login(page, "/admin");
 
   await page.getByRole("link", { name: "Filmes" }).first().click();
   await expect(page).toHaveURL("/admin/movies");

--- a/frontend/e2e/support/api-mocks.ts
+++ b/frontend/e2e/support/api-mocks.ts
@@ -21,11 +21,13 @@ type SessionSeat = {
 
 type MockOptions = {
   failNextReservation?: boolean;
+  isAdmin?: boolean;
   reservationExpiresAt?: string;
 };
 
 export function createMockApiState(options: MockOptions = {}) {
   let failNextReservation = options.failNextReservation ?? false;
+  const isAdmin = options.isAdmin ?? false;
   const reservationExpiresAt =
     options.reservationExpiresAt ??
     new Date(fixedNow.getTime() + 10 * 60 * 1000).toISOString();
@@ -76,6 +78,7 @@ export function createMockApiState(options: MockOptions = {}) {
       handleApiRoute(route, {
         checkoutPayloads,
         failNextReservation: () => failNextReservation,
+        isAdmin,
         markReservationFailureConsumed: () => {
           failNextReservation = false;
         },
@@ -98,6 +101,7 @@ export async function setupMockApi(page: Page, options: MockOptions = {}) {
 
 type ApiRouteState = {
   checkoutPayloads: unknown[];
+  isAdmin: boolean;
   failNextReservation: () => boolean;
   markReservationFailureConsumed: () => void;
   reservationExpiresAt: string;
@@ -132,8 +136,13 @@ async function handleApiRoute(route: Route, state: ApiRouteState) {
       created_at: fixedNow.toISOString(),
       email: "ana@example.com",
       id: "user-1",
+      is_staff: state.isAdmin,
       username: "ana",
     });
+  }
+
+  if (method === "GET" && url.pathname === "/api/v1/catalog/rooms/") {
+    return json(route, paginated([{ id: "room-1", name: "Sala 1" }]));
   }
 
   if (method === "GET" && url.pathname === "/api/v1/catalog/movies/") {

--- a/frontend/e2e/support/api-mocks.ts
+++ b/frontend/e2e/support/api-mocks.ts
@@ -131,6 +131,10 @@ async function handleApiRoute(route: Route, state: ApiRouteState) {
     });
   }
 
+  if (method === "POST" && url.pathname === "/api/v1/auth/token/refresh/") {
+    return json(route, { access: "access-token-e2e" });
+  }
+
   if (method === "GET" && url.pathname === "/api/v1/users/me/") {
     return json(route, {
       created_at: fixedNow.toISOString(),

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   {
-    ignores: ["dist/**", ".next/**", "out/**", "node_modules/**", "next-env.d.ts"],
+    ignores: ["dist/**", ".next/**", ".next.*/**", "out/**", "node_modules/**", "next-env.d.ts"],
   },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,0 +1,39 @@
+import { apiRequest, type PaginatedResponse } from "./client";
+
+export type AdminSummary = {
+  movieCount: number;
+  nowShowingCount: number;
+  roomCount: number;
+  sessionsTodayCount: number;
+};
+
+export const adminApi = {
+  async getSummary(): Promise<AdminSummary> {
+    const today = new Date().toISOString().split("T")[0];
+
+    const [allMovies, nowShowing, rooms, sessionsToday] = await Promise.all([
+      apiRequest<PaginatedResponse<{ id: string }>>("/api/v1/catalog/movies/?page_size=1", {
+        auth: "required",
+      }),
+      apiRequest<PaginatedResponse<{ id: string }>>(
+        "/api/v1/catalog/movies/?status=em_cartaz&page_size=1",
+        { auth: "required" }
+      ),
+      apiRequest<PaginatedResponse<{ id: string }>>(
+        "/api/v1/catalog/rooms/?page_size=1",
+        { auth: "required" }
+      ),
+      apiRequest<PaginatedResponse<{ id: string }>>(
+        `/api/v1/catalog/sessions/?date=${today}&page_size=1`,
+        { auth: "required" }
+      ),
+    ]);
+
+    return {
+      movieCount: allMovies.count,
+      nowShowingCount: nowShowing.count,
+      roomCount: rooms.count,
+      sessionsTodayCount: sessionsToday.count,
+    };
+  },
+};

--- a/frontend/src/app/admin/genres/page.tsx
+++ b/frontend/src/app/admin/genres/page.tsx
@@ -1,0 +1,21 @@
+import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminGenresPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="#" size="sm" variant="primary">
+            Novo gênero
+          </ButtonLink>
+        }
+        title="Gêneros"
+      />
+      <AdminEmptyState
+        description="O gerenciamento de gêneros será implementado em breve."
+        title="Nenhum gênero cadastrado"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { AdminRoute } from "@/components/auth/AdminRoute";
+import { AdminShell } from "@/components/admin/AdminShell";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AdminRoute>
+      <AdminShell>{children}</AdminShell>
+    </AdminRoute>
+  );
+}

--- a/frontend/src/app/admin/movies/page.tsx
+++ b/frontend/src/app/admin/movies/page.tsx
@@ -1,0 +1,21 @@
+import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminMoviesPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="#" size="sm" variant="primary">
+            Novo filme
+          </ButtonLink>
+        }
+        title="Filmes"
+      />
+      <AdminEmptyState
+        description="O gerenciamento de filmes será implementado em breve."
+        title="Nenhum filme cadastrado"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,16 +1,131 @@
-import { AdminRoute } from "@/components/auth/AdminRoute";
-import { PageSection } from "@/components/ui/PageSection";
+"use client";
 
-export default function AdminPage() {
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Building2, CalendarDays, Film, TrendingUp } from "lucide-react";
+
+import { adminApi, type AdminSummary } from "@/api/admin";
+
+type StatCardProps = {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  loading: boolean;
+  value: number | null;
+};
+
+function StatCard({ href, icon, label, loading, value }: StatCardProps) {
   return (
-    <AdminRoute>
-      <PageSection
-        description="Gerencie usuários, sessões e configurações do sistema."
-        eyebrow="Administração"
-        title="Painel Admin"
-      >
-        <p className="text-white/60">Em construção.</p>
-      </PageSection>
-    </AdminRoute>
+    <Link
+      className="group flex flex-col gap-3 rounded-[10px] border border-white/[0.07] bg-surface-muted p-5 transition hover:border-white/[0.14] hover:bg-white/[0.06]"
+      href={href}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-[750] uppercase tracking-wider text-white/40">
+          {label}
+        </span>
+        <span aria-hidden="true" className="text-white/30 group-hover:text-white/50">
+          {icon}
+        </span>
+      </div>
+      {loading ? (
+        <div className="h-8 w-16 animate-pulse rounded bg-white/[0.06]" />
+      ) : (
+        <span className="text-3xl font-[850] tabular-nums text-white">
+          {value ?? "—"}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+export default function AdminDashboardPage() {
+  const [summary, setSummary] = useState<AdminSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    adminApi
+      .getSummary()
+      .then(setSummary)
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="grid gap-8">
+      <div>
+        <h1 className="text-2xl font-[850] text-white">Dashboard</h1>
+        <p className="mt-1 text-sm text-white/50">
+          Visão geral do sistema CinePrime.
+        </p>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-error" role="alert">
+          Não foi possível carregar os contadores. Recarregue a página para tentar novamente.
+        </p>
+      ) : null}
+
+      <section aria-label="Resumo do sistema">
+        <h2 className="mb-4 text-xs font-[750] uppercase tracking-wider text-white/40">
+          Resumo
+        </h2>
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <StatCard
+            href="/admin/movies"
+            icon={<Film size={18} />}
+            label="Filmes"
+            loading={loading}
+            value={summary?.movieCount ?? null}
+          />
+          <StatCard
+            href="/admin/movies"
+            icon={<TrendingUp size={18} />}
+            label="Em cartaz"
+            loading={loading}
+            value={summary?.nowShowingCount ?? null}
+          />
+          <StatCard
+            href="/admin/sessions"
+            icon={<CalendarDays size={18} />}
+            label="Sessões hoje"
+            loading={loading}
+            value={summary?.sessionsTodayCount ?? null}
+          />
+          <StatCard
+            href="/admin/rooms"
+            icon={<Building2 size={18} />}
+            label="Salas"
+            loading={loading}
+            value={summary?.roomCount ?? null}
+          />
+        </div>
+      </section>
+
+      <section aria-label="Atalhos de gerenciamento">
+        <h2 className="mb-4 text-xs font-[750] uppercase tracking-wider text-white/40">
+          Gerenciamento
+        </h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {[
+            { href: "/admin/movies", label: "Filmes" },
+            { href: "/admin/genres", label: "Gêneros" },
+            { href: "/admin/rooms", label: "Salas" },
+            { href: "/admin/seat-rows", label: "Fileiras e Assentos" },
+            { href: "/admin/sessions", label: "Sessões" },
+            { href: "/admin/users", label: "Administradores" },
+          ].map((item) => (
+            <Link
+              className="rounded-[8px] border border-white/[0.07] px-4 py-3 text-sm font-bold text-white/60 transition hover:border-white/[0.14] hover:bg-white/[0.05] hover:text-white"
+              href={item.href}
+              key={item.href}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/app/admin/rooms/page.tsx
+++ b/frontend/src/app/admin/rooms/page.tsx
@@ -1,0 +1,21 @@
+import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminRoomsPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="#" size="sm" variant="primary">
+            Nova sala
+          </ButtonLink>
+        }
+        title="Salas"
+      />
+      <AdminEmptyState
+        description="O gerenciamento de salas será implementado em breve."
+        title="Nenhuma sala cadastrada"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/seat-rows/page.tsx
+++ b/frontend/src/app/admin/seat-rows/page.tsx
@@ -1,0 +1,21 @@
+import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminSeatRowsPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="#" size="sm" variant="primary">
+            Nova fileira
+          </ButtonLink>
+        }
+        title="Fileiras e Assentos"
+      />
+      <AdminEmptyState
+        description="O gerenciamento de fileiras e assentos será implementado em breve."
+        title="Nenhuma fileira cadastrada"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/sessions/page.tsx
+++ b/frontend/src/app/admin/sessions/page.tsx
@@ -1,0 +1,21 @@
+import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminSessionsPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="#" size="sm" variant="primary">
+            Nova sessão
+          </ButtonLink>
+        }
+        title="Sessões"
+      />
+      <AdminEmptyState
+        description="O gerenciamento de sessões será implementado em breve."
+        title="Nenhuma sessão cadastrada"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,13 @@
+import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+
+export default function AdminUsersPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar title="Administradores" />
+      <AdminEmptyState
+        description="O gerenciamento de administradores será implementado em breve."
+        title="Nenhum administrador além de você"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminConfirmDialog.tsx
+++ b/frontend/src/components/admin/AdminConfirmDialog.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/components/ui/classNames";
+
+type ConfirmTone = "danger" | "default";
+
+type AdminConfirmDialogProps = {
+  cancelLabel?: string;
+  confirmLabel?: string;
+  description?: string;
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  title: string;
+  tone?: ConfirmTone;
+};
+
+export function AdminConfirmDialog({
+  cancelLabel = "Cancelar",
+  confirmLabel = "Confirmar",
+  description,
+  isOpen,
+  onCancel,
+  onConfirm,
+  title,
+  tone = "default",
+}: AdminConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+
+    if (!dialog) return;
+
+    if (isOpen) {
+      dialog.showModal();
+    } else {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <dialog
+      aria-labelledby="confirm-dialog-title"
+      className={cn(
+        "w-full max-w-sm rounded-[10px] border border-white/[0.10]",
+        "bg-[#1a2030] p-6 text-white shadow-xl backdrop:bg-black/60",
+        "open:flex open:flex-col open:gap-4"
+      )}
+      onCancel={onCancel}
+      ref={dialogRef}
+    >
+      <div className="flex flex-col gap-1.5">
+        <strong className="text-base font-[850]" id="confirm-dialog-title">
+          {title}
+        </strong>
+        {description ? (
+          <p className="text-sm text-white/60">{description}</p>
+        ) : null}
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button onClick={onCancel} variant="ghost">
+          {cancelLabel}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          variant={tone === "danger" ? "danger" : "primary"}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/components/admin/AdminEmptyState.tsx
+++ b/frontend/src/components/admin/AdminEmptyState.tsx
@@ -1,0 +1,23 @@
+import React, { type ReactNode } from "react";
+
+type AdminEmptyStateProps = {
+  action?: ReactNode;
+  description?: string;
+  title: string;
+};
+
+export function AdminEmptyState({
+  action,
+  description,
+  title,
+}: AdminEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-[8px] border border-dashed border-white/[0.10] py-16 text-center">
+      <p className="text-sm font-bold text-white/60">{title}</p>
+      {description ? (
+        <p className="max-w-xs text-xs text-white/40">{description}</p>
+      ) : null}
+      {action ? <div className="mt-1">{action}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminShell.tsx
+++ b/frontend/src/components/admin/AdminShell.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import {
+  Building2,
+  CalendarDays,
+  Film,
+  Grid3x3,
+  LayoutDashboard,
+  Tag,
+  Users,
+} from "lucide-react";
+
+import { cn } from "@/components/ui/classNames";
+import {
+  ADMIN_NAV_LINKS,
+  isAdminNavItemActive,
+} from "./admin-nav-utils";
+
+export { isAdminNavItemActive } from "./admin-nav-utils";
+
+const navIcons: Record<string, ReactNode> = {
+  "/admin": <LayoutDashboard size={16} />,
+  "/admin/movies": <Film size={16} />,
+  "/admin/genres": <Tag size={16} />,
+  "/admin/rooms": <Building2 size={16} />,
+  "/admin/seat-rows": <Grid3x3 size={16} />,
+  "/admin/sessions": <CalendarDays size={16} />,
+  "/admin/users": <Users size={16} />,
+};
+
+function AdminNavItem({
+  active,
+  href,
+  label,
+}: {
+  active: boolean;
+  href: string;
+  label: string;
+}) {
+  return (
+    <Link
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "flex items-center gap-2.5 rounded-[6px] px-3 py-2 text-sm font-bold leading-none transition duration-150 active:scale-[0.98]",
+        active
+          ? "bg-brand/10 text-brand"
+          : "text-white/60 hover:bg-white/[0.08] hover:text-white"
+      )}
+      href={href}
+    >
+      <span aria-hidden="true" className="shrink-0">
+        {navIcons[href]}
+      </span>
+      {label}
+    </Link>
+  );
+}
+
+type AdminShellProps = {
+  children: ReactNode;
+};
+
+export function AdminShell({ children }: AdminShellProps) {
+  const pathname = usePathname();
+
+  const navItems = ADMIN_NAV_LINKS.map((item) => (
+    <AdminNavItem
+      active={isAdminNavItemActive(pathname, item.href)}
+      href={item.href}
+      key={item.href}
+      label={item.label}
+    />
+  ));
+
+  return (
+    <div className="flex min-h-[calc(100vh-var(--header-height))]">
+      {/* Sidebar — desktop */}
+      <nav
+        aria-label="Navegação administrativa"
+        className={cn(
+          "hidden lg:flex shrink-0 flex-col gap-1 w-56 border-r border-white/[0.07]",
+          "px-3 py-4 sticky top-[var(--header-height)] self-start",
+          "h-[calc(100vh-var(--header-height))]"
+        )}
+      >
+        <p className="px-3 pb-2 text-[11px] font-[750] uppercase tracking-widest text-white/30">
+          Admin
+        </p>
+        {navItems}
+      </nav>
+
+      {/* Top nav — mobile/tablet */}
+      <div className="flex flex-col flex-1 min-w-0">
+        <nav
+          aria-label="Navegação administrativa"
+          className={cn(
+            "lg:hidden flex overflow-x-auto gap-1 border-b border-white/[0.07]",
+            "px-3 py-2 [scrollbar-width:none] shrink-0"
+          )}
+        >
+          {navItems}
+        </nav>
+
+        <main className="flex-1 p-6 min-w-0">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminTable.tsx
+++ b/frontend/src/components/admin/AdminTable.tsx
@@ -1,0 +1,96 @@
+import React, { type ReactNode } from "react";
+
+import { cn } from "@/components/ui/classNames";
+import { AdminEmptyState } from "./AdminEmptyState";
+
+export type AdminTableColumn<T> = {
+  className?: string;
+  key: string;
+  label: string;
+  render?: (row: T, index: number) => ReactNode;
+};
+
+type AdminTableProps<T extends Record<string, unknown>> = {
+  caption?: string;
+  columns: AdminTableColumn<T>[];
+  data: T[];
+  emptyDescription?: string;
+  emptyTitle?: string;
+  keyField: keyof T;
+  loading?: boolean;
+};
+
+function SkeletonRow({ columns }: { columns: number }) {
+  return (
+    <tr aria-hidden="true">
+      {Array.from({ length: columns }).map((_, i) => (
+        <td className="px-4 py-3" key={i}>
+          <div className="h-4 w-3/4 animate-pulse rounded bg-white/[0.06]" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export function AdminTable<T extends Record<string, unknown>>({
+  caption,
+  columns,
+  data,
+  emptyDescription,
+  emptyTitle = "Nenhum item encontrado",
+  keyField,
+  loading = false,
+}: AdminTableProps<T>) {
+  if (!loading && data.length === 0) {
+    return <AdminEmptyState description={emptyDescription} title={emptyTitle} />;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-[8px] border border-white/[0.07]">
+      <table className="w-full text-sm">
+        {caption ? (
+          <caption className="sr-only">{caption}</caption>
+        ) : null}
+        <thead>
+          <tr className="border-b border-white/[0.07] bg-white/[0.03]">
+            {columns.map((col) => (
+              <th
+                className={cn(
+                  "px-4 py-3 text-left text-xs font-[750] uppercase tracking-wider text-white/40",
+                  col.className
+                )}
+                key={col.key}
+                scope="col"
+              >
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/[0.05]">
+          {loading
+            ? Array.from({ length: 5 }).map((_, i) => (
+                <SkeletonRow columns={columns.length} key={i} />
+              ))
+            : data.map((row, index) => (
+                <tr
+                  className="transition-colors hover:bg-white/[0.02]"
+                  key={String(row[keyField])}
+                >
+                  {columns.map((col) => (
+                    <td
+                      className={cn("px-4 py-3 text-white/80", col.className)}
+                      key={col.key}
+                    >
+                      {col.render
+                        ? col.render(row, index)
+                        : String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminToolbar.tsx
+++ b/frontend/src/components/admin/AdminToolbar.tsx
@@ -1,0 +1,46 @@
+import React, { type ReactNode } from "react";
+
+type AdminToolbarProps = {
+  actions?: ReactNode;
+  filters?: ReactNode;
+  onSearch?: (value: string) => void;
+  searchPlaceholder?: string;
+  title: string;
+};
+
+export function AdminToolbar({
+  actions,
+  filters,
+  onSearch,
+  searchPlaceholder = "Buscar...",
+  title,
+}: AdminToolbarProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-[850] text-white">{title}</h1>
+        {actions ? (
+          <div className="flex shrink-0 items-center gap-2">{actions}</div>
+        ) : null}
+      </div>
+      {(onSearch ?? filters) ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {onSearch ? (
+            <input
+              aria-label={`Buscar em ${title}`}
+              className={[
+                "min-w-[200px] flex-1 rounded-control border border-white/[0.12]",
+                "bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-white/30",
+                "outline-none transition focus:border-brand focus:bg-white/[0.07]",
+              ].join(" ")}
+              onChange={(e) => onSearch(e.target.value)}
+              placeholder={searchPlaceholder}
+              type="search"
+            />
+          ) : null}
+          {filters}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/admin-nav-utils.ts
+++ b/frontend/src/components/admin/admin-nav-utils.ts
@@ -1,0 +1,22 @@
+export type AdminNavLink = {
+  href: string;
+  label: string;
+};
+
+export const ADMIN_NAV_LINKS: AdminNavLink[] = [
+  { href: "/admin", label: "Dashboard" },
+  { href: "/admin/movies", label: "Filmes" },
+  { href: "/admin/genres", label: "Gêneros" },
+  { href: "/admin/rooms", label: "Salas" },
+  { href: "/admin/seat-rows", label: "Fileiras e Assentos" },
+  { href: "/admin/sessions", label: "Sessões" },
+  { href: "/admin/users", label: "Administradores" },
+];
+
+export function isAdminNavItemActive(pathname: string, href: string) {
+  if (href === "/admin") {
+    return pathname === "/admin";
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`);
+}

--- a/frontend/src/components/admin/admin-shell.test.ts
+++ b/frontend/src/components/admin/admin-shell.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { isAdminNavItemActive } from "./admin-nav-utils";
+import { AdminEmptyState } from "./AdminEmptyState";
+import { AdminToolbar } from "./AdminToolbar";
+
+// --- isAdminNavItemActive ---
+
+test("dashboard link is active only on the exact /admin path", () => {
+  assert.equal(isAdminNavItemActive("/admin", "/admin"), true);
+  assert.equal(isAdminNavItemActive("/admin/movies", "/admin"), false);
+  assert.equal(isAdminNavItemActive("/admin/users", "/admin"), false);
+});
+
+test("section link is active on its own path and nested paths", () => {
+  assert.equal(isAdminNavItemActive("/admin/movies", "/admin/movies"), true);
+  assert.equal(
+    isAdminNavItemActive("/admin/movies/edit/123", "/admin/movies"),
+    true
+  );
+  assert.equal(isAdminNavItemActive("/admin/genres", "/admin/movies"), false);
+});
+
+test("no nav item is active on unrelated paths", () => {
+  assert.equal(isAdminNavItemActive("/", "/admin"), false);
+  assert.equal(isAdminNavItemActive("/checkout", "/admin/sessions"), false);
+});
+
+// --- AdminEmptyState rendering ---
+
+test("AdminEmptyState renders title and description", () => {
+  const html = renderToStaticMarkup(
+    createElement(AdminEmptyState, {
+      title: "Nenhum item",
+      description: "Cadastre um item para começar.",
+    })
+  );
+
+  assert.match(html, /Nenhum item/);
+  assert.match(html, /Cadastre um item para começar\./);
+});
+
+test("AdminEmptyState renders without description", () => {
+  const html = renderToStaticMarkup(
+    createElement(AdminEmptyState, { title: "Lista vazia" })
+  );
+
+  assert.match(html, /Lista vazia/);
+  assert.doesNotMatch(html, /<p[^>]*>\s*<\/p>/);
+});
+
+// --- AdminToolbar rendering ---
+
+test("AdminToolbar renders title", () => {
+  const html = renderToStaticMarkup(
+    createElement(AdminToolbar, { title: "Filmes" })
+  );
+
+  assert.match(html, /Filmes/);
+});
+
+test("AdminToolbar renders search input when onSearch is provided", () => {
+  const html = renderToStaticMarkup(
+    createElement(AdminToolbar, {
+      title: "Sessões",
+      onSearch: () => {},
+      searchPlaceholder: "Buscar sessão...",
+    })
+  );
+
+  assert.match(html, /Buscar sessão\.\.\./);
+  assert.match(html, /type="search"/);
+});
+
+test("AdminToolbar omits search input when onSearch is not provided", () => {
+  const html = renderToStaticMarkup(
+    createElement(AdminToolbar, { title: "Administradores" })
+  );
+
+  assert.doesNotMatch(html, /type="search"/);
+});

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,0 +1,8 @@
+export { AdminConfirmDialog } from "./AdminConfirmDialog";
+export { AdminEmptyState } from "./AdminEmptyState";
+export { isAdminNavItemActive, ADMIN_NAV_LINKS } from "./admin-nav-utils";
+export type { AdminNavLink } from "./admin-nav-utils";
+export { AdminShell } from "./AdminShell";
+export { AdminTable } from "./AdminTable";
+export type { AdminTableColumn } from "./AdminTable";
+export { AdminToolbar } from "./AdminToolbar";


### PR DESCRIPTION
## Objective

Implement the foundation of the frontend administration area: a protected `/admin` route tree, a two-column shell layout, a live-data dashboard, six management section placeholders, and four shared reusable components — ready for CRUD screens to be bolted on per-section.

## What was done

### 1. Admin route protection

Added `frontend/src/app/admin/layout.tsx` that wraps all `/admin/**` pages in the existing `AdminRoute` component. Because the guard lives at the layout level, every new sub-page inherits protection automatically without repeating the check per-page.

- Unauthenticated users → redirect to `/login?redirect=...`
- Authenticated non-admin users → inline "Acesso restrito" error message
- Authenticated admin users → content rendered

### 2. Admin shell layout

`AdminShell` provides a two-column layout:

- **Desktop (`lg+`)**: sticky 224 px sidebar with `aria-label="Navegação administrativa"`
- **Mobile / tablet**: horizontally-scrollable top-nav bar (acceptable mobile fallback per spec)
- Active link highlighted with brand color; `aria-current="page"` set for screen readers

Navigation covers all seven areas from the spec: Dashboard, Filmes, Gêneros, Salas, Fileiras e Assentos, Sessões, Administradores.

### 3. Dashboard summary

`/admin` fetches four live counters in parallel from the existing catalog API:

- Total de filmes
- Em cartaz
- Sessões hoje
- Salas

Each stat card links to the corresponding management section. A management shortcuts grid below provides quick access to all six sections.

### 4. Management section placeholders

Six sub-routes created under `/admin/`:

| Route | Section |
|---|---|
| `/admin/movies` | Filmes |
| `/admin/genres` | Gêneros |
| `/admin/rooms` | Salas |
| `/admin/seat-rows` | Fileiras e Assentos |
| `/admin/sessions` | Sessões |
| `/admin/users` | Administradores |

Each page uses `AdminToolbar` + `AdminEmptyState` and is ready to receive a data-backed `AdminTable` in subsequent issues.

### 5. Shared admin UI components

All four components are in `src/components/admin/` and exported via `index.ts`:

- **`AdminTable`** — generic typed table with skeleton loaders and empty-state fallback; no per-section duplication needed
- **`AdminToolbar`** — section heading with optional search input and action button slot
- **`AdminEmptyState`** — dashed-border placeholder with title, description, and optional action
- **`AdminConfirmDialog`** — native `<dialog>`-based modal with `danger` / `default` tones

### 6. Admin API module

`src/api/admin.ts` exposes `adminApi.getSummary()` which runs four catalog requests in parallel and returns typed counts for the dashboard. No new backend endpoints required.

### 7. Tests

**Unit (8 new, total 226 passing):**

- `isAdminNavItemActive` — exact `/admin` match vs. nested path distinction
- `AdminEmptyState` rendering — with and without description
- `AdminToolbar` rendering — with and without search input

**E2E (3 new scenarios):**

- Authenticated non-admin user blocked at `/admin` with "Acesso restrito" message
- Authenticated admin user lands on the dashboard
- Admin nav link navigates correctly to a management sub-page

**Guard coverage** (existing `route-guards.test.ts`):
- loading / unauthenticated / non-admin / admin decisions already fully covered

## How to test

### Automated

```bash
cd frontend
npm run lint
npm run test
```

### Manual

1. Start the stack: `docker compose up`
2. Log in as an admin user (use the `bootstrap_admin` management command if needed)
3. Verify `/admin` shows the dashboard with live counters
4. Log out, log in as a regular user, navigate to `/admin` — expect "Acesso restrito"
5. Navigate to each sub-section (`/admin/movies`, `/admin/genres`, etc.) — expect empty-state placeholders
6. Resize to mobile — expect horizontal scrollable nav instead of sidebar

## Expected result

- `/admin` loads only for staff users; others see a clear denial message or are redirected to login
- All seven navigation areas are reachable from the shell
- Dashboard counters reflect live catalog data
- Shared components (`AdminTable`, `AdminToolbar`, `AdminEmptyState`, `AdminConfirmDialog`) eliminate duplication across future management screens
- Responsive on desktop and tablet; acceptable horizontal-nav fallback on mobile
- 226 unit tests pass; 3 new E2E scenarios cover access-control and routing

closes #165