### PR TITLE
feat(brand): SVG cp logo and favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ frontend/dist/
 frontend/.next/
 frontend/.next.*/
 frontend/out/
+frontend/tmp/
 frontend/.env
 frontend/.env.local
 frontend/playwright-report/

--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="14" fill="#1e2535"/>
+  <g stroke="#b31322" stroke-width="9" stroke-linecap="round" fill="none">
+    <!-- c -->
+    <path d="M 47 18 A 20 20 0 1 0 47 48"/>
+    <!-- p bowl -->
+    <circle cx="54" cy="33" r="15"/>
+    <!-- p descender -->
+    <line x1="39" y1="33" x2="39" y2="66"/>
+  </g>
+</svg>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const t = getTranslator(locale);
 
   return {
-    title: "CinePrime",
+    title: "Cine Prime",
     description: t("metadata.description"),
   };
 }

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -49,7 +49,9 @@ export function AppHeader() {
             className="inline-flex items-center gap-2.5 text-[18px] font-[850] text-white"
             href="/"
           >
-            <LogoCp className="h-[34px] w-[34px]" />
+            <span className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-[6px] bg-[#1e2535] p-[5px]">
+              <LogoCp className="h-full w-full" />
+            </span>
             <span>Cine Prime</span>
           </Link>
           <span

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -49,9 +49,7 @@ export function AppHeader() {
             className="inline-flex items-center gap-2.5 text-[18px] font-[850] text-white"
             href="/"
           >
-            <span className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-[6px] bg-[#1e2535] p-[5px]">
-              <LogoCp className="h-full w-full" />
-            </span>
+            <LogoCp className="h-[34px] w-[34px]" />
             <span>Cine Prime</span>
           </Link>
           <span

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button, ButtonLink } from "@/components/ui/Button";
 import { cn } from "@/components/ui/classNames";
+import { LogoCp } from "@/components/ui/LogoCp";
 import { useI18n } from "@/i18n";
 
 import { LanguageSwitcher } from "./LanguageSwitcher";
@@ -48,13 +49,8 @@ export function AppHeader() {
             className="inline-flex items-center gap-2.5 text-[18px] font-[850] text-white"
             href="/"
           >
-            <span
-              aria-hidden="true"
-              className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-[6px] bg-brand text-[12px] font-[850] text-white"
-            >
-              CP
-            </span>
-            <span>CinePrime</span>
+            <LogoCp className="h-[34px] w-[34px]" />
+            <span>Cine Prime</span>
           </Link>
           <span
             aria-label={t("nav.venue")}

--- a/frontend/src/components/ui/LogoCp.tsx
+++ b/frontend/src/components/ui/LogoCp.tsx
@@ -1,0 +1,20 @@
+export function LogoCp({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 80 90"
+      aria-hidden="true"
+      className={className}
+      fill="none"
+    >
+      <g stroke="#b31322" strokeWidth="10" strokeLinecap="round">
+        {/* c — large CCW arc, opens to the right */}
+        <path d="M 49 30 A 22 22 0 1 0 49 58" />
+        {/* p bowl */}
+        <circle cx="55" cy="44" r="15" />
+        {/* p descender */}
+        <line x1="40" y1="44" x2="40" y2="79" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## What Changed

* Replaced the text-based "CP" badge with an SVG component featuring the **cp** monogram (`c` arc + `p` circle and descender) using the brand color `#b31322`
* Added `icon.svg` to the `app/` directory — Next.js automatically detects it as the favicon (`<link rel="icon">`)
* Updated the browser tab title from `CinePrime` → `Cine Prime`
* Added `frontend/tmp/` to `.gitignore` to prevent build artifacts from being tracked in version control
