### PR TITLE
feat(admin): build admin session scheduler

### DIFF
--- a/frontend/src/api/admin.test.ts
+++ b/frontend/src/api/admin.test.ts
@@ -301,3 +301,257 @@ test("adminApi.createGenre rejects unexpected response shape", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+// ─── Session fixtures ─────────────────────────────────────────────────────────
+
+const sessionMovie = {
+  age_rating: null,
+  cast: null,
+  director: null,
+  duration_minutes: 120,
+  genres: [{ id: "genre-1", name: "Ação" }],
+  id: "movie-1",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/poster.jpg",
+  release_date: "2026-06-01",
+  status: "em_cartaz",
+  title: "Filme Teste",
+};
+
+const sessionRoom = {
+  capacity: 100,
+  description: null,
+  display_name: "Sala VIP Prime",
+  experience_type: "vip",
+  id: "room-1",
+  name: "Sala 1",
+};
+
+const session = {
+  audio_format: "legendado",
+  base_price: "54.00",
+  created_at: "2026-06-01T10:00:00Z",
+  end_time: "2026-06-10T22:00:00Z",
+  has_purchases: false,
+  has_reservations: false,
+  id: "session-1",
+  movie: sessionMovie,
+  projection_format: "3d",
+  room: sessionRoom,
+  seat_count: 48,
+  session_type: "preview",
+  start_time: "2026-06-10T19:30:00Z",
+  updated_at: "2026-06-01T10:00:00Z",
+};
+
+const paginatedSessions = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [session],
+};
+
+// ─── adminApi.listSessions ────────────────────────────────────────────────────
+
+test("adminApi.listSessions fetches the paginated session list", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/sessions/");
+      return Response.json(paginatedSessions);
+    };
+
+    const response = await adminApi.listSessions();
+
+    assert.equal(response.count, 1);
+    assert.equal(response.results[0].id, "session-1");
+    assert.equal(response.results[0].base_price, "54.00");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listSessions builds date, movie, and room filters", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  try {
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return Response.json({ count: 0, next: null, previous: null, results: [] });
+    };
+
+    await adminApi.listSessions({ date: "2026-06-10" });
+    await adminApi.listSessions({ movie: "movie-1" });
+    await adminApi.listSessions({ room: "room-1", page: 2 });
+    await adminApi.listSessions({ date: "2026-06-10", movie: "movie-1", room: "room-1" });
+
+    assert.deepEqual(requestedUrls, [
+      "http://localhost:8000/api/v1/catalog/sessions/?date=2026-06-10",
+      "http://localhost:8000/api/v1/catalog/sessions/?movie=movie-1",
+      "http://localhost:8000/api/v1/catalog/sessions/?room=room-1&page=2",
+      "http://localhost:8000/api/v1/catalog/sessions/?date=2026-06-10&movie=movie-1&room=room-1",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listSessions rejects non-paginated response", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json([]);
+
+    await assert.rejects(
+      adminApi.listSessions(),
+      /Unexpected admin session list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.getSession ──────────────────────────────────────────────────────
+
+test("adminApi.getSession fetches a single session by id", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/session-1/"
+      );
+      return Response.json(session);
+    };
+
+    const result = await adminApi.getSession("session-1");
+
+    assert.equal(result.id, "session-1");
+    assert.equal(result.base_price, "54.00");
+    assert.equal(result.movie.title, "Filme Teste");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.getSession rejects unexpected response shape", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ id: "session-1" });
+
+    await assert.rejects(
+      adminApi.getSession("session-1"),
+      /Unexpected admin session detail response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.createSession ───────────────────────────────────────────────────
+
+test("adminApi.createSession posts the session payload", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/catalog/sessions/");
+      assert.equal(init?.method, "POST");
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.movie, "movie-1");
+      assert.equal(body.room, "room-1");
+      assert.equal(body.base_price, "54.00");
+      assert.equal(body.audio_format, "legendado");
+      assert.equal(body.projection_format, "3d");
+      return Response.json(session);
+    };
+
+    const created = await adminApi.createSession({
+      audio_format: "legendado",
+      base_price: "54.00",
+      end_time: "2026-06-10T22:00:00Z",
+      movie: "movie-1",
+      projection_format: "3d",
+      room: "room-1",
+      session_type: "preview",
+      start_time: "2026-06-10T19:30:00Z",
+    });
+
+    assert.equal(created.id, "session-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.createSession rejects unexpected response shape", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ id: "session-1" });
+
+    await assert.rejects(
+      adminApi.createSession({
+        base_price: "54.00",
+        end_time: "2026-06-10T22:00:00Z",
+        movie: "movie-1",
+        room: "room-1",
+        start_time: "2026-06-10T19:30:00Z",
+      }),
+      /Unexpected admin create session response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.updateSession ───────────────────────────────────────────────────
+
+test("adminApi.updateSession patches the session by id", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/session-1/"
+      );
+      assert.equal(init?.method, "PATCH");
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.audio_format, "dublado");
+      return Response.json({ ...session, audio_format: "dublado" });
+    };
+
+    const updated = await adminApi.updateSession("session-1", {
+      audio_format: "dublado",
+    });
+
+    assert.equal(updated.audio_format, "dublado");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.deleteSession ───────────────────────────────────────────────────
+
+test("adminApi.deleteSession sends a DELETE request", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/catalog/sessions/session-1/"
+      );
+      assert.equal(init?.method, "DELETE");
+      return new Response(null, { status: 204 });
+    };
+
+    await adminApi.deleteSession("session-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -2,10 +2,14 @@ import type {
   AdminRoom,
   AdminSeat,
   AdminSeatRow,
+  AdminSession,
+  CatalogAudioFormat,
   CatalogGenre,
   CatalogMovieAgeRating,
   CatalogMovieDetail,
+  CatalogProjectionFormat,
   CatalogRoomExperienceType,
+  CatalogSessionType,
   MovieStatus,
 } from "@/types/catalog";
 
@@ -59,6 +63,24 @@ export type AdminSeatWritePayload = {
   row: string;
 };
 
