### PR TITLE
fix(admin): fix movie/room selection and dropdown design in session editing

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -32,6 +32,7 @@ export type AdminSummary = {
 export type AdminMovieWritePayload = {
   age_rating?: CatalogMovieAgeRating;
   cast?: string[];
+  classification_description?: string;
   director?: string;
   duration_minutes: number;
   genres: string[];
@@ -454,6 +455,14 @@ export const adminApi = {
     }
 
     return response satisfies RoomTypePricing;
+  },
+
+  async listAllMovies(): Promise<CatalogMovieDetail[]> {
+    return fetchAllPages<CatalogMovieDetail>(MOVIES_PATH);
+  },
+
+  async listAllRooms(): Promise<AdminRoom[]> {
+    return fetchAllPages<AdminRoom>(ROOMS_PATH);
   },
 
   async listAllSeatRows(roomId: string): Promise<AdminSeatRow[]> {

--- a/frontend/src/components/admin/AdminSessionForm.tsx
+++ b/frontend/src/components/admin/AdminSessionForm.tsx
@@ -16,7 +16,7 @@ import type {
 import { Badge } from "@/components/ui/Badge";
 import type { BadgeTone } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
-import { Select } from "@/components/ui/Select";
+import { SelectMenu } from "@/components/ui/SelectMenu";
 import { useI18n } from "@/i18n";
 import {
   addMinutesToLocalDateTime,
@@ -167,8 +167,6 @@ export function AdminSessionForm({ session }: AdminSessionFormProps) {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [conflictError, setConflictError] = useState<string | null>(null);
 
-  const movieSelectId = useId();
-  const roomSelectId = useId();
   const startDateId = useId();
   const startTimeId = useId();
   const endDateId = useId();
@@ -193,10 +191,10 @@ export function AdminSessionForm({ session }: AdminSessionFormProps) {
   ];
 
   useEffect(() => {
-    Promise.all([adminApi.listMovies({ page: 1 }), adminApi.listRooms()])
-      .then(([moviesRes, roomsRes]) => {
-        setMovies(moviesRes.results);
-        setRooms(roomsRes.results);
+    Promise.all([adminApi.listAllMovies(), adminApi.listAllRooms()])
+      .then(([allMovies, allRooms]) => {
+        setMovies(allMovies);
+        setRooms(allRooms);
       })
       .catch(() => {
         setGlobalError(t("admin.session.formLoadError"));
@@ -329,12 +327,11 @@ export function AdminSessionForm({ session }: AdminSessionFormProps) {
         </div>
       ) : null}
 
-      <Select
+      <SelectMenu
         disabled={formDisabled || locked}
         error={fieldErrors.movie}
-        id={movieSelectId}
         label={t("admin.session.movie")}
-        onChange={(e) => setMovieId(e.target.value)}
+        onChange={setMovieId}
         options={movieOptions}
         placeholder={
           loadingOptions
@@ -345,12 +342,11 @@ export function AdminSessionForm({ session }: AdminSessionFormProps) {
         value={movieId}
       />
 
-      <Select
+      <SelectMenu
         disabled={formDisabled || locked}
         error={fieldErrors.room}
-        id={roomSelectId}
         label={t("admin.session.room")}
-        onChange={(e) => setRoomId(e.target.value)}
+        onChange={setRoomId}
         options={roomOptions}
         placeholder={
           loadingOptions
@@ -534,33 +530,31 @@ export function AdminSessionForm({ session }: AdminSessionFormProps) {
       })()}
 
       <div className="grid gap-4 sm:grid-cols-3">
-        <Select
+        <SelectMenu
           disabled={formDisabled}
           error={fieldErrors.audio_format}
           label={t("admin.session.audioFormat")}
-          onChange={(e) => setAudioFormat(e.target.value as CatalogAudioFormat)}
+          onChange={(v) => setAudioFormat(v as CatalogAudioFormat)}
           options={audioFormatOptions}
           placeholder={t("common.notSpecified")}
           value={audioFormat}
         />
 
-        <Select
+        <SelectMenu
           disabled={formDisabled}
           error={fieldErrors.projection_format}
           label={t("admin.session.projection")}
-          onChange={(e) =>
-            setProjectionFormat(e.target.value as CatalogProjectionFormat)
-          }
+          onChange={(v) => setProjectionFormat(v as CatalogProjectionFormat)}
           options={projectionFormatOptions}
           placeholder={t("common.notSpecified")}
           value={projectionFormat}
         />
 
-        <Select
+        <SelectMenu
           disabled={formDisabled}
           error={fieldErrors.session_type}
           label={t("admin.session.type")}
-          onChange={(e) => setSessionType(e.target.value as CatalogSessionType)}
+          onChange={(v) => setSessionType(v as CatalogSessionType)}
           options={sessionTypeOptions}
           placeholder={t("common.notSpecified")}
           value={sessionType}

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -38,7 +38,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 
     return (
       <div className="grid gap-1.5">
-        <label className="text-sm font-extrabold text-text" htmlFor={selectId}>
+        <label className="text-sm font-extrabold text-white" htmlFor={selectId}>
           {label}
         </label>
         {description ? (
@@ -50,7 +50,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           aria-describedby={cn(descriptionId, errorId) || undefined}
           aria-invalid={error ? "true" : undefined}
           className={cn(
-            "min-h-[var(--control-height-lg)] w-full rounded-control border border-border bg-surface px-3 py-2 text-text shadow-none transition-colors duration-150 focus-visible:border-info focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
+            "min-h-[var(--control-height-lg)] w-full rounded-control border border-border bg-surface px-3 py-2 text-white shadow-none outline-none transition-colors duration-150 focus:border-brand focus:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
             error ? "border-error" : undefined,
             className
           )}

--- a/frontend/src/components/ui/SelectMenu.tsx
+++ b/frontend/src/components/ui/SelectMenu.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { ChevronDown, Check } from "lucide-react";
+
+import { cn } from "./classNames";
+import type { SelectOption } from "./Select";
+
+type SelectMenuProps = {
+  disabled?: boolean;
+  error?: string;
+  label: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  required?: boolean;
+  value: string;
+};
+
+export function SelectMenu({
+  disabled,
+  error,
+  label,
+  onChange,
+  options,
+  placeholder,
+  required,
+  value,
+}: SelectMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const buttonId = useId();
+  const listId = useId();
+  const errorId = error ? `${buttonId}-error` : undefined;
+
+  const selected = options.find((o) => o.value === value);
+  const displayLabel = selected?.label ?? placeholder ?? "";
+  const hasValue = Boolean(selected);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      const firstSelected = listRef.current?.querySelector<HTMLLIElement>('[aria-selected="true"]');
+      const firstItem = listRef.current?.querySelector<HTMLLIElement>('[role="option"]');
+      (firstSelected ?? firstItem)?.focus();
+    }
+  }, [open]);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  function handleOptionKeyDown(e: React.KeyboardEvent<HTMLLIElement>, optionValue: string) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onChange(optionValue);
+      setOpen(false);
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      (e.currentTarget.nextElementSibling as HTMLLIElement | null)?.focus();
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      (e.currentTarget.previousElementSibling as HTMLLIElement | null)?.focus();
+    }
+    if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-1.5" ref={containerRef}>
+      <label className="text-sm font-extrabold text-white" htmlFor={buttonId}>
+        {label}
+        {required ? <span aria-hidden="true" className="ml-0.5 text-error">*</span> : null}
+      </label>
+      <div className="relative">
+        <button
+          aria-controls={listId}
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-invalid={error ? "true" : undefined}
+          aria-required={required}
+          className={cn(
+            "flex min-h-[var(--control-height-lg)] w-full items-center justify-between gap-2 rounded-control border bg-surface px-3 py-2",
+            "text-sm text-left outline-none transition-colors duration-150",
+            "focus:border-brand focus:shadow-focus",
+            "disabled:cursor-not-allowed disabled:opacity-[0.68]",
+            hasValue ? "text-white" : "text-white/30",
+            error ? "border-error" : "border-border"
+          )}
+          disabled={disabled}
+          id={buttonId}
+          onClick={() => setOpen((prev) => !prev)}
+          onKeyDown={handleKeyDown}
+          type="button"
+        >
+          <span className="truncate">{displayLabel}</span>
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "size-4 shrink-0 text-white/40 transition-transform duration-150",
+              open && "rotate-180"
+            )}
+          />
+        </button>
+
+        {open ? (
+          <ul
+            aria-label={label}
+            className="absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-[8px] border border-white/[0.10] bg-[#1e2535] py-1 shadow-lg"
+            id={listId}
+            ref={listRef}
+            role="listbox"
+          >
+            {placeholder ? (
+              <li
+                aria-selected={!hasValue}
+                className={cn(
+                  "cursor-pointer px-3 py-2.5 text-sm outline-none transition",
+                  "hover:bg-white/[0.06] focus:bg-white/[0.06]",
+                  !hasValue ? "text-white/60" : "text-white/30"
+                )}
+                onClick={() => {
+                  onChange("");
+                  setOpen(false);
+                }}
+                onKeyDown={(e) => handleOptionKeyDown(e, "")}
+                role="option"
+                tabIndex={0}
+              >
+                {placeholder}
+              </li>
+            ) : null}
+            {options.map((option) => {
+              const isSelected = option.value === value;
+              return (
+                <li
+                  aria-selected={isSelected}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 px-3 py-2.5 text-sm outline-none transition",
+                    "hover:bg-white/[0.06] focus:bg-white/[0.06]",
+                    option.disabled && "cursor-not-allowed opacity-40",
+                    isSelected ? "text-brand font-bold" : "text-white/80"
+                  )}
+                  key={option.value}
+                  onClick={() => {
+                    if (!option.disabled) {
+                      onChange(option.value);
+                      setOpen(false);
+                    }
+                  }}
+                  onKeyDown={(e) => handleOptionKeyDown(e, option.value)}
+                  role="option"
+                  tabIndex={0}
+                >
+                  <Check
+                    aria-hidden="true"
+                    className={cn("size-3.5 shrink-0", isSelected ? "opacity-100" : "opacity-0")}
+                  />
+                  <span className="truncate">{option.label}</span>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="text-sm font-bold text-error" id={errorId} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

Three bugs when editing a session:

- The **movie select showed the wrong item** (first in the list instead of the session's movie)
- The movie list was **incomplete** — only the first 10 were loaded (page 1)
- Movie, room, audio, projection and type dropdowns **ignored the admin's dark design**, since native `<select>` delegates rendering to the OS

## Root cause

`adminApi.listMovies({ page: 1 })` fetched only the first page. When the session's movie was on a later page, the `<select>` found no matching option and fell back to the first available item. Native `<select>` also renders options using the OS theme, breaking the admin's visual.

## Fix

- Added `listAllMovies()` and `listAllRooms()` to `adminApi`, fetching all pages via `fetchAllPages` (same pattern as `listAllSeatRows`)
- Created `SelectMenu` — a fully CSS-controlled custom dropdown: dark background, white text, hover and selection using brand colors
- `AdminSessionForm` replaced all 5 native `<Select>` with `<SelectMenu>`
- `Select` (native) had its label and focus corrected to `text-white` / `border-brand`, matching `TextInput`

## Changed files

- `frontend/src/api/admin.ts` — `listAllMovies`, `listAllRooms`
- `frontend/src/components/ui/SelectMenu.tsx` — new component
- `frontend/src/components/ui/Select.tsx` — style fix
- `frontend/src/components/admin/AdminSessionForm.tsx` — uses `SelectMenu` + `listAll*`