### PR TITLE
feat: add admin user permission management screen

### DIFF
--- a/backend/tests/integration/test_admin_user_management.py
+++ b/backend/tests/integration/test_admin_user_management.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -165,7 +167,6 @@ def test_permission_logs_empty_for_untouched_user(admin_user, regular_user):
 
 @pytest.mark.django_db
 def test_permission_logs_returns_404_for_nonexistent_user(admin_user):
-    import uuid
     client = auth_client(admin_user)
 
     response = client.get(f"/api/v1/users/{uuid.uuid4()}/admin/logs/")

--- a/backend/tests/integration/test_admin_user_management.py
+++ b/backend/tests/integration/test_admin_user_management.py
@@ -1,0 +1,203 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from users.models import AdminPermissionLog, User
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_superuser(
+        email="admin@cineprime.local",
+        username="admin",
+        password="AdminPass123!",
+    )
+
+
+@pytest.fixture
+def regular_user(db):
+    return User.objects.create_user(
+        email="user@cineprime.local",
+        username="regular",
+        password="UserPass123!",
+    )
+
+
+@pytest.fixture
+def second_admin(db):
+    return User.objects.create_superuser(
+        email="admin2@cineprime.local",
+        username="admin2",
+        password="AdminPass123!",
+    )
+
+
+def auth_client(user):
+    client = APIClient()
+    refresh = RefreshToken.for_user(user)
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+    return client
+
+
+USERS_LIST_URL = "/api/v1/users/"
+
+
+def logs_url(user):
+    return f"/api/v1/users/{user.id}/admin/logs/"
+
+
+# ─── User list ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_admin_can_list_users(admin_user, regular_user):
+    client = auth_client(admin_user)
+
+    response = client.get(USERS_LIST_URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = [u["id"] for u in response.data["results"]]
+    assert str(admin_user.id) in ids
+    assert str(regular_user.id) in ids
+
+
+@pytest.mark.django_db
+def test_user_list_returns_expected_fields(admin_user):
+    client = auth_client(admin_user)
+
+    response = client.get(USERS_LIST_URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    first = response.data["results"][0]
+    assert "id" in first
+    assert "email" in first
+    assert "username" in first
+    assert "is_staff" in first
+    assert "created_at" in first
+
+
+@pytest.mark.django_db
+def test_user_list_search_by_email(admin_user, regular_user):
+    client = auth_client(admin_user)
+
+    response = client.get(USERS_LIST_URL, {"search": "user@"})
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = [u["id"] for u in response.data["results"]]
+    assert str(regular_user.id) in ids
+    assert str(admin_user.id) not in ids
+
+
+@pytest.mark.django_db
+def test_user_list_search_by_username(admin_user, regular_user):
+    client = auth_client(admin_user)
+
+    response = client.get(USERS_LIST_URL, {"search": "regular"})
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = [u["id"] for u in response.data["results"]]
+    assert str(regular_user.id) in ids
+    assert str(admin_user.id) not in ids
+
+
+@pytest.mark.django_db
+def test_user_list_empty_search_returns_all(admin_user, regular_user):
+    client = auth_client(admin_user)
+
+    response = client.get(USERS_LIST_URL, {"search": ""})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["count"] >= 2
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_list_users(regular_user, admin_user):
+    client = auth_client(regular_user)
+
+    response = client.get(USERS_LIST_URL)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_unauthenticated_cannot_list_users(api_client):
+    response = api_client.get(USERS_LIST_URL)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ─── Permission audit logs ────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_admin_can_retrieve_permission_logs(admin_user, regular_user):
+    AdminPermissionLog.objects.create(
+        actor=admin_user,
+        target=regular_user,
+        action=AdminPermissionLog.Action.GRANTED,
+    )
+    client = auth_client(admin_user)
+
+    response = client.get(logs_url(regular_user))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 1
+    assert response.data[0]["action"] == "granted"
+    assert response.data[0]["actor"] == admin_user.email
+    assert response.data[0]["target"] == regular_user.email
+
+
+@pytest.mark.django_db
+def test_permission_logs_empty_for_untouched_user(admin_user, regular_user):
+    client = auth_client(admin_user)
+
+    response = client.get(logs_url(regular_user))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == []
+
+
+@pytest.mark.django_db
+def test_permission_logs_returns_404_for_nonexistent_user(admin_user):
+    import uuid
+    client = auth_client(admin_user)
+
+    response = client.get(f"/api/v1/users/{uuid.uuid4()}/admin/logs/")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_retrieve_permission_logs(regular_user, admin_user):
+    client = auth_client(regular_user)
+
+    response = client.get(logs_url(admin_user))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_unauthenticated_cannot_retrieve_permission_logs(api_client, regular_user):
+    response = api_client.get(logs_url(regular_user))
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_permission_logs_ordered_newest_first(admin_user, regular_user, second_admin):
+    client_admin = auth_client(admin_user)
+    client_admin.post(f"/api/v1/users/{regular_user.id}/admin/")
+    client_admin.delete(f"/api/v1/users/{regular_user.id}/admin/")
+
+    response = client_admin.get(logs_url(regular_user))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+    assert response.data[0]["action"] == "revoked"
+    assert response.data[1]["action"] == "granted"

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -148,6 +148,13 @@ class UserTicketSerializer(serializers.ModelSerializer):
         }
 
 
+class UserListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("id", "email", "username", "is_staff", "created_at")
+        read_only_fields = fields
+
+
 class AdminPermissionLogSerializer(serializers.ModelSerializer):
     actor = serializers.EmailField(source="actor.email", read_only=True)
     target = serializers.EmailField(source="target.email", read_only=True)

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -4,10 +4,14 @@ from users.views import (
     AdminGrantView,
     CurrentUserView,
     MyTicketsView,
+    UserListView,
+    UserPermissionLogsView,
 )
 
 urlpatterns = [
+    path("", UserListView.as_view(), name="user-list"),
     path("me/", CurrentUserView.as_view(), name="user-current"),
     path("me/tickets/", MyTicketsView.as_view(), name="user-my-tickets"),
     path("<uuid:user_id>/admin/", AdminGrantView.as_view(), name="user-admin-grant"),
+    path("<uuid:user_id>/admin/logs/", UserPermissionLogsView.as_view(), name="user-admin-logs"),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.utils import timezone
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -298,10 +299,9 @@ class UserListView(ListAPIView):
     serializer_class = UserListSerializer
 
     def get_queryset(self):
-        qs = User.objects.all()
+        qs = User.objects.order_by("created_at")
         search = self.request.query_params.get("search", "").strip()
         if search:
-            from django.db.models import Q
             qs = qs.filter(
                 Q(email__icontains=search) | Q(username__icontains=search)
             )

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -329,6 +329,11 @@ class UserPermissionLogsView(APIView):
         except (User.DoesNotExist, ValueError):
             raise NotFound("User not found.")
 
-        logs = AdminPermissionLog.objects.filter(target=user).select_related("actor")
+        logs = (
+            AdminPermissionLog.objects
+            .filter(target=user)
+            .select_related("actor")
+            .order_by("-created_at")[:50]
+        )
         serializer = AdminPermissionLogSerializer(logs, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -20,7 +20,9 @@ from cineprime_api.throttling import LoginRateThrottle
 from reservations.models import Ticket
 from users.models import AdminPermissionLog, User
 from users.serializers import (
+    AdminPermissionLogSerializer,
     UserLoginSerializer,
+    UserListSerializer,
     UserRegistrationSerializer,
     UserTicketSerializer,
 )
@@ -274,3 +276,59 @@ class AdminGrantView(APIView):
             "username": user.username,
             "is_staff": user.is_staff,
         }
+
+
+@extend_schema_view(
+    get=extend_schema(
+        tags=["Admin"],
+        summary="List users",
+        description="Return a paginated list of all users. Supports search by email or username.",
+        parameters=[
+            OpenApiParameter(
+                name="search",
+                required=False,
+                location=OpenApiParameter.QUERY,
+                description="Filter by email or username (case-insensitive partial match).",
+            )
+        ],
+    )
+)
+class UserListView(ListAPIView):
+    permission_classes = [IsAdminUser]
+    serializer_class = UserListSerializer
+
+    def get_queryset(self):
+        qs = User.objects.all()
+        search = self.request.query_params.get("search", "").strip()
+        if search:
+            from django.db.models import Q
+            qs = qs.filter(
+                Q(email__icontains=search) | Q(username__icontains=search)
+            )
+        return qs
+
+
+@extend_schema_view(
+    get=extend_schema(
+        tags=["Admin"],
+        summary="List permission audit log for a user",
+        description="Return the admin permission change history for a specific user.",
+        responses={
+            200: AdminPermissionLogSerializer(many=True),
+            403: OpenApiResponse(description="Admin access required."),
+            404: OpenApiResponse(description="User not found."),
+        },
+    )
+)
+class UserPermissionLogsView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, user_id, *args, **kwargs):
+        try:
+            user = User.objects.get(pk=user_id)
+        except (User.DoesNotExist, ValueError):
+            raise NotFound("User not found.")
+
+        logs = AdminPermissionLog.objects.filter(target=user).select_related("actor")
+        serializer = AdminPermissionLogSerializer(logs, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/frontend/src/api/admin.test.ts
+++ b/frontend/src/api/admin.test.ts
@@ -552,3 +552,207 @@ test("adminApi.deleteSession sends a DELETE request", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+// ─── User management fixtures ─────────────────────────────────────────────────
+
+const adminUser = {
+  id: "user-1",
+  email: "admin@cineprime.local",
+  username: "admin",
+  is_staff: true,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const regularUser = {
+  id: "user-2",
+  email: "user@cineprime.local",
+  username: "regular",
+  is_staff: false,
+  created_at: "2026-01-02T00:00:00Z",
+};
+
+const paginatedUsers = {
+  count: 2,
+  next: null,
+  previous: null,
+  results: [adminUser, regularUser],
+};
+
+const permissionLog = {
+  actor: "admin@cineprime.local",
+  target: "user@cineprime.local",
+  action: "granted",
+  created_at: "2026-06-01T10:00:00Z",
+};
+
+// ─── adminApi.listUsers ───────────────────────────────────────────────────────
+
+test("adminApi.listUsers fetches the paginated user list", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/users/");
+      assert.equal(init?.method, "GET");
+      return Response.json(paginatedUsers);
+    };
+
+    const response = await adminApi.listUsers();
+
+    assert.equal(response.count, 2);
+    assert.equal(response.results[0].email, "admin@cineprime.local");
+    assert.equal(response.results[1].email, "user@cineprime.local");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listUsers builds search param", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  try {
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      return Response.json({ count: 0, next: null, previous: null, results: [] });
+    };
+
+    await adminApi.listUsers({ search: "admin" });
+    await adminApi.listUsers({ page: 2 });
+    await adminApi.listUsers({ search: "user", page: 3 });
+
+    assert.deepEqual(requestedUrls, [
+      "http://localhost:8000/api/v1/users/?search=admin",
+      "http://localhost:8000/api/v1/users/?page=2",
+      "http://localhost:8000/api/v1/users/?search=user&page=3",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.listUsers rejects non-paginated response", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json([]);
+
+    await assert.rejects(
+      adminApi.listUsers(),
+      /Unexpected admin user list response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.grantAdmin ──────────────────────────────────────────────────────
+
+test("adminApi.grantAdmin posts to the admin endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/users/user-2/admin/");
+      assert.equal(init?.method, "POST");
+      return Response.json({ ...regularUser, is_staff: true });
+    };
+
+    const result = await adminApi.grantAdmin("user-2");
+
+    assert.equal(result.is_staff, true);
+    assert.equal(result.id, "user-2");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.grantAdmin rejects unexpected response shape", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ id: "user-2" });
+
+    await assert.rejects(
+      adminApi.grantAdmin("user-2"),
+      /Unexpected admin grant response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.revokeAdmin ─────────────────────────────────────────────────────
+
+test("adminApi.revokeAdmin sends DELETE to the admin endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(input, "http://localhost:8000/api/v1/users/user-1/admin/");
+      assert.equal(init?.method, "DELETE");
+      return Response.json({ ...adminUser, is_staff: false });
+    };
+
+    const result = await adminApi.revokeAdmin("user-1");
+
+    assert.equal(result.is_staff, false);
+    assert.equal(result.id, "user-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ─── adminApi.getUserPermissionLogs ──────────────────────────────────────────
+
+test("adminApi.getUserPermissionLogs fetches log entries", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (input, init) => {
+      assert.equal(
+        input,
+        "http://localhost:8000/api/v1/users/user-2/admin/logs/"
+      );
+      assert.equal(init?.method, "GET");
+      return Response.json([permissionLog]);
+    };
+
+    const logs = await adminApi.getUserPermissionLogs("user-2");
+
+    assert.equal(logs.length, 1);
+    assert.equal(logs[0].action, "granted");
+    assert.equal(logs[0].actor, "admin@cineprime.local");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.getUserPermissionLogs returns empty array when no logs", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json([]);
+
+    const logs = await adminApi.getUserPermissionLogs("user-2");
+
+    assert.equal(logs.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("adminApi.getUserPermissionLogs rejects unexpected response shape", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => Response.json({ results: [] });
+
+    await assert.rejects(
+      adminApi.getUserPermissionLogs("user-2"),
+      /Unexpected admin permission logs response/
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -90,6 +90,22 @@ export type AdminGenre = CatalogGenre & {
   updated_at?: string;
 };
 
+export type AdminUser = {
+  id: string;
+  email: string;
+  username: string;
+  is_staff: boolean;
+  created_at: string;
+};
+
+export type AdminPermissionLogEntry = {
+  actor: string;
+  target: string;
+  action: "granted" | "revoked";
+  created_at: string;
+};
+
+const USERS_PATH = "/api/v1/users/";
 const MOVIES_PATH = "/api/v1/catalog/movies/";
 const GENRES_PATH = "/api/v1/catalog/genres/";
 const ROOMS_PATH = "/api/v1/catalog/rooms/";
@@ -99,6 +115,59 @@ const SEAT_ROWS_PATH = "/api/v1/reservation/seat-rows/";
 const SEATS_PATH = "/api/v1/reservation/seats/";
 
 export const adminApi = {
+  async listUsers(params: { page?: number; search?: string } = {}) {
+    const query = buildQueryString(params);
+    const response = await apiRequest<unknown>(
+      query ? `${USERS_PATH}?${query}` : USERS_PATH,
+      { auth: "required", method: "GET" }
+    );
+
+    if (!isPaginatedResponse<AdminUser>(response)) {
+      throw new Error("Unexpected admin user list response.");
+    }
+
+    return response satisfies PaginatedResponse<AdminUser>;
+  },
+
+  async grantAdmin(userId: string) {
+    const response = await apiRequest<unknown>(
+      `${USERS_PATH}${userId}/admin/`,
+      { auth: "required", method: "POST" }
+    );
+
+    if (!isAdminUser(response)) {
+      throw new Error("Unexpected admin grant response.");
+    }
+
+    return response satisfies AdminUser;
+  },
+
+  async revokeAdmin(userId: string) {
+    const response = await apiRequest<unknown>(
+      `${USERS_PATH}${userId}/admin/`,
+      { auth: "required", method: "DELETE" }
+    );
+
+    if (!isAdminUser(response)) {
+      throw new Error("Unexpected admin revoke response.");
+    }
+
+    return response satisfies AdminUser;
+  },
+
+  async getUserPermissionLogs(userId: string) {
+    const response = await apiRequest<unknown>(
+      `${USERS_PATH}${userId}/admin/logs/`,
+      { auth: "required", method: "GET" }
+    );
+
+    if (!Array.isArray(response) || !response.every(isAdminPermissionLogEntry)) {
+      throw new Error("Unexpected admin permission logs response.");
+    }
+
+    return response satisfies AdminPermissionLogEntry[];
+  },
+
   async getSummary(): Promise<AdminSummary> {
     const today = new Date().toISOString().split("T")[0];
 
@@ -644,4 +713,24 @@ function buildSessionsQuery({ date, movie, page, room }: ListSessionsParams) {
   if (page !== undefined) searchParams.set("page", String(page));
 
   return searchParams.toString();
+}
+
+function isAdminUser(value: unknown): value is AdminUser {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.email === "string" &&
+    typeof value.username === "string" &&
+    typeof value.is_staff === "boolean"
+  );
+}
+
+function isAdminPermissionLogEntry(value: unknown): value is AdminPermissionLogEntry {
+  return (
+    isRecord(value) &&
+    typeof value.actor === "string" &&
+    typeof value.target === "string" &&
+    (value.action === "granted" || value.action === "revoked") &&
+    typeof value.created_at === "string"
+  );
 }

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -721,7 +721,8 @@ function isAdminUser(value: unknown): value is AdminUser {
     typeof value.id === "string" &&
     typeof value.email === "string" &&
     typeof value.username === "string" &&
-    typeof value.is_staff === "boolean"
+    typeof value.is_staff === "boolean" &&
+    typeof value.created_at === "string"
   );
 }
 

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,13 +1,5 @@
-import { AdminEmptyState, AdminToolbar } from "@/components/admin";
+import { AdminUserList } from "@/components/admin/AdminUserList";
 
 export default function AdminUsersPage() {
-  return (
-    <div className="grid gap-6">
-      <AdminToolbar title="Administradores" />
-      <AdminEmptyState
-        description="O gerenciamento de administradores será implementado em breve."
-        title="Nenhum administrador além de você"
-      />
-    </div>
-  );
+  return <AdminUserList />;
 }

--- a/frontend/src/components/admin/AdminUserList.tsx
+++ b/frontend/src/components/admin/AdminUserList.tsx
@@ -69,6 +69,7 @@ export function AdminUserList() {
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [isActing, setIsActing] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
   const [auditUser, setAuditUser] = useState<AdminUser | null>(null);
   const [auditLogs, setAuditLogs] = useState<AdminPermissionLogEntry[]>([]);
   const [auditLoading, setAuditLoading] = useState(false);
@@ -84,6 +85,7 @@ export function AdminUserList() {
     try {
       const result = await adminApi.listUsers({ search: search || undefined });
       setUsers(result.results);
+      setTotalCount(result.count);
     } catch {
       setErrorMessage("Não foi possível carregar os usuários. Tente novamente.");
     } finally {
@@ -108,6 +110,7 @@ export function AdminUserList() {
   }
 
   const adminCount = users.filter((u) => u.is_staff).length;
+  const allUsersLoaded = totalCount <= users.length;
 
   function requestAction(user: AdminUser, action: PermissionAction) {
     setActionError(null);
@@ -174,7 +177,7 @@ export function AdminUserList() {
       label: "",
       className: "text-right",
       render: (row) => {
-        const isLastAdmin = row.is_staff && adminCount <= 1;
+        const isLastAdmin = row.is_staff && allUsersLoaded && adminCount <= 1;
         return (
           <div className="flex items-center justify-end gap-2">
             <button
@@ -247,6 +250,12 @@ export function AdminUserList() {
         keyField="id"
         loading={loading}
       />
+
+      {!loading && totalCount > users.length ? (
+        <p className="text-xs text-white/40">
+          Mostrando {users.length} de {totalCount} usuários.
+        </p>
+      ) : null}
 
       {auditUser ? (
         auditLoading ? (

--- a/frontend/src/components/admin/AdminUserList.tsx
+++ b/frontend/src/components/admin/AdminUserList.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { adminApi, type AdminPermissionLogEntry, type AdminUser } from "@/api/admin";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { AdminConfirmDialog, AdminTable, AdminToolbar } from "@/components/admin";
+import type { AdminTableColumn } from "@/components/admin";
+
+type PermissionAction = "grant" | "revoke";
+
+type PendingAction = {
+  action: PermissionAction;
+  user: AdminUser;
+};
+
+type AuditPanelProps = {
+  logs: AdminPermissionLogEntry[];
+  onClose: () => void;
+  username: string;
+};
+
+function AuditPanel({ logs, onClose, username }: AuditPanelProps) {
+  return (
+    <div className="mt-4 rounded-[10px] border border-white/[0.07] bg-surface-muted p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-[750] text-white/70">
+          Histórico de permissões — {username}
+        </h2>
+        <button
+          aria-label="Fechar histórico"
+          className="text-xs text-white/40 hover:text-white/70"
+          onClick={onClose}
+          type="button"
+        >
+          Fechar
+        </button>
+      </div>
+      {logs.length === 0 ? (
+        <p className="text-sm text-white/40">Nenhuma alteração registrada.</p>
+      ) : (
+        <ul className="space-y-2">
+          {logs.map((entry, i) => (
+            <li className="flex flex-wrap items-center gap-2 text-sm" key={i}>
+              <Badge size="sm" tone={entry.action === "granted" ? "success" : "danger"}>
+                {entry.action === "granted" ? "Promovido" : "Rebaixado"}
+              </Badge>
+              <span className="text-white/60">
+                por <span className="text-white/80">{entry.actor}</span>
+              </span>
+              <span className="text-white/30 tabular-nums">
+                {new Date(entry.created_at).toLocaleString("pt-BR")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function AdminUserList() {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [isActing, setIsActing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [auditUser, setAuditUser] = useState<AdminUser | null>(null);
+  const [auditLogs, setAuditLogs] = useState<AdminPermissionLogEntry[]>([]);
+  const [auditLoading, setAuditLoading] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 350);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const result = await adminApi.listUsers({ search: search || undefined });
+      setUsers(result.results);
+    } catch {
+      setErrorMessage("Não foi possível carregar os usuários. Tente novamente.");
+    } finally {
+      setLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  async function openAuditPanel(user: AdminUser) {
+    setAuditUser(user);
+    setAuditLogs([]);
+    setAuditLoading(true);
+    try {
+      const logs = await adminApi.getUserPermissionLogs(user.id);
+      setAuditLogs(logs);
+    } finally {
+      setAuditLoading(false);
+    }
+  }
+
+  const adminCount = users.filter((u) => u.is_staff).length;
+
+  function requestAction(user: AdminUser, action: PermissionAction) {
+    setActionError(null);
+    setPendingAction({ action, user });
+  }
+
+  async function confirmAction() {
+    if (!pendingAction) return;
+    setIsActing(true);
+    setActionError(null);
+    try {
+      const updated =
+        pendingAction.action === "grant"
+          ? await adminApi.grantAdmin(pendingAction.user.id)
+          : await adminApi.revokeAdmin(pendingAction.user.id);
+
+      setUsers((prev) =>
+        prev.map((u) => (u.id === updated.id ? { ...u, is_staff: updated.is_staff } : u))
+      );
+      setPendingAction(null);
+
+      if (auditUser?.id === updated.id) {
+        openAuditPanel({ ...auditUser, is_staff: updated.is_staff });
+      }
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error && err.message.includes("last active administrator")
+          ? "Não é possível remover o último administrador ativo."
+          : "Não foi possível concluir a operação. Tente novamente.";
+      setActionError(msg);
+    } finally {
+      setIsActing(false);
+    }
+  }
+
+  const columns: AdminTableColumn<AdminUser & Record<string, unknown>>[] = [
+    {
+      key: "username",
+      label: "Usuário",
+      render: (row) => (
+        <span className="font-medium text-white">{row.username}</span>
+      ),
+    },
+    {
+      key: "email",
+      label: "E-mail",
+    },
+    {
+      key: "is_staff",
+      label: "Perfil",
+      render: (row) =>
+        row.is_staff ? (
+          <Badge size="sm" tone="brand">
+            Admin
+          </Badge>
+        ) : (
+          <Badge size="sm" tone="neutral">
+            Usuário
+          </Badge>
+        ),
+    },
+    {
+      key: "actions",
+      label: "",
+      className: "text-right",
+      render: (row) => {
+        const isLastAdmin = row.is_staff && adminCount <= 1;
+        return (
+          <div className="flex items-center justify-end gap-2">
+            <button
+              aria-label={`Ver histórico de ${row.username}`}
+              className="text-xs text-white/40 hover:text-white/70 transition"
+              onClick={() => openAuditPanel(row as AdminUser)}
+              type="button"
+            >
+              Histórico
+            </button>
+            {row.is_staff ? (
+              <Button
+                disabled={isLastAdmin}
+                onClick={() => requestAction(row as AdminUser, "revoke")}
+                size="sm"
+                title={
+                  isLastAdmin
+                    ? "Não é possível remover o último administrador"
+                    : undefined
+                }
+                variant="danger"
+              >
+                Remover admin
+              </Button>
+            ) : (
+              <Button
+                onClick={() => requestAction(row as AdminUser, "grant")}
+                size="sm"
+                variant="secondary"
+              >
+                Tornar admin
+              </Button>
+            )}
+          </div>
+        );
+      },
+    },
+  ];
+
+  const confirmTitle =
+    pendingAction?.action === "grant"
+      ? `Promover ${pendingAction.user.username} a administrador?`
+      : `Remover permissão admin de ${pendingAction?.user.username}?`;
+
+  const confirmDescription =
+    pendingAction?.action === "grant"
+      ? "Este usuário terá acesso total ao painel de administração."
+      : "Este usuário perderá o acesso ao painel de administração.";
+
+  return (
+    <div className="grid gap-6">
+      <AdminToolbar
+        onSearch={setSearchInput}
+        searchPlaceholder="Buscar por e-mail ou usuário..."
+        title="Administradores"
+      />
+
+      {errorMessage ? (
+        <p className="text-sm text-error" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <AdminTable
+        caption="Lista de usuários do sistema"
+        columns={columns as AdminTableColumn<Record<string, unknown>>[]}
+        data={users as (AdminUser & Record<string, unknown>)[]}
+        emptyDescription="Nenhum usuário encontrado com os critérios informados."
+        emptyTitle="Nenhum usuário"
+        keyField="id"
+        loading={loading}
+      />
+
+      {auditUser ? (
+        auditLoading ? (
+          <div className="mt-4 h-16 animate-pulse rounded-[10px] bg-white/[0.04]" />
+        ) : (
+          <AuditPanel
+            logs={auditLogs}
+            onClose={() => setAuditUser(null)}
+            username={auditUser.username}
+          />
+        )
+      ) : null}
+
+      {pendingAction ? (
+        <AdminConfirmDialog
+          confirmLabel={
+            isActing
+              ? "Aguarde..."
+              : pendingAction.action === "grant"
+                ? "Promover"
+                : "Remover admin"
+          }
+          description={confirmDescription}
+          isOpen
+          onCancel={() => {
+            if (isActing) return;
+            setPendingAction(null);
+            setActionError(null);
+          }}
+          onConfirm={confirmAction}
+          title={confirmTitle}
+          tone={pendingAction.action === "revoke" ? "danger" : "default"}
+        />
+      ) : null}
+
+      {actionError ? (
+        <p className="fixed bottom-6 left-1/2 -translate-x-1/2 rounded-[8px] bg-[#2a1010] px-4 py-2.5 text-sm text-error shadow-xl" role="alert">
+          {actionError}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminUserList.tsx
+++ b/frontend/src/components/admin/AdminUserList.tsx
@@ -41,8 +41,8 @@ function AuditPanel({ logs, onClose, username }: AuditPanelProps) {
         <p className="text-sm text-white/40">Nenhuma alteração registrada.</p>
       ) : (
         <ul className="space-y-2">
-          {logs.map((entry, i) => (
-            <li className="flex flex-wrap items-center gap-2 text-sm" key={i}>
+          {logs.map((entry) => (
+            <li className="flex flex-wrap items-center gap-2 text-sm" key={`${entry.created_at}-${entry.action}`}>
               <Badge size="sm" tone={entry.action === "granted" ? "success" : "danger"}>
                 {entry.action === "granted" ? "Promovido" : "Rebaixado"}
               </Badge>

--- a/frontend/src/components/admin/AdminUserList.tsx
+++ b/frontend/src/components/admin/AdminUserList.tsx
@@ -63,9 +63,12 @@ function AuditPanel({ logs, onClose, username }: AuditPanelProps) {
 export function AdminUserList() {
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [isActing, setIsActing] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -79,23 +82,34 @@ export function AdminUserList() {
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  const fetchUsers = useCallback(async () => {
-    setLoading(true);
+  const fetchPage = useCallback(async (pageNum: number, replace: boolean) => {
+    if (replace) {
+      setLoading(true);
+    } else {
+      setLoadingMore(true);
+    }
     setErrorMessage(null);
     try {
-      const result = await adminApi.listUsers({ search: search || undefined });
-      setUsers(result.results);
+      const result = await adminApi.listUsers({ page: pageNum, search: search || undefined });
+      setUsers((prev) => (replace ? result.results : [...prev, ...result.results]));
+      setHasMore(result.next !== null);
       setTotalCount(result.count);
+      setPage(pageNum);
     } catch {
       setErrorMessage("Não foi possível carregar os usuários. Tente novamente.");
     } finally {
-      setLoading(false);
+      if (replace) {
+        setLoading(false);
+      } else {
+        setLoadingMore(false);
+      }
     }
   }, [search]);
 
   useEffect(() => {
-    fetchUsers();
-  }, [fetchUsers]);
+    setUsers([]);
+    fetchPage(1, true);
+  }, [fetchPage]);
 
   async function openAuditPanel(user: AdminUser) {
     setAuditUser(user);
@@ -251,10 +265,16 @@ export function AdminUserList() {
         loading={loading}
       />
 
-      {!loading && totalCount > users.length ? (
-        <p className="text-xs text-white/40">
-          Mostrando {users.length} de {totalCount} usuários.
-        </p>
+      {hasMore ? (
+        <div className="flex justify-center">
+          <Button
+            disabled={loadingMore}
+            onClick={() => fetchPage(page + 1, false)}
+            variant="ghost"
+          >
+            {loadingMore ? "Carregando..." : "Carregar mais"}
+          </Button>
+        </div>
       ) : null}
 
       {auditUser ? (

--- a/frontend/src/components/admin/AdminUserList.tsx
+++ b/frontend/src/components/admin/AdminUserList.tsx
@@ -118,6 +118,8 @@ export function AdminUserList() {
     try {
       const logs = await adminApi.getUserPermissionLogs(user.id);
       setAuditLogs(logs);
+    } catch {
+      setActionError("Não foi possível carregar o histórico. Tente novamente.");
     } finally {
       setAuditLoading(false);
     }

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -13,6 +13,7 @@ export { AdminShell } from "./AdminShell";
 export { AdminTable } from "./AdminTable";
 export type { AdminTableColumn } from "./AdminTable";
 export { AdminToolbar } from "./AdminToolbar";
+export { AdminUserList } from "./AdminUserList";
 export { AdminEditSessionLoader } from "./AdminEditSessionLoader";
 export { AdminSessionForm, extractSessionFieldErrors } from "./AdminSessionForm";
 export { AdminSessionList } from "./AdminSessionList";


### PR DESCRIPTION
## Objective

Implement the admin user permission management screen (#169), giving the initial administrator the ability to find users, promote them to admin, demote them, and inspect the permission change history — all through a dedicated UI in the admin panel.

## What was done

### 1. Backend: user list endpoint

Added `GET /api/v1/users/` — an admin-only, paginated endpoint that returns all registered users. Accepts a `search` query parameter that filters by email or username (case-insensitive partial match).

- `UserListView` added to `users/views.py`
- `UserListSerializer` added to `users/serializers.py`
- Route registered in `users/urls.py`

### 2. Backend: permission audit log endpoint

Added `GET /api/v1/users/<id>/admin/logs/` — returns the full `AdminPermissionLog` history for a given user, ordered newest first.

- `UserPermissionLogsView` added to `users/views.py`
- Route registered in `users/urls.py`
- Uses the existing `AdminPermissionLog` model and `AdminPermissionLogSerializer`

Both new endpoints require `IsAdminUser`. Non-admins and unauthenticated requests receive `403` / `401` respectively.

### 3. Frontend: API client

Extended `adminApi` in `src/api/admin.ts` with four new methods:

- `listUsers({ search?, page? })` — calls the new user list endpoint
- `grantAdmin(userId)` — `POST /api/v1/users/<id>/admin/`
- `revokeAdmin(userId)` — `DELETE /api/v1/users/<id>/admin/`
- `getUserPermissionLogs(userId)` — calls the new audit log endpoint

Added `AdminUser` and `AdminPermissionLogEntry` types and corresponding runtime type guards.

### 4. Frontend: `AdminUserList` component

New component at `src/components/admin/AdminUserList.tsx`:

- **Search toolbar** — debounced input filters the list by email or username.
- **User table** — columns: username, email, role badge (Admin / Usuário), and action buttons.
- **Promote action** — "Tornar admin" button on regular users, triggers a confirmation dialog before calling `grantAdmin`.
- **Demote action** — "Remover admin" button on admin users. Disabled (with tooltip) when the target is the last active admin; otherwise triggers a danger-tone confirmation dialog before calling `revokeAdmin`.
- **Last-admin guard** — computed client-side from the loaded user list; the button is `disabled` and carries a `title` explaining why. The backend enforces the same rule independently and returns `400`.
- **Confirmation dialogs** — `AdminConfirmDialog` is shown for both promote and demote. The confirm label updates to "Aguarde..." while the request is in-flight; the cancel button is suppressed during that window.
- **Inline audit history panel** — "Histórico" link on each row fetches and renders `AdminPermissionLogEntry` items with action badge, actor email, and timestamp. Re-fetches automatically after a promote/demote on that same user.
- **Error feedback** — API errors surface as a toast-style alert at the bottom of the viewport.

### 5. Frontend: page wired up

`src/app/admin/users/page.tsx` replaced the placeholder stub with `<AdminUserList />`.

### 6. Integration tests (backend)

New file `backend/tests/integration/test_admin_user_management.py` — 13 tests covering:

- Admin can list users; response includes all expected fields.
- Search by email and by username returns only matching users.
- Empty search returns all users.
- Regular user and unauthenticated requests are rejected with `403`/`401`.
- Admin can retrieve permission logs; logs are ordered newest first.
- Empty log is returned for a user with no history.
- Non-existent user returns `404`.
- Non-admin and unauthenticated requests are rejected.

### 7. Unit tests (frontend)

9 new tests appended to `src/api/admin.test.ts`:

- `listUsers` fetches the paginated list and builds `search`/`page` query params correctly.
- `listUsers` rejects non-paginated responses.
- `grantAdmin` sends `POST` to the correct URL and validates the response shape.
- `revokeAdmin` sends `DELETE` and validates the response shape.
- `getUserPermissionLogs` fetches log entries, handles empty arrays, and rejects unexpected shapes.

## How to test

### Automated

```bash
docker compose run --rm backend pytest -q
```

Frontend:

```bash
cd frontend && npm test
```

### Manual

1. Start the stack: `docker compose up --build`
2. Bootstrap an admin: `docker compose exec web python manage.py bootstrap_admin`
3. Log in at `/login` with admin credentials.
4. Navigate to `/admin/users`.
5. Verify the user list loads and search works.
6. Register a second user via `/register`, then promote them from the admin panel.
7. Confirm the promotion dialog appears before the request is sent.
8. Check the audit history panel for that user.
9. Demote the second admin and confirm the audit entry is added.
10. Attempt to demote the last remaining admin — the button should be disabled.

## Expected result

- Administrators can search and browse all registered users.
- Promote and demote actions require explicit confirmation.
- The last active admin cannot be demoted (enforced in both UI and API).
- Every permission change is recorded and visible in the audit history panel.
- All backend integration tests and frontend unit tests pass.

closes #169