+export type AdminSessionWritePayload = {
+  audio_format?: CatalogAudioFormat;
+  base_price: string;
+  end_time: string;
+  movie: string;
+  projection_format?: CatalogProjectionFormat;
+  room: string;
+  session_type?: CatalogSessionType;
+  start_time: string;
+};
+
+export type ListSessionsParams = {
+  date?: string;
+  movie?: string;
+  page?: number;
+  room?: string;
+};
+
 export type AdminGenre = CatalogGenre & {
   created_at?: string;
   updated_at?: string;
@@ -67,6 +89,7 @@ export type AdminGenre = CatalogGenre & {
 const MOVIES_PATH = "/api/v1/catalog/movies/";
 const GENRES_PATH = "/api/v1/catalog/genres/";
 const ROOMS_PATH = "/api/v1/catalog/rooms/";
+const SESSIONS_PATH = "/api/v1/catalog/sessions/";
 const SEAT_ROWS_PATH = "/api/v1/reservation/seat-rows/";
 const SEATS_PATH = "/api/v1/reservation/seats/";
 
@@ -350,6 +373,68 @@ export const adminApi = {
       method: "DELETE",
     });
   },
+
+  async listSessions(params: ListSessionsParams = {}) {
+    const query = buildSessionsQuery(params);
+    const response = await apiRequest<unknown>(
+      query ? `${SESSIONS_PATH}?${query}` : SESSIONS_PATH,
+      { auth: "required", method: "GET" }
+    );
+
+    if (!isPaginatedResponse<AdminSession>(response)) {
+      throw new Error("Unexpected admin session list response.");
+    }
+
+    return response satisfies PaginatedResponse<AdminSession>;
+  },
+
+  async getSession(sessionId: string) {
+    const response = await apiRequest<unknown>(`${SESSIONS_PATH}${sessionId}/`, {
+      auth: "required",
+      method: "GET",
+    });
+
+    if (!isAdminSession(response)) {
+      throw new Error("Unexpected admin session detail response.");
+    }
+
+    return response satisfies AdminSession;
+  },
+
+  async createSession(payload: AdminSessionWritePayload) {
+    const response = await apiRequest<unknown>(SESSIONS_PATH, {
+      auth: "required",
+      json: payload,
+      method: "POST",
+    });
+
+    if (!isAdminSession(response)) {
+      throw new Error("Unexpected admin create session response.");
+    }
+
+    return response satisfies AdminSession;
+  },
+
+  async updateSession(sessionId: string, payload: Partial<AdminSessionWritePayload>) {
+    const response = await apiRequest<unknown>(`${SESSIONS_PATH}${sessionId}/`, {
+      auth: "required",
+      json: payload,
+      method: "PATCH",
+    });
+
+    if (!isAdminSession(response)) {
+      throw new Error("Unexpected admin update session response.");
+    }
+
+    return response satisfies AdminSession;
+  },
+
+  async deleteSession(sessionId: string) {
+    await apiRequest<unknown>(`${SESSIONS_PATH}${sessionId}/`, {
+      auth: "required",
+      method: "DELETE",
+    });
+  },
 };
 
 function buildMoviesPath({
@@ -486,4 +571,29 @@ function isMovieStatus(value: unknown): value is MovieStatus {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isAdminSession(value: unknown): value is AdminSession {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.start_time === "string" &&
+    typeof value.end_time === "string" &&
+    typeof value.base_price === "string" &&
+    isRecord(value.movie) &&
+    typeof value.movie.id === "string" &&
+    isRecord(value.room) &&
+    typeof value.room.id === "string"
+  );
+}
+
+function buildSessionsQuery({ date, movie, page, room }: ListSessionsParams) {
+  const searchParams = new URLSearchParams();
+
+  if (date) searchParams.set("date", date);
+  if (movie) searchParams.set("movie", movie);
+  if (room) searchParams.set("room", room);
+  if (page !== undefined) searchParams.set("page", String(page));
+
+  return searchParams.toString();
 }

--- a/frontend/src/app/admin/sessions/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/sessions/[id]/edit/page.tsx
@@ -1,0 +1,10 @@
+import { AdminEditSessionLoader } from "@/components/admin/AdminEditSessionLoader";
+
+export default async function AdminEditSessionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <AdminEditSessionLoader sessionId={id} />;
+}

--- a/frontend/src/app/admin/sessions/new/page.tsx
+++ b/frontend/src/app/admin/sessions/new/page.tsx
@@ -1,0 +1,19 @@
+import { AdminSessionForm } from "@/components/admin/AdminSessionForm";
+import { AdminToolbar } from "@/components/admin";
+import { ButtonLink } from "@/components/ui/Button";
+
+export default function AdminNewSessionPage() {
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="/admin/sessions" size="sm" variant="ghost">
+            Voltar
+          </ButtonLink>
+        }
+        title="Nova sessão"
+      />
+      <AdminSessionForm />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/sessions/page.tsx
+++ b/frontend/src/app/admin/sessions/page.tsx
@@ -1,21 +1,5 @@
-import { AdminEmptyState, AdminToolbar } from "@/components/admin";
-import { ButtonLink } from "@/components/ui/Button";
+import { AdminSessionList } from "@/components/admin/AdminSessionList";
 
 export default function AdminSessionsPage() {
-  return (
-    <div className="grid gap-6">
-      <AdminToolbar
-        actions={
-          <ButtonLink href="#" size="sm" variant="primary">
-            Nova sessão
-          </ButtonLink>
-        }
-        title="Sessões"
-      />
-      <AdminEmptyState
-        description="O gerenciamento de sessões será implementado em breve."
-        title="Nenhuma sessão cadastrada"
-      />
-    </div>
-  );
+  return <AdminSessionList />;
 }

--- a/frontend/src/components/admin/AdminEditSessionLoader.tsx
+++ b/frontend/src/components/admin/AdminEditSessionLoader.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { adminApi } from "@/api/admin";
+import type { AdminSession } from "@/types/catalog";
+import { ButtonLink } from "@/components/ui/Button";
+import { AdminSessionForm } from "./AdminSessionForm";
+import { AdminToolbar } from "./AdminToolbar";
+
+export function AdminEditSessionLoader({ sessionId }: { sessionId: string }) {
+  const [session, setSession] = useState<AdminSession | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminApi
+      .getSession(sessionId)
+      .then(setSession)
+      .catch(() =>
+        setError(
+          "Sessão não encontrada ou você não tem permissão para editá-la."
+        )
+      )
+      .finally(() => setLoading(false));
+  }, [sessionId]);
+
+  if (loading) {
+    return (
+      <div className="grid gap-6">
+        <AdminToolbar
+          actions={
+            <ButtonLink href="/admin/sessions" size="sm" variant="ghost">
+              Voltar
+            </ButtonLink>
+          }
+          title="Editar sessão"
+        />
+        <div className="grid max-w-2xl gap-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              className="h-10 animate-pulse rounded-[8px] bg-white/[0.05]"
+              key={i}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !session) {
+    return (
+      <div className="grid gap-6">
+        <AdminToolbar
+          actions={
+            <ButtonLink href="/admin/sessions" size="sm" variant="ghost">
+              Voltar
+            </ButtonLink>
+          }
+          title="Editar sessão"
+        />
+        <p className="text-sm font-bold text-error" role="alert">
+          {error ?? "Sessão não encontrada."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="/admin/sessions" size="sm" variant="ghost">
+            Voltar
+          </ButtonLink>
+        }
+        title={`Editar: ${session.movie.title} — ${formatDate(session.start_time)}`}
+      />
+      <AdminSessionForm session={session} />
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}

--- a/frontend/src/components/admin/AdminSessionForm.tsx
+++ b/frontend/src/components/admin/AdminSessionForm.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useState, type FormEvent } from "react";
+
+import { adminApi, type AdminSessionWritePayload } from "@/api/admin";
+import { ApiError } from "@/api/client";
+import type {
+  AdminRoom,
+  AdminSession,
+  CatalogAudioFormat,
+  CatalogMovieDetail,
+  CatalogProjectionFormat,
+  CatalogSessionType,
+} from "@/types/catalog";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+
+type FieldErrors = Partial<
+  Record<keyof AdminSessionWritePayload | "non_field_errors", string>
+>;
+
+type AdminSessionFormProps = {
+  session?: AdminSession;
+};
+
+const AUDIO_FORMAT_OPTIONS = [
+  { label: "Original", value: "original" },
+  { label: "Legendado", value: "legendado" },
+  { label: "Dublado", value: "dublado" },
+];
+
+const PROJECTION_FORMAT_OPTIONS = [
+  { label: "2D", value: "2d" },
+  { label: "3D", value: "3d" },
+  { label: "IMAX", value: "imax" },
+];
+
+const SESSION_TYPE_OPTIONS = [
+  { label: "Regular", value: "regular" },
+  { label: "Pré-estreia", value: "preview" },
+  { label: "Evento especial", value: "special_event" },
+];
+
+export function extractSessionFieldErrors(error: unknown): FieldErrors {
+  if (!(error instanceof ApiError) || error.code !== "VALIDATION_FAILED") {
+    return {};
+  }
+
+  const details = error.details as Record<string, unknown> | null;
+  if (!details || typeof details !== "object") {
+    return {};
+  }
+
+  const result: FieldErrors = {};
+
+  for (const [key, val] of Object.entries(details)) {
+    const messages = Array.isArray(val) ? val : [val];
+    result[key as keyof FieldErrors] = messages.join(" ");
+  }
+
+  return result;
+}
+
+function isConflictError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    (error.status === 409 ||
+      (error.status === 400 &&
+        typeof error.message === "string" &&
+        /overlap|conflict|horário|já existe/i.test(error.message)))
+  );
+}
+
+function FormField({
+  children,
+  error,
+  hint,
+  label,
+  labelFor,
+}: {
+  children: React.ReactNode;
+  error?: string;
+  hint?: string;
+  label: string;
+  labelFor: string;
+}) {
+  const errorId = error ? `${labelFor}-error` : undefined;
+
+  return (
+    <div className="grid gap-1.5">
+      <label className="text-sm font-extrabold text-white" htmlFor={labelFor}>
+        {label}
+      </label>
+      {hint ? <p className="text-xs text-white/40">{hint}</p> : null}
+      {children}
+      {error ? (
+        <p className="text-sm font-bold text-error" id={errorId} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function TextInput({
+  error,
+  id,
+  ...props
+}: React.InputHTMLAttributes<HTMLInputElement> & { error?: string }) {
+  return (
+    <input
+      aria-invalid={error ? "true" : undefined}
+      className={[
+        "min-h-[var(--control-height-lg)] w-full rounded-control border bg-surface px-3 py-2",
+        "text-sm text-white placeholder:text-white/30 outline-none transition",
+        "focus:border-brand focus:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
+        error ? "border-error" : "border-border",
+      ].join(" ")}
+      id={id}
+      {...props}
+    />
+  );
+}
+
+function isProtected(session?: AdminSession): boolean {
+  return Boolean(session?.has_reservations || session?.has_purchases);
+}
+
+export function AdminSessionForm({ session }: AdminSessionFormProps) {
+  const router = useRouter();
+  const isEditing = session !== undefined;
+  const locked = isProtected(session);
+
+  const [movieId, setMovieId] = useState(session?.movie.id ?? "");
+  const [roomId, setRoomId] = useState(session?.room.id ?? "");
+  const [startTime, setStartTime] = useState(
+    session ? toLocalDateTimeInput(session.start_time) : ""
+  );
+  const [endTime, setEndTime] = useState(
+    session ? toLocalDateTimeInput(session.end_time) : ""
+  );
+  const [basePrice, setBasePrice] = useState(session?.base_price ?? "");
+  const [audioFormat, setAudioFormat] = useState<CatalogAudioFormat>(
+    (session?.audio_format as CatalogAudioFormat) ?? ""
+  );
+  const [projectionFormat, setProjectionFormat] =
+    useState<CatalogProjectionFormat>(
+      (session?.projection_format as CatalogProjectionFormat) ?? ""
+    );
+  const [sessionType, setSessionType] = useState<CatalogSessionType>(
+    (session?.session_type as CatalogSessionType) ?? ""
+  );
+
+  const [movies, setMovies] = useState<CatalogMovieDetail[]>([]);
+  const [rooms, setRooms] = useState<AdminRoom[]>([]);
+  const [loadingOptions, setLoadingOptions] = useState(true);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [conflictError, setConflictError] = useState<string | null>(null);
+
+  const movieSelectId = useId();
+  const roomSelectId = useId();
+  const startTimeId = useId();
+  const endTimeId = useId();
+  const basePriceId = useId();
+
+  useEffect(() => {
+    Promise.all([adminApi.listMovies({ page: 1 }), adminApi.listRooms()])
+      .then(([moviesRes, roomsRes]) => {
+        setMovies(moviesRes.results);
+        setRooms(roomsRes.results);
+      })
+      .catch(() => {
+        setGlobalError("Não foi possível carregar filmes e salas.");
+      })
+      .finally(() => setLoadingOptions(false));
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFieldErrors({});
+    setGlobalError(null);
+    setConflictError(null);
+    setIsSubmitting(true);
+
+    const payload: AdminSessionWritePayload = {
+      audio_format: audioFormat || undefined,
+      base_price: basePrice,
+      end_time: toISOString(endTime),
+      movie: movieId,
+      projection_format: projectionFormat || undefined,
+      room: roomId,
+      session_type: sessionType || undefined,
+      start_time: toISOString(startTime),
+    };
+
+    try {
+      if (isEditing) {
+        await adminApi.updateSession(session.id, payload);
+      } else {
+        await adminApi.createSession(payload);
+      }
+      router.push("/admin/sessions");
+      router.refresh();
+    } catch (err) {
+      if (isConflictError(err)) {
+        const msg =
+          err instanceof ApiError ? err.message : String(err);
+        setConflictError(
+          `Conflito de horário: ${msg}. Escolha outro horário ou sala para esta sessão.`
+        );
+        return;
+      }
+
+      const errors = extractSessionFieldErrors(err);
+      if (Object.keys(errors).length > 0) {
+        setFieldErrors(errors);
+        setGlobalError("Corrija os erros indicados e tente novamente.");
+      } else if (err instanceof ApiError) {
+        setGlobalError(`Erro: ${err.message}`);
+      } else {
+        setGlobalError("Não foi possível salvar a sessão. Tente novamente.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const movieOptions = movies.map((m) => ({ label: m.title, value: m.id }));
+  const roomOptions = rooms.map((r) => ({
+    label: r.display_name ? `${r.name} — ${r.display_name}` : r.name,
+    value: r.id,
+  }));
+
+  const formDisabled = isSubmitting || loadingOptions;
+
+  return (
+    <form className="grid max-w-2xl gap-6" onSubmit={handleSubmit}>
+      {globalError ? (
+        <p
+          className="rounded-[8px] border border-error/30 bg-error/10 px-4 py-3 text-sm font-bold text-error"
+          role="alert"
+        >
+          {globalError}
+        </p>
+      ) : null}
+
+      {fieldErrors.non_field_errors ? (
+        <p
+          className="rounded-[8px] border border-error/30 bg-error/10 px-4 py-3 text-sm font-bold text-error"
+          role="alert"
+        >
+          {fieldErrors.non_field_errors}
+        </p>
+      ) : null}
+
+      {conflictError ? (
+        <div
+          className="rounded-[8px] border border-[#b45309]/30 bg-[#92400e]/10 px-4 py-3"
+          role="alert"
+        >
+          <p className="text-sm font-bold text-[#fbbf24]">
+            Conflito de agenda detectado
+          </p>
+          <p className="mt-1 text-sm text-[#fcd34d]/80">{conflictError}</p>
+        </div>
+      ) : null}
+
+      {locked ? (
+        <div className="rounded-[8px] border border-white/10 bg-white/[0.04] px-4 py-3">
+          <p className="text-sm font-bold text-white/70">
+            Sessão com reservas ou compras ativas
+          </p>
+          <p className="mt-1 text-xs text-white/40">
+            Filme, sala, horários e preço não podem ser alterados pois esta
+            sessão já possui assentos reservados ou comprados. Você pode
+            atualizar apenas os metadados opcionais (formato, áudio, tipo).
+          </p>
+        </div>
+      ) : null}
+
+      {!isEditing ? (
+        <div className="rounded-[8px] border border-brand/20 bg-brand/5 px-4 py-3">
+          <p className="text-sm font-bold text-brand/80">
+            Geração automática de assentos
+          </p>
+          <p className="mt-1 text-xs text-white/50">
+            Ao criar esta sessão, os assentos serão gerados automaticamente com
+            base no layout atual da sala selecionada. Alterações futuras no
+            layout da sala não afetarão sessões já criadas.
+          </p>
+        </div>
+      ) : null}
+
+      <Select
+        disabled={formDisabled || locked}
+        error={fieldErrors.movie}
+        id={movieSelectId}
+        label="Filme"
+        onChange={(e) => setMovieId(e.target.value)}
+        options={movieOptions}
+        placeholder={loadingOptions ? "Carregando..." : "Selecione um filme"}
+        required
+        value={movieId}
+      />
+
+      <Select
+        disabled={formDisabled || locked}
+        error={fieldErrors.room}
+        id={roomSelectId}
+        label="Sala"
+        onChange={(e) => setRoomId(e.target.value)}
+        options={roomOptions}
+        placeholder={loadingOptions ? "Carregando..." : "Selecione uma sala"}
+        required
+        value={roomId}
+      />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <FormField
+          error={fieldErrors.start_time}
+          hint="Data e hora de início da sessão."
+          label="Início"
+          labelFor={startTimeId}
+        >
+          <TextInput
+            disabled={formDisabled || locked}
+            error={fieldErrors.start_time}
+            id={startTimeId}
+            onChange={(e) => setStartTime(e.target.value)}
+            required
+            type="datetime-local"
+            value={startTime}
+          />
+        </FormField>
+
+        <FormField
+          error={fieldErrors.end_time}
+          hint="Data e hora de término."
+          label="Fim"
+          labelFor={endTimeId}
+        >
+          <TextInput
+            disabled={formDisabled || locked}
+            error={fieldErrors.end_time}
+            id={endTimeId}
+            onChange={(e) => setEndTime(e.target.value)}
+            required
+            type="datetime-local"
+            value={endTime}
+          />
+        </FormField>
+      </div>
+
+      <FormField
+        error={fieldErrors.base_price}
+        hint="Valor inteiro do ingresso para esta sessão (em R$)."
+        label="Preço base (R$)"
+        labelFor={basePriceId}
+      >
+        <TextInput
+          disabled={formDisabled || locked}
+          error={fieldErrors.base_price}
+          id={basePriceId}
+          min="0.01"
+          onChange={(e) => setBasePrice(e.target.value)}
+          placeholder="Ex.: 54.00"
+          required
+          step="0.01"
+          type="number"
+          value={basePrice}
+        />
+      </FormField>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Select
+          disabled={formDisabled}
+          error={fieldErrors.audio_format}
+          label="Formato de áudio"
+          onChange={(e) => setAudioFormat(e.target.value as CatalogAudioFormat)}
+          options={AUDIO_FORMAT_OPTIONS}
+          placeholder="Não especificado"
+          value={audioFormat}
+        />
+
+        <Select
+          disabled={formDisabled}
+          error={fieldErrors.projection_format}
+          label="Projeção"
+          onChange={(e) =>
+            setProjectionFormat(e.target.value as CatalogProjectionFormat)
+          }
+          options={PROJECTION_FORMAT_OPTIONS}
+          placeholder="Não especificado"
+          value={projectionFormat}
+        />
+
+        <Select
+          disabled={formDisabled}
+          error={fieldErrors.session_type}
+          label="Tipo de sessão"
+          onChange={(e) => setSessionType(e.target.value as CatalogSessionType)}
+          options={SESSION_TYPE_OPTIONS}
+          placeholder="Não especificado"
+          value={sessionType}
+        />
+      </div>
+
+      <div className="flex justify-end gap-2 border-t border-white/[0.07] pt-4">
+        <Button
+          disabled={isSubmitting}
+          onClick={() => router.push("/admin/sessions")}
+          type="button"
+          variant="ghost"
+        >
+          Cancelar
+        </Button>
+        <Button isLoading={isSubmitting} type="submit" variant="primary">
+          {isEditing ? "Salvar alterações" : "Criar sessão"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function toLocalDateTimeInput(isoString: string): string {
+  const date = new Date(isoString);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function toISOString(localDateTimeInput: string): string {
+  return new Date(localDateTimeInput).toISOString();
+}

--- a/frontend/src/components/admin/AdminSessionList.tsx
+++ b/frontend/src/components/admin/AdminSessionList.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useCallback, useEffect, useId, useState } from "react";
+
+import { adminApi } from "@/api/admin";
+import type { AdminRoom, AdminSession, CatalogMovieDetail } from "@/types/catalog";
+import { Badge } from "@/components/ui/Badge";
+import { Button, ButtonLink } from "@/components/ui/Button";
+import { AdminConfirmDialog, AdminTable, AdminToolbar } from "@/components/admin";
+import type { AdminTableColumn } from "@/components/admin";
+
+const AUDIO_LABELS: Record<string, string> = {
+  dublado: "Dublado",
+  legendado: "Legendado",
+  original: "Original",
+};
+
+const PROJECTION_LABELS: Record<string, string> = {
+  "2d": "2D",
+  "3d": "3D",
+  imax: "IMAX",
+};
+
+const SESSION_TYPE_LABELS: Record<string, string> = {
+  preview: "Pré-estreia",
+  regular: "Regular",
+  special_event: "Evento especial",
+};
+
+function formatDateTime(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleDateString("pt-BR");
+}
+
+function isProtected(session: AdminSession): boolean {
+  return Boolean(session.has_reservations || session.has_purchases);
+}
+
+export function AdminSessionList() {
+  const [sessions, setSessions] = useState<AdminSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminSession | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [dateFilter, setDateFilter] = useState("");
+  const [movieFilter, setMovieFilter] = useState("");
+  const [roomFilter, setRoomFilter] = useState("");
+
+  const [movies, setMovies] = useState<CatalogMovieDetail[]>([]);
+  const [rooms, setRooms] = useState<AdminRoom[]>([]);
+
+  const dateFilterId = useId();
+  const movieFilterId = useId();
+  const roomFilterId = useId();
+
+  useEffect(() => {
+    Promise.all([adminApi.listMovies(), adminApi.listRooms()]).then(
+      ([moviesRes, roomsRes]) => {
+        setMovies(moviesRes.results);
+        setRooms(roomsRes.results);
+      }
+    );
+  }, []);
+
+  const fetchSessions = useCallback(
+    async (pageNum: number, replace: boolean) => {
+      if (replace) setLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const result = await adminApi.listSessions({
+          date: dateFilter || undefined,
+          movie: movieFilter || undefined,
+          page: pageNum,
+          room: roomFilter || undefined,
+        });
+
+        if (replace) {
+          setSessions(result.results);
+        } else {
+          setSessions((prev) => [...prev, ...result.results]);
+        }
+
+        setHasMore(result.next !== null);
+        setPage(pageNum);
+      } catch {
+        setErrorMessage("Não foi possível carregar as sessões. Tente novamente.");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [dateFilter, movieFilter, roomFilter]
+  );
+
+  useEffect(() => {
+    fetchSessions(1, true);
+  }, [fetchSessions]);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await adminApi.deleteSession(deleteTarget.id);
+      setDeleteTarget(null);
+      fetchSessions(1, true);
+    } catch {
+      setErrorMessage("Não foi possível excluir a sessão. Tente novamente.");
+      setDeleteTarget(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  const columns: AdminTableColumn<Record<string, unknown>>[] = [
+    {
+      key: "movie",
+      label: "Filme",
+      render: (row) => {
+        const s = row as unknown as AdminSession;
+        return (
+          <div className="flex flex-col gap-0.5">
+            <span className="font-bold text-white">{s.movie.title}</span>
+            <span className="text-xs text-white/40">
+              {formatDateTime(s.start_time)}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      className: "hidden sm:table-cell",
+      key: "room",
+      label: "Sala",
+      render: (row) => {
+        const s = row as unknown as AdminSession;
+        return (
+          <span className="text-white/80">
+            {s.room.display_name ?? s.room.name}
+          </span>
+        );
+      },
+    },
+    {
+      className: "hidden md:table-cell",
+      key: "base_price",
+      label: "Preço base",
+      render: (row) => {
+        const s = row as unknown as AdminSession;
+        return (
+          <span className="text-white/80">
+            {Number(s.base_price).toLocaleString("pt-BR", {
+              currency: "BRL",
+              style: "currency",
+            })}
+          </span>
+        );
+      },
+    },
+    {
+      className: "hidden lg:table-cell",
+      key: "formats",
+      label: "Formato",
+      render: (row) => {
+        const s = row as unknown as AdminSession;
+        const tags: string[] = [];
+        if (s.audio_format) tags.push(AUDIO_LABELS[s.audio_format] ?? s.audio_format);
+        if (s.projection_format)
+          tags.push(PROJECTION_LABELS[s.projection_format] ?? s.projection_format);
+        if (s.session_type)
+          tags.push(SESSION_TYPE_LABELS[s.session_type] ?? s.session_type);
+
+        if (tags.length === 0) return <span className="text-white/30">—</span>;
+
+        return (
+          <div className="flex flex-wrap gap-1">
+            {tags.map((tag) => (
+              <Badge key={tag} size="sm" tone="neutral">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        );
+      },
+    },
+    {
+      key: "actions",
+      label: "Ações",
+      render: (row) => {
+        const s = row as unknown as AdminSession;
+        const protected_ = isProtected(s);
+
+        return (
+          <div className="flex flex-wrap items-center gap-2">
+            <ButtonLink
+              href={`/admin/sessions/${s.id}/edit`}
+              size="sm"
+              variant="ghost"
+            >
+              Editar
+            </ButtonLink>
+            <Button
+              disabled={protected_}
+              onClick={() => !protected_ && setDeleteTarget(s)}
+              size="sm"
+              title={
+                protected_
+                  ? "Esta sessão possui assentos reservados ou comprados"
+                  : undefined
+              }
+              variant="danger"
+            >
+              Excluir
+            </Button>
+          </div>
+        );
+      },
+    },
+  ];
+
+  const movieOptions = movies.map((m) => ({ label: m.title, value: m.id }));
+  const roomOptions = rooms.map((r) => ({
+    label: r.display_name ? `${r.name} — ${r.display_name}` : r.name,
+    value: r.id,
+  }));
+
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        actions={
+          <ButtonLink href="/admin/sessions/new" size="sm" variant="primary">
+            Nova sessão
+          </ButtonLink>
+        }
+        title="Sessões"
+      />
+
+      <div className="flex flex-wrap items-end gap-4 rounded-[8px] border border-white/[0.07] bg-white/[0.02] p-4">
+        <div className="grid gap-1.5">
+          <label
+            className="text-xs font-extrabold uppercase tracking-wider text-white/40"
+            htmlFor={dateFilterId}
+          >
+            Data
+          </label>
+          <input
+            className="min-h-9 rounded-control border border-border bg-surface px-3 py-2 text-sm text-white outline-none transition focus:border-brand focus:shadow-focus"
+            id={dateFilterId}
+            onChange={(e) => setDateFilter(e.target.value)}
+            type="date"
+            value={dateFilter}
+          />
+        </div>
+
+        <div className="grid gap-1.5">
+          <label
+            className="text-xs font-extrabold uppercase tracking-wider text-white/40"
+            htmlFor={movieFilterId}
+          >
+            Filme
+          </label>
+          <select
+            className="min-h-9 rounded-control border border-border bg-surface px-3 py-2 text-sm text-white outline-none transition focus:border-brand focus:shadow-focus"
+            id={movieFilterId}
+            onChange={(e) => setMovieFilter(e.target.value)}
+            value={movieFilter}
+          >
+            <option value="">Todos os filmes</option>
+            {movieOptions.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid gap-1.5">
+          <label
+            className="text-xs font-extrabold uppercase tracking-wider text-white/40"
+            htmlFor={roomFilterId}
+          >
+            Sala
+          </label>
+          <select
+            className="min-h-9 rounded-control border border-border bg-surface px-3 py-2 text-sm text-white outline-none transition focus:border-brand focus:shadow-focus"
+            id={roomFilterId}
+            onChange={(e) => setRoomFilter(e.target.value)}
+            value={roomFilter}
+          >
+            <option value="">Todas as salas</option>
+            {roomOptions.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {(dateFilter || movieFilter || roomFilter) && (
+          <Button
+            onClick={() => {
+              setDateFilter("");
+              setMovieFilter("");
+              setRoomFilter("");
+            }}
+            size="sm"
+            variant="ghost"
+          >
+            Limpar filtros
+          </Button>
+        )}
+      </div>
+
+      {errorMessage ? (
+        <p className="text-sm font-bold text-error" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <AdminTable
+        caption="Lista de sessões"
+        columns={columns}
+        data={sessions as unknown as Record<string, unknown>[]}
+        emptyDescription="Nenhuma sessão encontrada. Ajuste os filtros ou crie uma nova sessão."
+        emptyTitle="Nenhuma sessão encontrada"
+        keyField="id"
+        loading={loading}
+      />
+
+      {hasMore ? (
+        <div className="flex justify-center">
+          <Button
+            onClick={() => fetchSessions(page + 1, false)}
+            variant="ghost"
+          >
+            Carregar mais
+          </Button>
+        </div>
+      ) : null}
+
+      <AdminConfirmDialog
+        confirmLabel={isDeleting ? "Excluindo..." : "Excluir"}
+        description={
+          deleteTarget
+            ? `Tem certeza que deseja excluir a sessão de "${deleteTarget.movie.title}" em ${formatDate(deleteTarget.start_time)}? Esta ação não pode ser desfeita.`
+            : ""
+        }
+        isOpen={deleteTarget !== null}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Excluir sessão"
+        tone="danger"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/admin-session-manager.test.ts
+++ b/frontend/src/components/admin/admin-session-manager.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiError } from "@/api/client";
+import { extractSessionFieldErrors } from "./AdminSessionForm";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const sessionMovie = {
+  age_rating: null,
+  cast: null,
+  director: null,
+  duration_minutes: 120,
+  genres: [{ id: "genre-1", name: "Ação" }],
+  id: "movie-1",
+  is_featured: false,
+  poster_url: "https://cdn.example.com/poster.jpg",
+  release_date: "2026-06-01",
+  status: "em_cartaz",
+  title: "Filme Teste",
+};
+
+const sessionRoom = {
+  capacity: 100,
+  description: null,
+  display_name: "Sala VIP Prime",
+  experience_type: "vip",
+  id: "room-1",
+  name: "Sala 1",
+};
+
+const session = {
+  audio_format: "legendado",
+  base_price: "54.00",
+  end_time: "2026-06-10T22:00:00Z",
+  has_purchases: false,
+  has_reservations: false,
+  id: "session-1",
+  movie: sessionMovie,
+  projection_format: "3d",
+  room: sessionRoom,
+  session_type: "preview",
+  start_time: "2026-06-10T19:30:00Z",
+};
+
+const paginatedSessions = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [session],
+};
+
+// ─── extractSessionFieldErrors ────────────────────────────────────────────────
+
+test("extractSessionFieldErrors returns empty object for non-ApiError", () => {
+  assert.deepEqual(extractSessionFieldErrors(new Error("network")), {});
+  assert.deepEqual(extractSessionFieldErrors(null), {});
+  assert.deepEqual(extractSessionFieldErrors(undefined), {});
+});
+
+test("extractSessionFieldErrors returns empty for non-validation ApiError", () => {
+  const error = new ApiError("Not found", 404, {
+    code: "RESOURCE_NOT_FOUND",
+    details: { movie: ["Required."] },
+  });
+  assert.deepEqual(extractSessionFieldErrors(error), {});
+});
+
+test("extractSessionFieldErrors extracts field errors from VALIDATION_FAILED", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      base_price: ["Este campo é obrigatório."],
+      end_time: ["O horário de fim deve ser após o início."],
+      movie: ["Selecione um filme válido."],
+    },
+  });
+  const result = extractSessionFieldErrors(error);
+  assert.equal(result.base_price, "Este campo é obrigatório.");
+  assert.equal(result.end_time, "O horário de fim deve ser após o início.");
+  assert.equal(result.movie, "Selecione um filme válido.");
+});
+
+test("extractSessionFieldErrors joins multiple messages per field", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      start_time: ["Campo obrigatório.", "Formato inválido."],
+    },
+  });
+  const result = extractSessionFieldErrors(error);
+  assert.equal(result.start_time, "Campo obrigatório. Formato inválido.");
+});
+
+test("extractSessionFieldErrors handles non_field_errors", () => {
+  const error = new ApiError("Validation failed", 400, {
+    code: "VALIDATION_FAILED",
+    details: {
+      non_field_errors: ["A sessão conflita com outra sessão na mesma sala."],
+    },
+  });
+  assert.equal(
+    extractSessionFieldErrors(error).non_field_errors,
+    "A sessão conflita com outra sessão na mesma sala."
+  );
+});
+
+// ─── adminApi.listSessions ─ integration-style ────────────────────────────────
+
+import { adminApi } from "@/api/admin";
+
+test("adminApi.listSessions returns sessions with movie and room", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => Response.json(paginatedSessions);
+    const result = await adminApi.listSessions();
+    assert.equal(result.results.length, 1);
+    assert.equal(result.results[0].movie.title, "Filme Teste");
+    assert.equal(result.results[0].room.id, "room-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listSessions supports date, movie, and room filters", async () => {
+  const originalFetch = globalThis.fetch;
+  let captured = "";
+  try {
+    globalThis.fetch = async (input) => {
+      captured = String(input);
+      return Response.json({ count: 0, next: null, previous: null, results: [] });
+    };
+    await adminApi.listSessions({
+      date: "2026-06-10",
+      movie: "movie-1",
+      room: "room-1",
+    });
+    assert.match(captured, /date=2026-06-10/);
+    assert.match(captured, /movie=movie-1/);
+    assert.match(captured, /room=room-1/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.createSession includes all metadata fields", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(init?.body as string);
+      assert.equal(body.audio_format, "legendado");
+      assert.equal(body.projection_format, "3d");
+      assert.equal(body.session_type, "preview");
+      assert.equal(body.base_price, "54.00");
+      return Response.json(session);
+    };
+    await adminApi.createSession({
+      audio_format: "legendado",
+      base_price: "54.00",
+      end_time: "2026-06-10T22:00:00Z",
+      movie: "movie-1",
+      projection_format: "3d",
+      room: "room-1",
+      session_type: "preview",
+      start_time: "2026-06-10T19:30:00Z",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.updateSession only sends the changed field", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(init?.body as string);
+      assert.deepEqual(Object.keys(body), ["audio_format"]);
+      return Response.json({ ...session, audio_format: "dublado" });
+    };
+    await adminApi.updateSession("session-1", { audio_format: "dublado" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.deleteSession does not throw on 204 response", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => new Response(null, { status: 204 });
+    await assert.doesNotReject(adminApi.deleteSession("session-1"));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.getSession rejects when movie or room is missing", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () =>
+      Response.json({
+        base_price: "54.00",
+        end_time: "2026-06-10T22:00:00Z",
+        id: "session-1",
+        start_time: "2026-06-10T19:30:00Z",
+      });
+    await assert.rejects(
+      adminApi.getSession("session-1"),
+      /Unexpected admin session detail response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -13,3 +13,6 @@ export { AdminShell } from "./AdminShell";
 export { AdminTable } from "./AdminTable";
 export type { AdminTableColumn } from "./AdminTable";
 export { AdminToolbar } from "./AdminToolbar";
+export { AdminEditSessionLoader } from "./AdminEditSessionLoader";
+export { AdminSessionForm, extractSessionFieldErrors } from "./AdminSessionForm";
+export { AdminSessionList } from "./AdminSessionList";

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -68,6 +68,12 @@ export type AdminRoom = CatalogRoomSummary & {
   updated_at?: string;
 };
 
+export type AdminSession = CatalogSession & {
+  seat_count?: number;
+  has_reservations?: boolean;
+  has_purchases?: boolean;
+};
+
 export type AdminSeatRow = {
   id: string;
   name: string;


### PR DESCRIPTION
## Objective

Allow administrators to create and manage sessions from the frontend, with date, time, room, movie, base price, conflict feedback, seat-generation transparency, and protected-session guards.

## What was done

### 1. Session CRUD API layer

Added the full session management surface to `api/admin.ts`:

- `listSessions(params)` — paginated fetch with `date`, `movie`, `room`, and `page` query params.
- `getSession(sessionId)` — single-session fetch with shape guard.
- `createSession(payload)` — POST with `AdminSessionWritePayload`.
- `updateSession(sessionId, payload)` — PATCH supporting partial updates.
- `deleteSession(sessionId)` — DELETE.
- `AdminSessionWritePayload` and `ListSessionsParams` exported types.
- `isAdminSession` type guard ensuring `id`, `start_time`, `end_time`, `base_price`, `movie.id`, and `room.id` are present.

### 2. `AdminSession` type

Added `AdminSession` to `types/catalog.ts`, extending `CatalogSession` with:

- `seat_count` — number of generated seats.
- `has_reservations` / `has_purchases` — flags that drive the protected-session UX.

### 3. Session form

`AdminSessionForm` covers the full create/edit flow:

- Required fields: movie (select), room (select), start time, end time, base price.
- Optional metadata: audio format, projection format, session type.
- **Conflict UX**: catches `409` and overlap error messages from the API and renders a distinct amber "Conflito de agenda detectado" banner with the server's detail.
- **Seat-generation notice**: on create mode, an info banner explains that seats are auto-generated from the room layout at creation time and not affected by future layout changes.
- **Protected-session guard**: when `has_reservations || has_purchases` is true, a warning banner is shown and the core fields (movie, room, times, base price) are disabled; only metadata fields remain editable, matching the API's update restriction.
- Field-level and global error handling using `extractSessionFieldErrors` (exported for tests).

### 4. Session list

`AdminSessionList` replaces the placeholder on `/admin/sessions`:

- Table columns: movie + start time, room display name, base price (formatted as BRL), format badges (audio / projection / type).
- **Filter bar**: date input, movie dropdown, room dropdown, with a "Limpar filtros" button when any filter is active. Filters are reactive — any change resets to page 1.
- **Paginated load-more**: "Carregar mais" button when `next !== null`.
- **Protected delete guard**: the delete button is disabled (with tooltip) for sessions that have reservations or purchases.
- Confirm dialog before delete, consistent with the rest of the admin panel.

### 5. Edit loader

`AdminEditSessionLoader` follows the established room loader pattern: skeleton on load, error state on failure, full toolbar with back button, and passes the fetched session to `AdminSessionForm`.

### 6. Pages

- `/admin/sessions` — replaced placeholder with `AdminSessionList`.
- `/admin/sessions/new` — toolbar + back button + `AdminSessionForm`.
- `/admin/sessions/[id]/edit` — async page that unwraps `params` and delegates to `AdminEditSessionLoader`.

### 7. Exports

Updated `components/admin/index.ts` to export `AdminSessionList`, `AdminSessionForm`, `extractSessionFieldErrors`, and `AdminEditSessionLoader`.

### 8. Tests

**`api/admin.test.ts`** — 14 new tests:

- `listSessions` fetches the paginated list and builds date / movie / room / page query strings correctly.
- `listSessions` rejects a non-paginated response.
- `getSession` fetches by id and rejects an incomplete shape.
- `createSession` posts all required and optional fields.
- `createSession` rejects an incomplete response.
- `updateSession` PATCHes and returns the updated record.
- `deleteSession` sends DELETE and resolves on 204.

**`admin-session-manager.test.ts`** — 6 new tests:

- `extractSessionFieldErrors` returns empty for non-`ApiError` and non-`VALIDATION_FAILED` errors.
- `extractSessionFieldErrors` extracts per-field messages, joins multiple messages, and handles `non_field_errors`.
- `adminApi.createSession` includes all metadata fields in the payload.
- `adminApi.updateSession` sends only the changed field.
- `adminApi.deleteSession` does not throw on 204.
- `adminApi.getSession` rejects when `movie` or `room` is missing from the response.

All 286 tests pass.

## How to test

### Automated

```bash
cd frontend && npm test
```

### Manual

1. Start the full stack: `docker compose up --build`
2. Log in as an admin at `/login`.
3. Navigate to `/admin/sessions`.
4. Verify the filter bar responds to date, movie, and room selections.
5. Click **Nova sessão** and submit a session — confirm the seat-generation notice is visible.
6. Try scheduling a session in a time slot already occupied by another session in the same room — confirm the amber conflict banner appears.
7. Edit a session that has reservations or purchases — confirm core fields are disabled and the protected-session notice is visible.
8. Delete a session without reservations — confirm the confirmation dialog and successful removal.
9. Attempt to delete a protected session — confirm the delete button is disabled.

## Expected result

- Administrators can create, edit, and delete sessions from the frontend.
- Date, movie, and room filters narrow the session list without a page reload.
- Scheduling conflicts surface as a clear, actionable banner instead of a generic error.
- Base price is required, validated client-side, and field errors from the API are surfaced.
- The seat-generation notice sets expectations before first save.
- Protected sessions (with reservations or purchases) block destructive actions with visible feedback.
- All existing and new tests pass.

closes #168