### PR TITLE
fix(security): resolve review findings on TMDB token encryption layer

### DIFF
--- a/backend/cineprime_api/encryption.py
+++ b/backend/cineprime_api/encryption.py
@@ -12,14 +12,19 @@ Encrypted values are stored with a "fernet:" prefix so legacy plaintext rows
 continue to be readable until they are re-saved.
 """
 import base64
+import functools
 import hashlib
+import logging
 
 from cryptography.fernet import Fernet
 from django.conf import settings
 
+logger = logging.getLogger(__name__)
+
 _ENCRYPTED_PREFIX = "fernet:"
 
 
+@functools.lru_cache(maxsize=1)
 def _get_fernet() -> Fernet:
     raw = getattr(settings, "SITE_CONFIG_ENCRYPTION_KEY", None)
     if raw:
@@ -39,6 +44,7 @@ def encrypt_value(plaintext: str) -> str:
 
 def decrypt_value(stored: str) -> str:
     if not stored.startswith(_ENCRYPTED_PREFIX):
+        logger.warning("SiteConfig value is unencrypted (plaintext); re-save to encrypt")
         return stored
     token = stored[len(_ENCRYPTED_PREFIX):]
     return _get_fernet().decrypt(token.encode()).decode()

--- a/backend/cineprime_api/views.py
+++ b/backend/cineprime_api/views.py
@@ -1,5 +1,6 @@
 import hmac
 
+from cryptography.fernet import InvalidToken
 from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
@@ -28,6 +29,8 @@ def internal_tmdb_token(request):
         return JsonResponse({"value": plaintext or None})
     except SiteConfig.DoesNotExist:
         return JsonResponse({"value": None})
+    except InvalidToken:
+        return JsonResponse({"error": "Token de criptografia inválido — possível rotação de chave"}, status=503)
 
 
 def health_check(request):

--- a/backend/cineprime_api/views.py
+++ b/backend/cineprime_api/views.py
@@ -26,7 +26,7 @@ def internal_tmdb_token(request):
     try:
         cfg = SiteConfig.objects.get(key="tmdb_api_read_token")
         plaintext = decrypt_value(cfg.value) if cfg.value else None
-        return JsonResponse({"value": plaintext or None})
+        return JsonResponse({"value": plaintext})
     except SiteConfig.DoesNotExist:
         return JsonResponse({"value": None})
     except InvalidToken:

--- a/backend/users/apps.py
+++ b/backend/users/apps.py
@@ -6,3 +6,15 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         from . import checks  # noqa: F401 — registra system checks de criptografia
+
+        from cineprime_api.encryption import _get_fernet
+
+        try:
+            _get_fernet()
+        except ValueError as exc:
+            from django.core.exceptions import ImproperlyConfigured
+
+            raise ImproperlyConfigured(
+                f"SITE_CONFIG_ENCRYPTION_KEY inválida: {exc}. "
+                'Gere com: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+            ) from exc

--- a/backend/users/apps.py
+++ b/backend/users/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class UsersConfig(AppConfig):
     name = "users"
+
+    def ready(self):
+        from . import checks  # noqa: F401 — registra system checks de criptografia

--- a/backend/users/checks.py
+++ b/backend/users/checks.py
@@ -1,0 +1,48 @@
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.core.checks import Error, Tags, Warning, register
+
+
+@register(Tags.security)
+def check_encryption_key(app_configs, **kwargs):
+    messages = []
+    raw = getattr(settings, "SITE_CONFIG_ENCRYPTION_KEY", None)
+
+    if not raw and not settings.DEBUG:
+        messages.append(
+            Warning(
+                "SITE_CONFIG_ENCRYPTION_KEY não está definida.",
+                hint=(
+                    "Em produção, defina SITE_CONFIG_ENCRYPTION_KEY com uma chave Fernet válida. "
+                    "Gere com: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\". "
+                    "Sem ela, a chave é derivada de SECRET_KEY — rotacionar SECRET_KEY invalida todos os tokens criptografados."
+                ),
+                id="cineprime.W001",
+            )
+        )
+
+    if raw:
+        key = raw.encode() if isinstance(raw, str) else raw
+    else:
+        key = base64.urlsafe_b64encode(
+            hashlib.sha256(settings.SECRET_KEY.encode()).digest()
+        )
+
+    try:
+        Fernet(key)
+    except (ValueError, Exception) as exc:
+        messages.append(
+            Error(
+                f"SITE_CONFIG_ENCRYPTION_KEY inválida: {exc}",
+                hint=(
+                    "A chave deve ser uma string Fernet de 32 bytes em base64. "
+                    "Gere com: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+                ),
+                id="cineprime.E001",
+            )
+        )
+
+    return messages

--- a/backend/users/checks.py
+++ b/backend/users/checks.py
@@ -1,13 +1,11 @@
-import base64
-import hashlib
-
-from cryptography.fernet import Fernet
 from django.conf import settings
 from django.core.checks import Error, Tags, Warning, register
 
 
 @register(Tags.security)
 def check_encryption_key(app_configs, **kwargs):
+    from cineprime_api.encryption import _get_fernet
+
     messages = []
     raw = getattr(settings, "SITE_CONFIG_ENCRYPTION_KEY", None)
 
@@ -17,29 +15,22 @@ def check_encryption_key(app_configs, **kwargs):
                 "SITE_CONFIG_ENCRYPTION_KEY não está definida.",
                 hint=(
                     "Em produção, defina SITE_CONFIG_ENCRYPTION_KEY com uma chave Fernet válida. "
-                    "Gere com: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\". "
+                    'Gere com: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())". '
                     "Sem ela, a chave é derivada de SECRET_KEY — rotacionar SECRET_KEY invalida todos os tokens criptografados."
                 ),
                 id="cineprime.W001",
             )
         )
 
-    if raw:
-        key = raw.encode() if isinstance(raw, str) else raw
-    else:
-        key = base64.urlsafe_b64encode(
-            hashlib.sha256(settings.SECRET_KEY.encode()).digest()
-        )
-
     try:
-        Fernet(key)
-    except (ValueError, Exception) as exc:
+        _get_fernet()
+    except ValueError as exc:
         messages.append(
             Error(
                 f"SITE_CONFIG_ENCRYPTION_KEY inválida: {exc}",
                 hint=(
                     "A chave deve ser uma string Fernet de 32 bytes em base64. "
-                    "Gere com: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+                    'Gere com: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
                 ),
                 id="cineprime.E001",
             )

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -599,7 +599,7 @@ class TmdbTokenView(APIView):
     def get(self, request, *args, **kwargs):
         try:
             cfg = SiteConfig.objects.get(key="tmdb_api_read_token")
-            plaintext = decrypt_value(cfg.value) if cfg.value else ""
+            plaintext = decrypt_value(cfg.value) if cfg.value else None
             configured = bool(plaintext)
             hint = plaintext[-4:] if configured else None
         except SiteConfig.DoesNotExist:

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -18,6 +18,8 @@ from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenRefreshView
 
+from cryptography.fernet import InvalidToken
+
 from cineprime_api.encryption import decrypt_value, encrypt_value
 from cineprime_api.permissions import IsMasterUser
 from cineprime_api.throttling import LoginRateThrottle
@@ -603,6 +605,11 @@ class TmdbTokenView(APIView):
         except SiteConfig.DoesNotExist:
             configured = False
             hint = None
+        except InvalidToken:
+            return Response(
+                {"detail": "Falha ao descriptografar token — possível rotação de chave de criptografia."},
+                status=503,
+            )
         return Response({"configured": configured, "hint": hint})
 
     @extend_schema(summary="Set TMDB token", request=TmdbTokenBodySerializer)

--- a/frontend/src/app/admin/actions.ts
+++ b/frontend/src/app/admin/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+export async function revalidateTmdbToken() {
+  revalidateTag("tmdb-token");
+}

--- a/frontend/src/app/api/tmdb/get-token.ts
+++ b/frontend/src/app/api/tmdb/get-token.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 // BACKEND_INTERNAL_URL is a server-only var for server-to-server calls (e.g., Docker).
 // Falls back to NEXT_PUBLIC_API_BASE_URL if not set.
 const BACKEND_URL = (

--- a/frontend/src/app/api/tmdb/get-token.ts
+++ b/frontend/src/app/api/tmdb/get-token.ts
@@ -13,14 +13,17 @@ export async function getTmdbToken(): Promise<string | null> {
     return process.env.TMDB_API_READ_TOKEN;
   }
 
-  if (!INTERNAL_API_KEY) return null;
+  if (!INTERNAL_API_KEY) {
+    console.warn("[getTmdbToken] INTERNAL_API_KEY não configurada — TMDB indisponível");
+    return null;
+  }
 
   try {
     const res = await fetch(`${BACKEND_URL}/api/v1/internal/tmdb-token/`, {
       headers: { "X-Internal-Key": INTERNAL_API_KEY },
       // Next.js data cache: revalidate every 5 min. Works correctly across
       // serverless invocations and multi-worker deployments unlike module-level vars.
-      next: { revalidate: 300 },
+      next: { revalidate: 300, tags: ["tmdb-token"] },
     });
     if (!res.ok) return null;
     const data = (await res.json()) as { value: string | null };

--- a/frontend/src/components/admin/AdminMovieForm.tsx
+++ b/frontend/src/components/admin/AdminMovieForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useId, useRef, useState, type FormEvent } from "react";
 
 import { adminApi, type AdminMovieWritePayload } from "@/api/admin";
+import { revalidateTmdbToken } from "@/app/admin/actions";
 import { ApiError, getApiErrorUserMessage } from "@/api/client";
 import { useAuth } from "@/contexts/AuthContext";
 import type { CatalogGenre, CatalogMovieDetail, CatalogMovieAgeRating, MovieStatus } from "@/types/catalog";
@@ -102,6 +103,7 @@ function TmdbTokenModal({
     setError(null);
     try {
       await adminApi.setTmdbToken(value);
+      await revalidateTmdbToken();
       setStatus({ configured: true, hint: value.slice(-4) });
       setTokenInput("");
       setSaved(true);


### PR DESCRIPTION
## What was done

**Reliability**
- Added `InvalidToken` handling in both the admin and internal endpoints, returning HTTP 503 instead of crashing silently during key rotation
- Fixed stale Next.js cache on token update — the cache is now invalidated immediately when the admin saves a new token

**Operational visibility**
- Added a Django system check that warns at startup when `SITE_CONFIG_ENCRYPTION_KEY` is absent in production, catching broken deploys before any request is processed
- Changed malformed encryption key behavior: raises `ImproperlyConfigured` on startup instead of returning an opaque HTTP 500 on the first request
- Added a warning log when a legacy unencrypted value is read from `SiteConfig`, making mixed-state databases visible
- Added a warning log when `INTERNAL_API_KEY` is missing in Next.js, replacing silent failure

**Consistency and correctness**
- Unified the `None` fallback for absent tokens across both callers of `decrypt_value`, removing a divergence where the admin endpoint could report a token as configured while the internal endpoint returned null
- Cached `_get_fernet()` so the encryption key is derived once per process instead of on every call
- Marked `get-token.ts` as `server-only` to prevent accidental import in client components or edge runtimes

## How to test

- Save a valid TMDB token via `PUT /api/v1/admin/tmdb-token/` and confirm `GET` returns `configured: true` with the last 4 characters as hint
- Confirm `GET /api/v1/internal/tmdb-token/` returns the token value immediately after saving, with no stale cache
- Remove `SITE_CONFIG_ENCRYPTION_KEY` from env with `DEBUG=False` and run `manage.py check` — expect a security warning
- Set `SITE_CONFIG_ENCRYPTION_KEY` to an invalid value and start the server — expect an `ImproperlyConfigured` error on startup, not on the first request
- Manually insert a plaintext value in `SiteConfig` and read it — confirm a warning appears in the logs
- Try importing `getTmdbToken` in a Client Component — expect a build error from `server-only`