### PR TITLE
feat: build admin movie and genre manager

### DIFF
--- a/backend/catalog/serializers.py
+++ b/backend/catalog/serializers.py
@@ -91,6 +91,12 @@ class MovieWriteSerializer(serializers.ModelSerializer):
         many=True,
         queryset=Genre.objects.all(),
     )
+    cast = serializers.ListField(
+        child=serializers.CharField(max_length=255),
+        required=False,
+        default=list,
+        write_only=True,
+    )
 
     class Meta:
         model = Movie
@@ -104,12 +110,34 @@ class MovieWriteSerializer(serializers.ModelSerializer):
             "poster_url",
             "age_rating",
             "director",
+            "cast",
             "status",
             "is_featured",
             "created_at",
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["cast"] = [m.name for m in instance.cast.all()]
+        return data
+
+    def create(self, validated_data):
+        cast_names = validated_data.pop("cast", [])
+        movie = super().create(validated_data)
+        for i, name in enumerate(cast_names):
+            CastMember.objects.create(movie=movie, name=name, order=i)
+        return movie
+
+    def update(self, instance, validated_data):
+        cast_names = validated_data.pop("cast", None)
+        movie = super().update(instance, validated_data)
+        if cast_names is not None:
+            instance.cast.all().delete()
+            for i, name in enumerate(cast_names):
+                CastMember.objects.create(movie=movie, name=name, order=i)
+        return movie
 
 
 class MovieReadSerializer(serializers.ModelSerializer):

--- a/backend/catalog/serializers.py
+++ b/backend/catalog/serializers.py
@@ -123,20 +123,24 @@ class MovieWriteSerializer(serializers.ModelSerializer):
         data["cast"] = [m.name for m in instance.cast.all()]
         return data
 
+    @transaction.atomic
     def create(self, validated_data):
         cast_names = validated_data.pop("cast", [])
         movie = super().create(validated_data)
-        for i, name in enumerate(cast_names):
-            CastMember.objects.create(movie=movie, name=name, order=i)
+        CastMember.objects.bulk_create(
+            [CastMember(movie=movie, name=name, order=i) for i, name in enumerate(cast_names)]
+        )
         return movie
 
+    @transaction.atomic
     def update(self, instance, validated_data):
         cast_names = validated_data.pop("cast", None)
         movie = super().update(instance, validated_data)
         if cast_names is not None:
             instance.cast.all().delete()
-            for i, name in enumerate(cast_names):
-                CastMember.objects.create(movie=movie, name=name, order=i)
+            CastMember.objects.bulk_create(
+                [CastMember(movie=movie, name=name, order=i) for i, name in enumerate(cast_names)]
+            )
         return movie
 
 

--- a/frontend/src/api/admin.test.ts
+++ b/frontend/src/api/admin.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { adminApi } from "./admin";
+
+const movieDetail = {
+  age_rating: "12",
+  cast: ["Actor One", "Actor Two"],
+  created_at: "2026-05-20T10:00:00-03:00",
+  director: "Director Name",
+  duration_minutes: 120,
+  genres: [{ id: "genre-1", name: "Ação" }],
+  id: "movie-1",
+  is_featured: true,
+  poster_url: "https://cdn.example.com/poster.jpg",
+  release_date: "2026-06-01",
+  status: "em_cartaz",
+  synopsis: "Uma sinopse.",
+  title: "Filme Teste",
+  updated_at: "2026-05-21T10:00:00-03:00",
+};
+
+const paginatedMovies = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [movieDetail],
+};
+
+const genre = {
+  created_at: "2026-05-20T10:00:00-03:00",
+  id: "genre-1",
+  name: "Ação",
+  updated_at: "2026-05-21T10:00:00-03:00",
+};
+
+const paginatedGenres = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [genre],
+};
+
+test("adminApi.listMovies fetches the paginated movie list", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/");
+      assert.equal(init?.method, "GET");
+
+      return Response.json(paginatedMovies);
+    };
+
+    const response = await adminApi.listMovies();
+
+    assert.equal(response.count, 1);
+    assert.equal(response.results[0].title, "Filme Teste");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listMovies builds status and search filters", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  try {
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return Response.json({ count: 0, next: null, previous: null, results: [] });
+    };
+
+    await adminApi.listMovies({ status: "em_cartaz" });
+    await adminApi.listMovies({ search: "Blade" });
+    await adminApi.listMovies({ status: "pre_venda", search: "Runner", page: 2 });
+
+    assert.deepEqual(requestedUrls, [
+      "http://localhost:8000/api/v1/catalog/movies/?status=em_cartaz",
+      "http://localhost:8000/api/v1/catalog/movies/?search=Blade",
+      "http://localhost:8000/api/v1/catalog/movies/?status=pre_venda&search=Runner&page=2",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.getMovie fetches a single movie by id", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/movie-1/");
+      return Response.json(movieDetail);
+    };
+
+    const movie = await adminApi.getMovie("movie-1");
+
+    assert.equal(movie.id, "movie-1");
+    assert.equal(movie.title, "Filme Teste");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.createMovie posts the movie payload", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/");
+      assert.equal(init?.method, "POST");
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.title, "Filme Teste");
+      assert.deepEqual(body.genres, ["genre-1"]);
+      assert.deepEqual(body.cast, ["Actor One"]);
+      return Response.json(movieDetail);
+    };
+
+    await adminApi.createMovie({
+      cast: ["Actor One"],
+      duration_minutes: 120,
+      genres: ["genre-1"],
+      is_featured: true,
+      poster_url: "https://cdn.example.com/poster.jpg",
+      release_date: "2026-06-01",
+      status: "em_cartaz",
+      synopsis: "Uma sinopse.",
+      title: "Filme Teste",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.updateMovie patches the movie by id", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/movie-1/");
+      assert.equal(init?.method, "PATCH");
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.is_featured, false);
+      return Response.json({ ...movieDetail, is_featured: false });
+    };
+
+    const updated = await adminApi.updateMovie("movie-1", { is_featured: false });
+    assert.equal(updated.is_featured, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.deleteMovie sends a DELETE request", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/movies/movie-1/");
+      assert.equal(init?.method, "DELETE");
+      return new Response(null, { status: 204 });
+    };
+
+    await adminApi.deleteMovie("movie-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listGenres fetches the paginated genre list with auth", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/genres/");
+      assert.equal(init?.method, "GET");
+      return Response.json(paginatedGenres);
+    };
+
+    const response = await adminApi.listGenres();
+
+    assert.equal(response.count, 1);
+    assert.equal(response.results[0].name, "Ação");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listGenres builds page param", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/genres/?page=2");
+      return Response.json(paginatedGenres);
+    };
+
+    await adminApi.listGenres({ page: 2 });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.createGenre posts the genre payload", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/genres/");
+      assert.equal(init?.method, "POST");
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.name, "Ação");
+      return Response.json(genre);
+    };
+
+    const created = await adminApi.createGenre({ name: "Ação" });
+    assert.equal(created.id, "genre-1");
+    assert.equal(created.name, "Ação");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.updateGenre patches the genre by id", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/genres/genre-1/");
+      assert.equal(init?.method, "PATCH");
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.name, "Drama");
+      return Response.json({ ...genre, name: "Drama" });
+    };
+
+    const updated = await adminApi.updateGenre("genre-1", { name: "Drama" });
+    assert.equal(updated.name, "Drama");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.deleteGenre sends a DELETE request", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/genres/genre-1/");
+      assert.equal(init?.method, "DELETE");
+      return new Response(null, { status: 204 });
+    };
+
+    await adminApi.deleteGenre("genre-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.getMovie rejects unexpected response shape", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ id: "movie-1" });
+
+    await assert.rejects(
+      adminApi.getMovie("movie-1"),
+      /Unexpected admin movie detail response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listMovies rejects non-paginated response", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json([]);
+
+    await assert.rejects(
+      adminApi.listMovies(),
+      /Unexpected admin movie list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.createGenre rejects unexpected response shape", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({});
+
+    await assert.rejects(
+      adminApi.createGenre({ name: "Ação" }),
+      /Unexpected admin create genre response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,4 +1,15 @@
-import { apiRequest, type PaginatedResponse } from "./client";
+import type {
+  CatalogGenre,
+  CatalogMovieAgeRating,
+  CatalogMovieDetail,
+  MovieStatus,
+} from "@/types/catalog";
+
+import {
+  apiRequest,
+  isPaginatedResponse,
+  type PaginatedResponse,
+} from "./client";
 
 export type AdminSummary = {
   movieCount: number;
@@ -6,6 +17,32 @@ export type AdminSummary = {
   roomCount: number;
   sessionsTodayCount: number;
 };
+
+export type AdminMovieWritePayload = {
+  age_rating?: CatalogMovieAgeRating;
+  cast?: string[];
+  director?: string;
+  duration_minutes: number;
+  genres: string[];
+  is_featured?: boolean;
+  poster_url: string;
+  release_date: string;
+  status: MovieStatus;
+  synopsis: string;
+  title: string;
+};
+
+export type AdminGenreWritePayload = {
+  name: string;
+};
+
+export type AdminGenre = CatalogGenre & {
+  created_at?: string;
+  updated_at?: string;
+};
+
+const MOVIES_PATH = "/api/v1/catalog/movies/";
+const GENRES_PATH = "/api/v1/catalog/genres/";
 
 export const adminApi = {
   async getSummary(): Promise<AdminSummary> {
@@ -36,4 +73,174 @@ export const adminApi = {
       sessionsTodayCount: sessionsToday.count,
     };
   },
+
+  async listMovies(params: { page?: number; search?: string; status?: MovieStatus } = {}) {
+    const response = await apiRequest<unknown>(buildMoviesPath(params), {
+      auth: "required",
+      method: "GET",
+    });
+
+    if (!isPaginatedResponse<CatalogMovieDetail>(response)) {
+      throw new Error("Unexpected admin movie list response.");
+    }
+
+    return response satisfies PaginatedResponse<CatalogMovieDetail>;
+  },
+
+  async getMovie(movieId: string) {
+    const response = await apiRequest<unknown>(`${MOVIES_PATH}${movieId}/`, {
+      auth: "required",
+      method: "GET",
+    });
+
+    if (!isAdminMovieDetail(response)) {
+      throw new Error("Unexpected admin movie detail response.");
+    }
+
+    return response satisfies CatalogMovieDetail;
+  },
+
+  async createMovie(payload: AdminMovieWritePayload) {
+    const response = await apiRequest<unknown>(MOVIES_PATH, {
+      auth: "required",
+      json: payload,
+      method: "POST",
+    });
+
+    if (!isAdminMovieDetail(response)) {
+      throw new Error("Unexpected admin create movie response.");
+    }
+
+    return response satisfies CatalogMovieDetail;
+  },
+
+  async updateMovie(movieId: string, payload: Partial<AdminMovieWritePayload>) {
+    const response = await apiRequest<unknown>(`${MOVIES_PATH}${movieId}/`, {
+      auth: "required",
+      json: payload,
+      method: "PATCH",
+    });
+
+    if (!isAdminMovieDetail(response)) {
+      throw new Error("Unexpected admin update movie response.");
+    }
+
+    return response satisfies CatalogMovieDetail;
+  },
+
+  async deleteMovie(movieId: string) {
+    await apiRequest<unknown>(`${MOVIES_PATH}${movieId}/`, {
+      auth: "required",
+      method: "DELETE",
+    });
+  },
+
+  async listGenres(params: { page?: number } = {}) {
+    const query = params.page !== undefined ? `?page=${params.page}` : "";
+    const response = await apiRequest<unknown>(`${GENRES_PATH}${query}`, {
+      auth: "required",
+      method: "GET",
+    });
+
+    if (!isPaginatedResponse<AdminGenre>(response)) {
+      throw new Error("Unexpected admin genre list response.");
+    }
+
+    return response satisfies PaginatedResponse<AdminGenre>;
+  },
+
+  async createGenre(payload: AdminGenreWritePayload) {
+    const response = await apiRequest<unknown>(GENRES_PATH, {
+      auth: "required",
+      json: payload,
+      method: "POST",
+    });
+
+    if (!isAdminGenre(response)) {
+      throw new Error("Unexpected admin create genre response.");
+    }
+
+    return response satisfies AdminGenre;
+  },
+
+  async updateGenre(genreId: string, payload: AdminGenreWritePayload) {
+    const response = await apiRequest<unknown>(`${GENRES_PATH}${genreId}/`, {
+      auth: "required",
+      json: payload,
+      method: "PATCH",
+    });
+
+    if (!isAdminGenre(response)) {
+      throw new Error("Unexpected admin update genre response.");
+    }
+
+    return response satisfies AdminGenre;
+  },
+
+  async deleteGenre(genreId: string) {
+    await apiRequest<unknown>(`${GENRES_PATH}${genreId}/`, {
+      auth: "required",
+      method: "DELETE",
+    });
+  },
 };
+
+function buildMoviesPath({
+  page,
+  search,
+  status,
+}: {
+  page?: number;
+  search?: string;
+  status?: MovieStatus;
+}) {
+  const searchParams = new URLSearchParams();
+
+  if (status) {
+    searchParams.set("status", status);
+  }
+
+  if (search) {
+    searchParams.set("search", search);
+  }
+
+  if (page !== undefined) {
+    searchParams.set("page", String(page));
+  }
+
+  const query = searchParams.toString();
+  return query ? `${MOVIES_PATH}?${query}` : MOVIES_PATH;
+}
+
+function isAdminMovieDetail(value: unknown): value is CatalogMovieDetail {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    Array.isArray(value.genres) &&
+    typeof value.duration_minutes === "number" &&
+    typeof value.poster_url === "string" &&
+    isMovieStatus(value.status) &&
+    typeof value.is_featured === "boolean" &&
+    typeof value.synopsis === "string"
+  );
+}
+
+function isAdminGenre(value: unknown): value is AdminGenre {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string"
+  );
+}
+
+function isMovieStatus(value: unknown): value is MovieStatus {
+  return value === "em_cartaz" || value === "pre_venda" || value === "em_breve";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/frontend/src/app/admin/genres/page.tsx
+++ b/frontend/src/app/admin/genres/page.tsx
@@ -1,21 +1,5 @@
-import { AdminEmptyState, AdminToolbar } from "@/components/admin";
-import { ButtonLink } from "@/components/ui/Button";
+import { AdminGenreList } from "@/components/admin";
 
 export default function AdminGenresPage() {
-  return (
-    <div className="grid gap-6">
-      <AdminToolbar
-        actions={
-          <ButtonLink href="#" size="sm" variant="primary">
-            Novo gênero
-          </ButtonLink>
-        }
-        title="Gêneros"
-      />
-      <AdminEmptyState
-        description="O gerenciamento de gêneros será implementado em breve."
-        title="Nenhum gênero cadastrado"
-      />
-    </div>
-  );
+  return <AdminGenreList />;
 }

--- a/frontend/src/app/admin/movies/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/movies/[id]/edit/page.tsx
@@ -1,0 +1,10 @@
+import { AdminEditMovieLoader } from "@/components/admin/AdminEditMovieLoader";
+
+export default async function AdminEditMoviePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <AdminEditMovieLoader movieId={id} />;
+}

--- a/frontend/src/app/admin/movies/new/page.tsx
+++ b/frontend/src/app/admin/movies/new/page.tsx
@@ -1,0 +1,19 @@
+import { AdminMovieForm } from "@/components/admin";
+import { AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminNewMoviePage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="/admin/movies" size="sm" variant="ghost">
+            Voltar
+          </ButtonLink>
+        }
+        title="Novo filme"
+      />
+      <AdminMovieForm />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/movies/page.tsx
+++ b/frontend/src/app/admin/movies/page.tsx
@@ -1,21 +1,5 @@
-import { AdminEmptyState, AdminToolbar } from "@/components/admin";
-import { ButtonLink } from "@/components/ui/Button";
+import { AdminMovieList } from "@/components/admin";
 
 export default function AdminMoviesPage() {
-  return (
-    <div className="grid gap-6">
-      <AdminToolbar
-        actions={
-          <ButtonLink href="#" size="sm" variant="primary">
-            Novo filme
-          </ButtonLink>
-        }
-        title="Filmes"
-      />
-      <AdminEmptyState
-        description="O gerenciamento de filmes será implementado em breve."
-        title="Nenhum filme cadastrado"
-      />
-    </div>
-  );
+  return <AdminMovieList />;
 }

--- a/frontend/src/components/admin/AdminEditMovieLoader.tsx
+++ b/frontend/src/components/admin/AdminEditMovieLoader.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { adminApi } from "@/api/admin";
+import type { CatalogMovieDetail } from "@/types/catalog";
+import { AdminMovieForm } from "./AdminMovieForm";
+import { AdminToolbar } from "./AdminToolbar";
+import { ButtonLink } from "@/components/ui/Button";
+
+export function AdminEditMovieLoader({ movieId }: { movieId: string }) {
+  const [movie, setMovie] = useState<CatalogMovieDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminApi
+      .getMovie(movieId)
+      .then(setMovie)
+      .catch(() => setError("Filme não encontrado ou você não tem permissão para editá-lo."))
+      .finally(() => setLoading(false));
+  }, [movieId]);
+
+  if (loading) {
+    return (
+      <div className="grid gap-6">
+        <AdminToolbar
+          actions={
+            <ButtonLink href="/admin/movies" size="sm" variant="ghost">
+              Voltar
+            </ButtonLink>
+          }
+          title="Editar filme"
+        />
+        <div className="grid gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div className="h-10 animate-pulse rounded-[8px] bg-white/[0.05]" key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !movie) {
+    return (
+      <div className="grid gap-6">
+        <AdminToolbar
+          actions={
+            <ButtonLink href="/admin/movies" size="sm" variant="ghost">
+              Voltar
+            </ButtonLink>
+          }
+          title="Editar filme"
+        />
+        <p className="text-sm font-bold text-error" role="alert">
+          {error ?? "Filme não encontrado."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="/admin/movies" size="sm" variant="ghost">
+            Voltar
+          </ButtonLink>
+        }
+        title={`Editar: ${movie.title}`}
+      />
+      <AdminMovieForm movie={movie} />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminGenreList.tsx
+++ b/frontend/src/components/admin/AdminGenreList.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { adminApi, type AdminGenre } from "@/api/admin";
+import { ApiError } from "@/api/client";
+import { Button } from "@/components/ui/Button";
+import { AdminConfirmDialog, AdminTable, AdminToolbar } from "@/components/admin";
+import type { AdminTableColumn } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export function AdminGenreList() {
+  const [genres, setGenres] = useState<AdminGenre[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const [deleteTarget, setDeleteTarget] = useState<AdminGenre | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [showCreateInput, setShowCreateInput] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const createInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchGenres = useCallback(async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const result = await adminApi.listGenres();
+      setGenres(result.results);
+    } catch {
+      setErrorMessage("Não foi possível carregar os gêneros. Tente novamente.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGenres();
+  }, [fetchGenres]);
+
+  useEffect(() => {
+    if (editingId) {
+      editInputRef.current?.focus();
+    }
+  }, [editingId]);
+
+  useEffect(() => {
+    if (showCreateInput) {
+      createInputRef.current?.focus();
+    }
+  }, [showCreateInput]);
+
+  function startEdit(genre: AdminGenre) {
+    setEditingId(genre.id);
+    setEditName(genre.name);
+    setEditError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditName("");
+    setEditError(null);
+  }
+
+  async function handleSaveEdit(genreId: string) {
+    const name = editName.trim();
+    if (!name) return;
+
+    setIsSaving(true);
+    setEditError(null);
+    try {
+      const updated = await adminApi.updateGenre(genreId, { name });
+      setGenres((prev) => prev.map((g) => (g.id === genreId ? updated : g)));
+      cancelEdit();
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "VALIDATION_FAILED") {
+        const details = err.details as Record<string, unknown> | null;
+        const nameErr = details?.name;
+        setEditError(Array.isArray(nameErr) ? nameErr[0] : String(nameErr ?? "Nome inválido."));
+      } else {
+        setEditError("Não foi possível salvar. Tente novamente.");
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await adminApi.deleteGenre(deleteTarget.id);
+      setGenres((prev) => prev.filter((g) => g.id !== deleteTarget.id));
+      setDeleteTarget(null);
+    } catch {
+      setErrorMessage("Não foi possível excluir o gênero. Tente novamente.");
+      setDeleteTarget(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  async function handleCreate() {
+    const name = createName.trim();
+    if (!name) return;
+
+    setIsCreating(true);
+    setCreateError(null);
+    try {
+      const created = await adminApi.createGenre({ name });
+      setGenres((prev) => [...prev, created]);
+      setCreateName("");
+      setShowCreateInput(false);
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "VALIDATION_FAILED") {
+        const details = err.details as Record<string, unknown> | null;
+        const nameErr = details?.name;
+        setCreateError(Array.isArray(nameErr) ? nameErr[0] : String(nameErr ?? "Nome inválido."));
+      } else {
+        setCreateError("Não foi possível criar o gênero. Tente novamente.");
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  const columns: AdminTableColumn<Record<string, unknown>>[] = [
+    {
+      key: "name",
+      label: "Nome",
+      render: (row) => {
+        const genre = row as unknown as AdminGenre;
+        if (editingId === genre.id) {
+          return (
+            <div className="flex flex-col gap-1">
+              <input
+                className={[
+                  "min-h-[var(--control-height)] rounded-control border bg-surface px-3 py-1.5",
+                  "text-sm text-white outline-none transition focus:border-brand focus:shadow-focus",
+                  editError ? "border-error" : "border-border",
+                ].join(" ")}
+                disabled={isSaving}
+                onChange={(e) => setEditName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSaveEdit(genre.id);
+                  if (e.key === "Escape") cancelEdit();
+                }}
+                ref={editInputRef}
+                value={editName}
+              />
+              {editError ? (
+                <p className="text-xs font-bold text-error" role="alert">
+                  {editError}
+                </p>
+              ) : null}
+            </div>
+          );
+        }
+        return <span className="font-medium text-white">{genre.name}</span>;
+      },
+    },
+    {
+      key: "actions",
+      label: "Ações",
+      render: (row) => {
+        const genre = row as unknown as AdminGenre;
+        if (editingId === genre.id) {
+          return (
+            <div className="flex items-center gap-2">
+              <Button
+                disabled={isSaving || !editName.trim()}
+                isLoading={isSaving}
+                onClick={() => handleSaveEdit(genre.id)}
+                size="sm"
+                type="button"
+                variant="primary"
+              >
+                Salvar
+              </Button>
+              <Button
+                disabled={isSaving}
+                onClick={cancelEdit}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Cancelar
+              </Button>
+            </div>
+          );
+        }
+        return (
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={() => startEdit(genre)}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Editar
+            </Button>
+            <Button
+              onClick={() => setDeleteTarget(genre)}
+              size="sm"
+              type="button"
+              variant="danger"
+            >
+              Excluir
+            </Button>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <Button
+            onClick={() => {
+              setShowCreateInput(true);
+              setCreateName("");
+              setCreateError(null);
+            }}
+            size="sm"
+            type="button"
+            variant="primary"
+          >
+            Novo gênero
+          </Button>
+        }
+        title="Gêneros"
+      />
+
+      {errorMessage ? (
+        <p className="text-sm font-bold text-error" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      {showCreateInput ? (
+        <div className="flex flex-col gap-2 rounded-[8px] border border-brand/30 bg-brand/5 p-4">
+          <span className="text-sm font-extrabold text-white">Novo gênero</span>
+          <div className="flex gap-2">
+            <input
+              className={[
+                "flex-1 min-h-[var(--control-height-lg)] rounded-control border bg-surface px-3 py-2",
+                "text-sm text-white placeholder:text-white/30 outline-none transition",
+                "focus:border-brand focus:shadow-focus",
+                createError ? "border-error" : "border-border",
+              ].join(" ")}
+              disabled={isCreating}
+              onChange={(e) => setCreateName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCreate();
+                if (e.key === "Escape") {
+                  setShowCreateInput(false);
+                  setCreateName("");
+                  setCreateError(null);
+                }
+              }}
+              placeholder="Nome do gênero"
+              ref={createInputRef}
+              value={createName}
+            />
+            <Button
+              disabled={isCreating || !createName.trim()}
+              isLoading={isCreating}
+              onClick={handleCreate}
+              size="sm"
+              type="button"
+              variant="primary"
+            >
+              Criar
+            </Button>
+            <Button
+              disabled={isCreating}
+              onClick={() => {
+                setShowCreateInput(false);
+                setCreateName("");
+                setCreateError(null);
+              }}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Cancelar
+            </Button>
+          </div>
+          {createError ? (
+            <p className="text-sm font-bold text-error" role="alert">
+              {createError}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <AdminTable
+        caption="Lista de gêneros"
+        columns={columns}
+        data={genres as unknown as Record<string, unknown>[]}
+        emptyDescription="Nenhum gênero cadastrado. Clique em 'Novo gênero' para adicionar."
+        emptyTitle="Nenhum gênero cadastrado"
+        keyField="id"
+        loading={loading}
+      />
+
+      <AdminConfirmDialog
+        confirmLabel={isDeleting ? "Excluindo..." : "Excluir"}
+        description={`Tem certeza que deseja excluir o gênero "${deleteTarget?.name}"?`}
+        isOpen={deleteTarget !== null}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Excluir gênero"
+        tone="danger"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminMovieForm.tsx
+++ b/frontend/src/components/admin/AdminMovieForm.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useRef, useState, type FormEvent } from "react";
+
+import { adminApi, type AdminMovieWritePayload } from "@/api/admin";
+import { ApiError } from "@/api/client";
+import type { CatalogGenre, CatalogMovieDetail, CatalogMovieAgeRating, MovieStatus } from "@/types/catalog";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+
+type FieldErrors = Partial<Record<keyof AdminMovieWritePayload | "non_field_errors", string>>;
+
+type AdminMovieFormProps = {
+  movie?: CatalogMovieDetail;
+};
+
+const STATUS_OPTIONS = [
+  { label: "Em cartaz", value: "em_cartaz" },
+  { label: "Pré-venda", value: "pre_venda" },
+  { label: "Em breve", value: "em_breve" },
+];
+
+const AGE_RATING_OPTIONS = [
+  { label: "Livre (L)", value: "L" },
+  { label: "10 anos", value: "10" },
+  { label: "12 anos", value: "12" },
+  { label: "14 anos", value: "14" },
+  { label: "16 anos", value: "16" },
+  { label: "18 anos", value: "18" },
+];
+
+export function extractFieldErrors(error: unknown): FieldErrors {
+  if (!(error instanceof ApiError) || error.code !== "VALIDATION_FAILED") {
+    return {};
+  }
+
+  const details = error.details as Record<string, unknown> | null;
+  if (!details || typeof details !== "object") {
+    return {};
+  }
+
+  const result: FieldErrors = {};
+
+  for (const [key, val] of Object.entries(details)) {
+    const messages = Array.isArray(val) ? val : [val];
+    result[key as keyof FieldErrors] = messages.join(" ");
+  }
+
+  return result;
+}
+
+function FormField({
+  children,
+  error,
+  label,
+  labelFor,
+}: {
+  children: React.ReactNode;
+  error?: string;
+  label: string;
+  labelFor: string;
+}) {
+  const errorId = error ? `${labelFor}-error` : undefined;
+
+  return (
+    <div className="grid gap-1.5">
+      <label className="text-sm font-extrabold text-white" htmlFor={labelFor}>
+        {label}
+      </label>
+      {children}
+      {error ? (
+        <p className="text-sm font-bold text-error" id={errorId} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function TextInput({
+  error,
+  id,
+  ...props
+}: React.InputHTMLAttributes<HTMLInputElement> & { error?: string }) {
+  return (
+    <input
+      aria-invalid={error ? "true" : undefined}
+      className={[
+        "min-h-[var(--control-height-lg)] w-full rounded-control border bg-surface px-3 py-2",
+        "text-sm text-white placeholder:text-white/30 outline-none transition",
+        "focus:border-brand focus:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
+        error ? "border-error" : "border-border",
+      ].join(" ")}
+      id={id}
+      {...props}
+    />
+  );
+}
+
+function Textarea({
+  error,
+  id,
+  ...props
+}: React.TextareaHTMLAttributes<HTMLTextAreaElement> & { error?: string }) {
+  return (
+    <textarea
+      aria-invalid={error ? "true" : undefined}
+      className={[
+        "w-full rounded-control border bg-surface px-3 py-2 min-h-[120px]",
+        "text-sm text-white placeholder:text-white/30 outline-none transition resize-y",
+        "focus:border-brand focus:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
+        error ? "border-error" : "border-border",
+      ].join(" ")}
+      id={id}
+      {...props}
+    />
+  );
+}
+
+export function AdminMovieForm({ movie }: AdminMovieFormProps) {
+  const router = useRouter();
+  const isEditing = movie !== undefined;
+
+  const [title, setTitle] = useState(movie?.title ?? "");
+  const [synopsis, setSynopsis] = useState(movie?.synopsis ?? "");
+  const [durationMinutes, setDurationMinutes] = useState(
+    movie?.duration_minutes ? String(movie.duration_minutes) : ""
+  );
+  const [releaseDate, setReleaseDate] = useState(movie?.release_date ?? "");
+  const [posterUrl, setPosterUrl] = useState(movie?.poster_url ?? "");
+  const [status, setStatus] = useState<MovieStatus>(movie?.status ?? "em_cartaz");
+  const [isFeatured, setIsFeatured] = useState(movie?.is_featured ?? false);
+  const [ageRating, setAgeRating] = useState<CatalogMovieAgeRating>(
+    (movie?.age_rating as CatalogMovieAgeRating) ?? ""
+  );
+  const [director, setDirector] = useState(movie?.director ?? "");
+  const [selectedGenreIds, setSelectedGenreIds] = useState<string[]>(
+    movie?.genres.map((g) => g.id) ?? []
+  );
+  const [castMembers, setCastMembers] = useState<string[]>(movie?.cast ?? []);
+  const [castInput, setCastInput] = useState("");
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [globalError, setGlobalError] = useState<string | null>(null);
+
+  const [showNewGenreInput, setShowNewGenreInput] = useState(false);
+  const [newGenreName, setNewGenreName] = useState("");
+  const [isCreatingGenre, setIsCreatingGenre] = useState(false);
+  const [localGenres, setLocalGenres] = useState<CatalogGenre[]>([]);
+  const [genresLoading, setGenresLoading] = useState(true);
+
+  const newGenreInputRef = useRef<HTMLInputElement>(null);
+  const titleId = useId();
+  const synopsisId = useId();
+  const durationId = useId();
+  const releaseDateId = useId();
+  const posterUrlId = useId();
+  const directorId = useId();
+  const castInputId = useId();
+
+  useEffect(() => {
+    adminApi.listGenres().then((res) => setLocalGenres(res.results)).catch(() => {}).finally(() => setGenresLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (showNewGenreInput) {
+      newGenreInputRef.current?.focus();
+    }
+  }, [showNewGenreInput]);
+
+  function toggleGenre(genreId: string) {
+    setSelectedGenreIds((prev) =>
+      prev.includes(genreId) ? prev.filter((id) => id !== genreId) : [...prev, genreId]
+    );
+  }
+
+  function addCastMember() {
+    const name = castInput.trim();
+    if (!name || castMembers.includes(name)) return;
+    setCastMembers((prev) => [...prev, name]);
+    setCastInput("");
+  }
+
+  function removeCastMember(name: string) {
+    setCastMembers((prev) => prev.filter((m) => m !== name));
+  }
+
+  async function handleCreateGenre() {
+    const name = newGenreName.trim();
+    if (!name) return;
+
+    setIsCreatingGenre(true);
+    try {
+      const created = await adminApi.createGenre({ name });
+      setLocalGenres((prev) => [...prev, created]);
+      setSelectedGenreIds((prev) => [...prev, created.id]);
+      setNewGenreName("");
+      setShowNewGenreInput(false);
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "VALIDATION_FAILED") {
+        const details = err.details as Record<string, unknown> | null;
+        const nameError = details?.name;
+        const msg = Array.isArray(nameError) ? nameError[0] : String(nameError ?? "Nome inválido.");
+        setGlobalError(`Erro ao criar gênero: ${msg}`);
+      } else {
+        setGlobalError("Não foi possível criar o gênero. Tente novamente.");
+      }
+    } finally {
+      setIsCreatingGenre(false);
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFieldErrors({});
+    setGlobalError(null);
+    setIsSubmitting(true);
+
+    const payload: AdminMovieWritePayload = {
+      age_rating: ageRating || undefined,
+      cast: castMembers,
+      director: director || undefined,
+      duration_minutes: Number(durationMinutes),
+      genres: selectedGenreIds,
+      is_featured: isFeatured,
+      poster_url: posterUrl,
+      release_date: releaseDate,
+      status,
+      synopsis,
+      title,
+    };
+
+    try {
+      if (isEditing) {
+        await adminApi.updateMovie(movie.id, payload);
+      } else {
+        await adminApi.createMovie(payload);
+      }
+      router.push("/admin/movies");
+      router.refresh();
+    } catch (err) {
+      const errors = extractFieldErrors(err);
+      if (Object.keys(errors).length > 0) {
+        setFieldErrors(errors);
+        setGlobalError("Corrija os erros indicados e tente novamente.");
+      } else if (err instanceof ApiError) {
+        setGlobalError(`Erro: ${err.message}`);
+      } else {
+        setGlobalError("Não foi possível salvar o filme. Tente novamente.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="grid gap-6" onSubmit={handleSubmit}>
+      {globalError ? (
+        <p className="rounded-[8px] border border-error/30 bg-error/10 px-4 py-3 text-sm font-bold text-error" role="alert">
+          {globalError}
+        </p>
+      ) : null}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Left column */}
+        <div className="grid gap-4 content-start">
+          <FormField error={fieldErrors.title} label="Título" labelFor={titleId}>
+            <TextInput
+              disabled={isSubmitting}
+              error={fieldErrors.title}
+              id={titleId}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Nome do filme"
+              required
+              value={title}
+            />
+          </FormField>
+
+          <FormField error={fieldErrors.synopsis} label="Sinopse" labelFor={synopsisId}>
+            <Textarea
+              disabled={isSubmitting}
+              error={fieldErrors.synopsis}
+              id={synopsisId}
+              onChange={(e) => setSynopsis(e.target.value)}
+              placeholder="Descrição do filme..."
+              required
+              value={synopsis}
+            />
+          </FormField>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField error={fieldErrors.duration_minutes} label="Duração (min)" labelFor={durationId}>
+              <TextInput
+                disabled={isSubmitting}
+                error={fieldErrors.duration_minutes}
+                id={durationId}
+                min={1}
+                onChange={(e) => setDurationMinutes(e.target.value)}
+                placeholder="120"
+                required
+                type="number"
+                value={durationMinutes}
+              />
+            </FormField>
+
+            <FormField error={fieldErrors.release_date} label="Data de lançamento" labelFor={releaseDateId}>
+              <TextInput
+                disabled={isSubmitting}
+                error={fieldErrors.release_date}
+                id={releaseDateId}
+                onChange={(e) => setReleaseDate(e.target.value)}
+                required
+                type="date"
+                value={releaseDate}
+              />
+            </FormField>
+          </div>
+
+          <FormField error={fieldErrors.director} label="Direção" labelFor={directorId}>
+            <TextInput
+              disabled={isSubmitting}
+              error={fieldErrors.director}
+              id={directorId}
+              onChange={(e) => setDirector(e.target.value)}
+              placeholder="Nome do(a) diretor(a)"
+              value={director}
+            />
+          </FormField>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Select
+              disabled={isSubmitting}
+              error={fieldErrors.status}
+              label="Status"
+              onChange={(e) => setStatus(e.target.value as MovieStatus)}
+              options={STATUS_OPTIONS}
+              value={status}
+            />
+
+            <Select
+              disabled={isSubmitting}
+              error={fieldErrors.age_rating}
+              label="Faixa etária"
+              onChange={(e) => setAgeRating(e.target.value as CatalogMovieAgeRating)}
+              options={AGE_RATING_OPTIONS}
+              placeholder="Não classificado"
+              value={ageRating}
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <input
+              checked={isFeatured}
+              className="h-4 w-4 accent-brand"
+              disabled={isSubmitting}
+              id="is_featured"
+              onChange={(e) => setIsFeatured(e.target.checked)}
+              type="checkbox"
+            />
+            <label className="text-sm font-extrabold text-white" htmlFor="is_featured">
+              Destaque (exibir no carrossel principal)
+            </label>
+          </div>
+        </div>
+
+        {/* Right column */}
+        <div className="grid gap-4 content-start">
+          <FormField error={fieldErrors.poster_url} label="URL do Poster" labelFor={posterUrlId}>
+            <TextInput
+              disabled={isSubmitting}
+              error={fieldErrors.poster_url}
+              id={posterUrlId}
+              onChange={(e) => setPosterUrl(e.target.value)}
+              placeholder="https://..."
+              required
+              type="url"
+              value={posterUrl}
+            />
+          </FormField>
+
+          {posterUrl ? (
+            <div className="overflow-hidden rounded-[8px] border border-white/[0.07]">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt="Prévia do poster"
+                className="w-full object-cover"
+                src={posterUrl}
+                style={{ maxHeight: 280 }}
+              />
+            </div>
+          ) : (
+            <div className="flex h-40 items-center justify-center rounded-[8px] border border-dashed border-white/[0.12] text-sm text-white/30">
+              Prévia do poster
+            </div>
+          )}
+
+          {/* Genres */}
+          <div className="grid gap-1.5">
+            <span className="text-sm font-extrabold text-white">Gêneros</span>
+            {fieldErrors.genres ? (
+              <p className="text-sm font-bold text-error" role="alert">
+                {fieldErrors.genres}
+              </p>
+            ) : null}
+            {genresLoading ? (
+              <div className="h-8 w-48 animate-pulse rounded-pill bg-white/[0.06]" />
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              {localGenres.map((genre) => {
+                const selected = selectedGenreIds.includes(genre.id);
+                return (
+                  <button
+                    className={[
+                      "rounded-pill border px-3 py-1 text-xs font-bold transition",
+                      selected
+                        ? "border-brand bg-brand/20 text-brand"
+                        : "border-white/[0.12] bg-white/[0.04] text-white/60 hover:border-white/30 hover:text-white",
+                    ].join(" ")}
+                    disabled={isSubmitting}
+                    key={genre.id}
+                    onClick={() => toggleGenre(genre.id)}
+                    type="button"
+                  >
+                    {genre.name}
+                  </button>
+                );
+              })}
+
+              {showNewGenreInput ? (
+                <div className="flex items-center gap-1.5">
+                  <input
+                    className="h-7 rounded-control border border-brand/50 bg-brand/10 px-2 text-xs text-white outline-none focus:border-brand"
+                    disabled={isCreatingGenre}
+                    onChange={(e) => setNewGenreName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleCreateGenre();
+                      }
+                      if (e.key === "Escape") {
+                        setShowNewGenreInput(false);
+                        setNewGenreName("");
+                      }
+                    }}
+                    placeholder="Nome do gênero"
+                    ref={newGenreInputRef}
+                    value={newGenreName}
+                  />
+                  <Button
+                    disabled={isCreatingGenre || !newGenreName.trim()}
+                    isLoading={isCreatingGenre}
+                    onClick={handleCreateGenre}
+                    size="sm"
+                    type="button"
+                    variant="primary"
+                  >
+                    Criar
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setShowNewGenreInput(false);
+                      setNewGenreName("");
+                    }}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    Cancelar
+                  </Button>
+                </div>
+              ) : (
+                <button
+                  className="rounded-pill border border-dashed border-white/[0.15] px-3 py-1 text-xs font-bold text-white/40 transition hover:border-brand/50 hover:text-brand"
+                  disabled={isSubmitting}
+                  onClick={() => setShowNewGenreInput(true)}
+                  type="button"
+                >
+                  + Novo gênero
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Cast */}
+          <div className="grid gap-1.5">
+            <label className="text-sm font-extrabold text-white" htmlFor={castInputId}>
+              Elenco
+            </label>
+            {fieldErrors.cast ? (
+              <p className="text-sm font-bold text-error" role="alert">
+                {fieldErrors.cast}
+              </p>
+            ) : null}
+            <div className="flex gap-2">
+              <TextInput
+                disabled={isSubmitting}
+                id={castInputId}
+                onChange={(e) => setCastInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    addCastMember();
+                  }
+                }}
+                placeholder="Nome do ator / atriz"
+                value={castInput}
+              />
+              <Button
+                disabled={isSubmitting || !castInput.trim()}
+                onClick={addCastMember}
+                size="sm"
+                type="button"
+                variant="secondary"
+              >
+                Adicionar
+              </Button>
+            </div>
+            {castMembers.length > 0 ? (
+              <ul className="flex flex-wrap gap-2">
+                {castMembers.map((name) => (
+                  <li
+                    className="flex items-center gap-1.5 rounded-pill border border-white/[0.10] bg-white/[0.04] pl-3 pr-2 py-1 text-xs text-white/80"
+                    key={name}
+                  >
+                    {name}
+                    <button
+                      aria-label={`Remover ${name}`}
+                      className="text-white/40 transition hover:text-error"
+                      disabled={isSubmitting}
+                      onClick={() => removeCastMember(name)}
+                      type="button"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 border-t border-white/[0.07] pt-4">
+        <Button
+          disabled={isSubmitting}
+          onClick={() => router.push("/admin/movies")}
+          type="button"
+          variant="ghost"
+        >
+          Cancelar
+        </Button>
+        <Button isLoading={isSubmitting} type="submit" variant="primary">
+          {isEditing ? "Salvar alterações" : "Criar filme"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/admin/AdminMovieForm.tsx
+++ b/frontend/src/components/admin/AdminMovieForm.tsx
@@ -262,6 +262,11 @@ export function AdminMovieForm({ movie }: AdminMovieFormProps) {
           {globalError}
         </p>
       ) : null}
+      {fieldErrors.non_field_errors ? (
+        <p className="rounded-[8px] border border-error/30 bg-error/10 px-4 py-3 text-sm font-bold text-error" role="alert">
+          {fieldErrors.non_field_errors}
+        </p>
+      ) : null}
 
       <div className="grid gap-6 md:grid-cols-2">
         {/* Left column */}

--- a/frontend/src/components/admin/AdminMovieList.tsx
+++ b/frontend/src/components/admin/AdminMovieList.tsx
@@ -27,11 +27,17 @@ const STATUS_TONES: Record<MovieStatus, "success" | "info" | "neutral"> = {
 export function AdminMovieList() {
   const [movies, setMovies] = useState<CatalogMovieDetail[]>([]);
   const [loading, setLoading] = useState(true);
+  const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<MovieStatus | "">("");
   const [deleteTarget, setDeleteTarget] = useState<CatalogMovieDetail | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 400);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
   const fetchMovies = useCallback(async () => {
     setLoading(true);
@@ -182,7 +188,7 @@ export function AdminMovieList() {
             <option value="em_breve">Em breve</option>
           </select>
         }
-        onSearch={setSearch}
+        onSearch={setSearchInput}
         searchPlaceholder="Buscar filme..."
         title="Filmes"
       />

--- a/frontend/src/components/admin/AdminMovieList.tsx
+++ b/frontend/src/components/admin/AdminMovieList.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { adminApi } from "@/api/admin";
+import type { CatalogMovieDetail } from "@/types/catalog";
+import type { MovieStatus } from "@/types/catalog";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { AdminConfirmDialog, AdminTable, AdminToolbar } from "@/components/admin";
+import type { AdminTableColumn } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+const STATUS_LABELS: Record<MovieStatus, string> = {
+  em_cartaz: "Em cartaz",
+  pre_venda: "Pré-venda",
+  em_breve: "Em breve",
+};
+
+const STATUS_TONES: Record<MovieStatus, "success" | "info" | "neutral"> = {
+  em_cartaz: "success",
+  pre_venda: "info",
+  em_breve: "neutral",
+};
+
+export function AdminMovieList() {
+  const [movies, setMovies] = useState<CatalogMovieDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<MovieStatus | "">("");
+  const [deleteTarget, setDeleteTarget] = useState<CatalogMovieDetail | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchMovies = useCallback(async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const result = await adminApi.listMovies({
+        search: search || undefined,
+        status: statusFilter || undefined,
+      });
+      setMovies(result.results);
+    } catch {
+      setErrorMessage("Não foi possível carregar os filmes. Tente novamente.");
+    } finally {
+      setLoading(false);
+    }
+  }, [search, statusFilter]);
+
+  useEffect(() => {
+    fetchMovies();
+  }, [fetchMovies]);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await adminApi.deleteMovie(deleteTarget.id);
+      setDeleteTarget(null);
+      fetchMovies();
+    } catch {
+      setErrorMessage("Não foi possível excluir o filme. Tente novamente.");
+      setDeleteTarget(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  const columns: AdminTableColumn<Record<string, unknown>>[] = [
+    {
+      className: "w-14",
+      key: "poster",
+      label: "Poster",
+      render: (row) => {
+        const movie = row as unknown as CatalogMovieDetail;
+        return movie.poster_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            alt={movie.title}
+            className="h-12 w-8 rounded object-cover"
+            src={movie.poster_url}
+          />
+        ) : (
+          <div className="h-12 w-8 rounded bg-white/[0.06]" />
+        );
+      },
+    },
+    {
+      key: "title",
+      label: "Título",
+      render: (row) => {
+        const movie = row as unknown as CatalogMovieDetail;
+        return (
+          <div className="flex flex-col gap-0.5">
+            <span className="font-bold text-white">{movie.title}</span>
+            {movie.genres.length > 0 && (
+              <span className="text-xs text-white/40">
+                {movie.genres.map((g) => g.name).join(", ")}
+              </span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      className: "hidden sm:table-cell",
+      key: "duration_minutes",
+      label: "Duração",
+      render: (row) => {
+        const movie = row as unknown as CatalogMovieDetail;
+        return `${movie.duration_minutes} min`;
+      },
+    },
+    {
+      className: "hidden md:table-cell",
+      key: "release_date",
+      label: "Lançamento",
+      render: (row) => {
+        const movie = row as unknown as CatalogMovieDetail;
+        return movie.release_date ?? "—";
+      },
+    },
+    {
+      key: "status",
+      label: "Status",
+      render: (row) => {
+        const movie = row as unknown as CatalogMovieDetail;
+        return (
+          <Badge size="sm" tone={STATUS_TONES[movie.status]}>
+            {STATUS_LABELS[movie.status]}
+          </Badge>
+        );
+      },
+    },
+    {
+      key: "actions",
+      label: "Ações",
+      render: (row) => {
+        const movie = row as unknown as CatalogMovieDetail;
+        return (
+          <div className="flex items-center gap-2">
+            <ButtonLink
+              href={`/admin/movies/${movie.id}/edit`}
+              size="sm"
+              variant="ghost"
+            >
+              Editar
+            </ButtonLink>
+            <Button
+              onClick={() => setDeleteTarget(movie)}
+              size="sm"
+              variant="danger"
+            >
+              Excluir
+            </Button>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="/admin/movies/new" size="sm" variant="primary">
+            Novo filme
+          </ButtonLink>
+        }
+        filters={
+          <select
+            aria-label="Filtrar por status"
+            className="rounded-control border border-white/[0.12] bg-white/[0.05] px-3 py-2 text-sm text-white outline-none transition focus:border-brand focus:bg-white/[0.07]"
+            onChange={(e) => setStatusFilter(e.target.value as MovieStatus | "")}
+            value={statusFilter}
+          >
+            <option value="">Todos os status</option>
+            <option value="em_cartaz">Em cartaz</option>
+            <option value="pre_venda">Pré-venda</option>
+            <option value="em_breve">Em breve</option>
+          </select>
+        }
+        onSearch={setSearch}
+        searchPlaceholder="Buscar filme..."
+        title="Filmes"
+      />
+
+      {errorMessage ? (
+        <p className="text-sm font-bold text-error" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <AdminTable
+        caption="Lista de filmes"
+        columns={columns}
+        data={movies as unknown as Record<string, unknown>[]}
+        emptyDescription="Nenhum filme encontrado. Adicione um novo filme para começar."
+        emptyTitle="Nenhum filme cadastrado"
+        keyField="id"
+        loading={loading}
+      />
+
+      <AdminConfirmDialog
+        confirmLabel={isDeleting ? "Excluindo..." : "Excluir"}
+        description={`Tem certeza que deseja excluir "${deleteTarget?.title}"? Esta ação não pode ser desfeita.`}
+        isOpen={deleteTarget !== null}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Excluir filme"
+        tone="danger"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/admin-movie-manager.test.ts
+++ b/frontend/src/components/admin/admin-movie-manager.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiError } from "@/api/client";
+import { extractFieldErrors } from "./AdminMovieForm";
+
+// --- extractFieldErrors ---
+
+test("extractFieldErrors returns empty object for non-ApiError", () => {
+  assert.deepEqual(extractFieldErrors(new Error("network")), {});
+  assert.deepEqual(extractFieldErrors("string error"), {});
+  assert.deepEqual(extractFieldErrors(null), {});
+});
+
+test("extractFieldErrors returns empty object for ApiError with non-validation code", () => {
+  const error = new ApiError("Not found", 404, {
+    code: "RESOURCE_NOT_FOUND",
+    details: { title: ["Required."] },
+  });
+
+  assert.deepEqual(extractFieldErrors(error), {});
+});
+
+test("extractFieldErrors extracts field-level messages from VALIDATION_FAILED error", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      title: ["Este campo é obrigatório."],
+      duration_minutes: ["Informe um valor positivo."],
+    },
+  });
+
+  assert.deepEqual(extractFieldErrors(error), {
+    duration_minutes: "Informe um valor positivo.",
+    title: "Este campo é obrigatório.",
+  });
+});
+
+test("extractFieldErrors joins multiple messages for the same field", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      title: ["Muito curto.", "Caracteres inválidos."],
+    },
+  });
+
+  const result = extractFieldErrors(error);
+
+  assert.equal(result.title, "Muito curto. Caracteres inválidos.");
+});
+
+test("extractFieldErrors handles single string value (not array)", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      poster_url: "Informe uma URL válida.",
+    },
+  });
+
+  assert.equal(extractFieldErrors(error).poster_url, "Informe uma URL válida.");
+});
+
+test("extractFieldErrors returns empty object when details is null", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: null,
+  });
+
+  assert.deepEqual(extractFieldErrors(error), {});
+});
+
+test("extractFieldErrors handles non_field_errors key", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      non_field_errors: ["Título e data de lançamento já existem."],
+    },
+  });
+
+  assert.equal(
+    extractFieldErrors(error).non_field_errors,
+    "Título e data de lançamento já existem."
+  );
+});

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,5 +1,8 @@
 export { AdminConfirmDialog } from "./AdminConfirmDialog";
 export { AdminEmptyState } from "./AdminEmptyState";
+export { AdminGenreList } from "./AdminGenreList";
+export { AdminMovieForm } from "./AdminMovieForm";
+export { AdminMovieList } from "./AdminMovieList";
 export { isAdminNavItemActive, ADMIN_NAV_LINKS } from "./admin-nav-utils";
 export type { AdminNavLink } from "./admin-nav-utils";
 export { AdminShell } from "./AdminShell";


### PR DESCRIPTION
## Objective

Give administrators a complete interface to manage the movie catalog and genre taxonomy from the admin console, covering all fields registered for movies today — including director, age rating, and cast.

## What was done

### 1. Backend: cast write support on MovieWriteSerializer

Extended `MovieWriteSerializer` to accept a `cast` field (list of actor names):

- Field declared `write_only=True` to avoid iterating the `RelatedManager` on serialization.
- `to_representation` explicitly resolves cast names from the `CastMember` relation.
- `create` and `update` lifecycle methods sync `CastMember` rows (full replace on update).

### 2. Admin API client

Expanded `src/api/admin.ts` with authenticated CRUD operations for movies and genres:

- `listMovies` — supports `status`, `search`, and `page` filters.
- `getMovie`, `createMovie`, `updateMovie`, `deleteMovie`.
- `listGenres`, `createGenre`, `updateGenre`, `deleteGenre`.

All functions include runtime type guards on responses, consistent with the existing catalog API pattern.

### 3. Movie list page

`AdminMovieList` — client component rendered at `/admin/movies`:

- Table with poster thumbnail, title, genre tags, duration, release date, and status badge.
- Search input and status filter (em cartaz / pré-venda / em breve).
- Edit link per row and delete button with `AdminConfirmDialog` confirmation.

### 4. Movie form

`AdminMovieForm` — client component shared by `/admin/movies/new` and `/admin/movies/[id]/edit`:

- All movie fields: title, synopsis, duration, release date, poster URL, status, featured flag, age rating, director.
- Poster URL field shows a live preview image below as the value is typed.
- Genre multi-select: pill toggles from the loaded genre list, plus a "+ Novo gênero" inline input that calls `adminApi.createGenre` and immediately adds the new genre to the selection — no page navigation required.
- Cast list: text input adds actor names one at a time; each entry renders as a removable pill.
- Backend `VALIDATION_FAILED` details are parsed by `extractFieldErrors` and rendered as inline error messages next to the relevant field.

### 5. Genre management page

`AdminGenreList` — client component rendered at `/admin/genres`:

- Table with all genres.
- "Novo gênero" button expands an inline create form above the table.
- Each row has an Edit button that replaces the name cell with an in-place text input; Salvar/Cancelar controls appear in the actions cell.
- Delete button with `AdminConfirmDialog` confirmation.

### 6. Pages wired

- `/admin/movies` → `AdminMovieList`
- `/admin/movies/new` → `AdminMovieForm` (create mode)
- `/admin/movies/[id]/edit` → `AdminEditMovieLoader` (fetches the movie client-side, then renders `AdminMovieForm` in edit mode)
- `/admin/genres` → `AdminGenreList`

### 7. Tests

- `src/api/admin.test.ts` — 14 cases covering all CRUD functions: URL construction, method, request body, response shape validation, and rejection of malformed responses.
- `src/components/admin/admin-movie-manager.test.ts` — 7 cases for `extractFieldErrors`: non-ApiError passthrough, non-validation code passthrough, field message extraction, multi-message join, single string value, null details, and `non_field_errors` key.

All 247 frontend and 237 backend tests pass.

## How to test

### Automated

```bash
# Frontend
npm --prefix frontend test

# Backend (requires running stack)
docker compose exec backend python -m pytest tests/ -q
```

### Manual

1. Start the stack:

```bash
docker compose up
```

2. Log in as an admin at `http://localhost:3000/admin`.

3. Navigate to **Filmes** and verify the list loads with search and status filter.

4. Click **Novo filme**, fill all fields including director, age rating, and cast members, upload a poster URL and confirm the preview renders, select genres (create a new one inline if needed), and submit.

5. Confirm the new movie appears in the list with the correct status badge.

6. Click **Editar** on the movie, change the featured flag and a cast member, and save.

7. Click **Excluir**, confirm the dialog, and verify the movie is removed.

8. Navigate to **Gêneros** and verify inline create, rename, and delete all work without page navigation.

9. Return to a movie form, add a genre created from the genre page, and confirm it appears in the genre list.

10. Submit the movie form with an empty required field and verify the error appears next to the correct input.

## Expected Result

- Administrators can perform full CRUD on movies and genres from the frontend.
- All movie fields registered in the data model are exposed in the form, including director, age rating, and cast.
- Genre management is available both as a standalone page and inline within the movie form.
- Backend validation errors surface next to the relevant fields instead of as a generic message.
- The poster preview provides immediate visual feedback without leaving the form.
- All automated tests pass.

closes #166