### PR TITLE
fix: backend audit — security vulnerabilities (section 2)

### DIFF
--- a/backend/cineprime_api/middleware.py
+++ b/backend/cineprime_api/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import uuid
 
 from .logging_context import (
@@ -9,6 +10,7 @@ from .logging_context import (
 )
 
 CORRELATION_ID_HEADER = "X-Correlation-ID"
+_CORRELATION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-_]{1,64}$")
 
 logger = logging.getLogger("cineprime.observability")
 
@@ -18,7 +20,11 @@ class CorrelationIdMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        correlation_id = request.headers.get(CORRELATION_ID_HEADER) or str(uuid.uuid4())
+        raw = request.headers.get(CORRELATION_ID_HEADER, "")
+        if _CORRELATION_ID_PATTERN.match(raw):
+            correlation_id = raw
+        else:
+            correlation_id = str(uuid.uuid4())
         request.correlation_id = correlation_id
 
         correlation_token = set_correlation_id(correlation_id)

--- a/backend/cineprime_api/settings.py
+++ b/backend/cineprime_api/settings.py
@@ -113,6 +113,12 @@ def _build_production_configuration_errors():
                     "in production."
                 )
 
+    if not os.getenv("SITE_CONFIG_ENCRYPTION_KEY"):
+        errors.append(
+            "SITE_CONFIG_ENCRYPTION_KEY is required when DJANGO_ENV=production. "
+            "Generate with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+        )
+
     return errors
 
 
@@ -476,3 +482,7 @@ INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY") or None
 # Falls back to a SHA-256 derivation of SECRET_KEY if not set.
 SITE_CONFIG_ENCRYPTION_KEY = os.getenv("SITE_CONFIG_ENCRYPTION_KEY") or None
 HEALTH_DEEP_INTERNAL_KEY = os.getenv("HEALTH_DEEP_INTERNAL_KEY") or None
+
+# Fernet key for encrypting sensitive values stored in the site_config table.
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+SITE_CONFIG_ENCRYPTION_KEY = os.getenv("SITE_CONFIG_ENCRYPTION_KEY") or None

--- a/backend/cineprime_api/settings.py
+++ b/backend/cineprime_api/settings.py
@@ -49,7 +49,14 @@ def _csv_env(name, default):
 DJANGO_ENV = os.getenv("DJANGO_ENV", os.getenv("ENVIRONMENT", "development")).lower()
 IS_PRODUCTION = DJANGO_ENV in PRODUCTION_ENVIRONMENTS
 
-SECRET_KEY = os.getenv("SECRET_KEY", "unsafe-secret-key").strip()
+SECRET_KEY = os.getenv("SECRET_KEY", "").strip()
+if not SECRET_KEY or SECRET_KEY in UNSAFE_SECRET_KEYS:
+    if not _env_bool("ALLOW_UNSAFE_SECRET_KEY"):
+        raise ImproperlyConfigured(
+            "SECRET_KEY must be set to a secure value. "
+            "For local development, set ALLOW_UNSAFE_SECRET_KEY=true in your environment."
+        )
+    SECRET_KEY = SECRET_KEY or "unsafe-secret-key"
 DEBUG = _env_bool("DEBUG", default=False)
 
 ALLOWED_HOSTS = _csv_env("ALLOWED_HOSTS", LOCAL_ALLOWED_HOSTS)
@@ -357,6 +364,7 @@ REST_FRAMEWORK = {
         "anon": os.getenv("THROTTLE_ANON_RATE", "60/minute"),
         "user": os.getenv("THROTTLE_USER_RATE", "120/minute"),
         "login": os.getenv("THROTTLE_LOGIN_RATE", "5/minute"),
+        "registration": os.getenv("THROTTLE_REGISTRATION_RATE", "5/hour"),
         "reservation": os.getenv("THROTTLE_RESERVATION_RATE", "10/minute"),
     },
     "EXCEPTION_HANDLER": "cineprime_api.exception_handler.standardized_exception_handler",
@@ -467,3 +475,4 @@ INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY") or None
 # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # Falls back to a SHA-256 derivation of SECRET_KEY if not set.
 SITE_CONFIG_ENCRYPTION_KEY = os.getenv("SITE_CONFIG_ENCRYPTION_KEY") or None
+HEALTH_DEEP_INTERNAL_KEY = os.getenv("HEALTH_DEEP_INTERNAL_KEY") or None

--- a/backend/cineprime_api/throttling.py
+++ b/backend/cineprime_api/throttling.py
@@ -38,6 +38,16 @@ class LoginRateThrottle(SimpleRateThrottle):
         }
 
 
+class RegistrationRateThrottle(SimpleRateThrottle):
+    scope = "registration"
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": self.get_ident(request),
+        }
+
+
 class ReservationRateThrottle(SimpleRateThrottle):
     scope = "reservation"
 

--- a/backend/cineprime_api/views.py
+++ b/backend/cineprime_api/views.py
@@ -48,5 +48,8 @@ def readiness_check(request):
 
 
 def deep_health_check(request):
+    internal_key = getattr(settings, "HEALTH_DEEP_INTERNAL_KEY", None)
+    if internal_key and request.headers.get("X-Internal-Key") != internal_key:
+        return JsonResponse({"error": "Forbidden"}, status=403)
     result = HealthCheckService().deep()
     return _health_response(result)

--- a/backend/cineprime_api/views.py
+++ b/backend/cineprime_api/views.py
@@ -25,8 +25,7 @@ def internal_tmdb_token(request):
     from users.models import SiteConfig
     try:
         cfg = SiteConfig.objects.get(key="tmdb_api_read_token")
-        plaintext = decrypt_value(cfg.value) if cfg.value else None
-        return JsonResponse({"value": plaintext})
+        return JsonResponse({"value": cfg.get_value()})
     except SiteConfig.DoesNotExist:
         return JsonResponse({"value": None})
     except InvalidToken:

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -522,6 +522,28 @@ offline = ["drf-spectacular-sidecar"]
 sidecar = ["drf-spectacular-sidecar"]
 
 [[package]]
+name = "gunicorn"
+version = "23.0.0"
+description = "WSGI HTTP Server for UNIX"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"},
+    {file = "gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "inflection"
 version = "0.5.1"
 description = "A port of Ruby on Rails inflector to Python"
@@ -1317,4 +1339,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "91e9a81e570dcd9c65067ab331a6f223d6d10679ae9434c7e0c15c076416d78d"
+content-hash = "6f9670afe28b538b63f0ac0bb3dd70e6f5d2de6a057beb775a8314fd87ca6b02"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "djangorestframework-simplejwt (>=5.5.1,<6.0.0)",
     "drf-spectacular (>=0.29.0,<0.30.0)",
     "django-cors-headers (>=4.9.0,<5.0.0)",
-    "cryptography (>=44.0.0,<45.0.0)",
+    "gunicorn (>=23.0.0,<24.0.0)",
+    "cryptography (>=44.0.0,<46.0.0)",
 ]
 
 

--- a/backend/reservations/serializers.py
+++ b/backend/reservations/serializers.py
@@ -287,6 +287,7 @@ class TemporaryReservationRequestSerializer(serializers.Serializer):
     seat_ids = serializers.ListField(
         child=serializers.UUIDField(),
         allow_empty=False,
+        max_length=20,
     )
 
     def validate_seat_ids(self, value):
@@ -366,6 +367,7 @@ class CheckoutRequestSerializer(serializers.Serializer):
     seats = serializers.ListField(
         child=CheckoutSeatRequestSerializer(),
         allow_empty=False,
+        max_length=20,
     )
     payment_method = serializers.CharField()
     total_amount = serializers.DecimalField(

--- a/backend/reservations/views.py
+++ b/backend/reservations/views.py
@@ -15,7 +15,7 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 from cineprime_api.localization import get_request_locale
-from cineprime_api.throttling import ReservationRateThrottle
+from cineprime_api.throttling import GlobalAnonRateThrottle, ReservationRateThrottle
 
 from catalog.models import Room, Session
 from reservations.exceptions import (
@@ -179,6 +179,7 @@ class TicketDetailView(RetrieveDestroyAPIView):
 class SessionSeatMapView(ListAPIView):
     serializer_class = SessionSeatMapItemSerializer
     permission_classes = [AllowAny]
+    throttle_classes = [GlobalAnonRateThrottle]
     pagination_class = None
 
     def get_queryset(self):

--- a/backend/tests/integration/test_production_settings.py
+++ b/backend/tests/integration/test_production_settings.py
@@ -13,10 +13,12 @@ BASE_PRODUCTION_ENV = {
     "SECRET_KEY": "production-secret-key-for-settings-tests",
     "ALLOWED_HOSTS": "api.example.com",
     "CORS_ALLOWED_ORIGINS": "https://app.example.com",
+    "SITE_CONFIG_ENCRYPTION_KEY": "BsB5RCI121YV2KdnpZ3bpFV6xectSpZGYSn6496wlEA=",
 }
 
 CONTROLLED_ENV_KEYS = {
     "ALLOW_INSECURE_PRODUCTION_CORS_ORIGINS",
+    "ALLOW_UNSAFE_SECRET_KEY",
     "ALLOW_WILDCARD_PRODUCTION_HOSTS",
     "ALLOWED_HOSTS",
     "CORS_ALLOWED_ORIGINS",
@@ -24,6 +26,7 @@ CONTROLLED_ENV_KEYS = {
     "DJANGO_ENV",
     "ENVIRONMENT",
     "SECRET_KEY",
+    "SITE_CONFIG_ENCRYPTION_KEY",
 }
 
 
@@ -57,28 +60,28 @@ def test_production_requires_secret_key():
     result = _production_import({"SECRET_KEY": ""})
 
     assert result.returncode != 0
-    assert "SECRET_KEY is required" in result.stderr
+    assert "SECRET_KEY must be set to a secure value" in result.stderr
 
 
 def test_production_rejects_whitespace_only_secret_key():
     result = _production_import({"SECRET_KEY": "   "})
 
     assert result.returncode != 0
-    assert "SECRET_KEY is required" in result.stderr
+    assert "SECRET_KEY must be set to a secure value" in result.stderr
 
 
 def test_production_rejects_unsafe_secret_key():
     result = _production_import({"SECRET_KEY": "unsafe-secret-key"})
 
     assert result.returncode != 0
-    assert "known unsafe development value" in result.stderr
+    assert "SECRET_KEY must be set to a secure value" in result.stderr
 
 
 def test_production_rejects_unsafe_secret_key_with_surrounding_whitespace():
     result = _production_import({"SECRET_KEY": " change-me "})
 
     assert result.returncode != 0
-    assert "known unsafe development value" in result.stderr
+    assert "SECRET_KEY must be set to a secure value" in result.stderr
 
 
 def test_production_rejects_debug_true():

--- a/backend/users/migrations/0007_encrypt_site_config_value.py
+++ b/backend/users/migrations/0007_encrypt_site_config_value.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+
+def encrypt_existing_site_config_values(apps, schema_editor):
+    from django.conf import settings
+
+    encryption_key = getattr(settings, "SITE_CONFIG_ENCRYPTION_KEY", None)
+
+    SiteConfig = apps.get_model("users", "SiteConfig")
+    rows = SiteConfig.objects.exclude(value="")
+    if not rows.exists():
+        return
+
+    if not encryption_key:
+        # No key available: clear plaintext values so they are not left exposed.
+        # The admin must re-configure them after setting SITE_CONFIG_ENCRYPTION_KEY.
+        count = rows.update(value="")
+        print(
+            f"\n  WARNING: SITE_CONFIG_ENCRYPTION_KEY is not set. "
+            f"Cleared {count} plaintext site_config value(s). "
+            f"Re-configure them via the admin UI after setting the key."
+        )
+        return
+
+    from cryptography.fernet import Fernet
+
+    cipher = Fernet(encryption_key)
+    for config in rows:
+        config.value = cipher.encrypt(config.value.encode()).decode()
+        config.save(update_fields=["value"])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0006_add_site_config"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            encrypt_existing_site_config_values,
+            reverse_code=noop,
+        ),
+    ]

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -1,8 +1,10 @@
 import uuid
 
+from cryptography.fernet import Fernet
 from django.conf import settings
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 
 
@@ -93,6 +95,22 @@ class SiteConfig(models.Model):
 
     def __str__(self):
         return self.key
+
+    def _cipher(self) -> Fernet:
+        key = getattr(settings, "SITE_CONFIG_ENCRYPTION_KEY", None)
+        if not key:
+            raise ImproperlyConfigured(
+                "SITE_CONFIG_ENCRYPTION_KEY must be set to read or write encrypted site config values."
+            )
+        return Fernet(key)
+
+    def set_value(self, plaintext: str) -> None:
+        self.value = self._cipher().encrypt(plaintext.encode()).decode()
+
+    def get_value(self) -> str | None:
+        if not self.value:
+            return None
+        return self._cipher().decrypt(self.value.encode()).decode()
 
 
 class AdminPermissionLog(models.Model):

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -28,9 +28,19 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "email", "username", "password", "created_at")
         read_only_fields = ("id", "created_at")
+        # Disable the auto-added UniqueValidator so we can return a generic message
+        # that does not confirm whether a given email address is already registered.
+        extra_kwargs = {
+            "email": {"validators": []},
+        }
 
     def validate_email(self, value):
-        return value.strip().lower()
+        normalized = value.strip().lower()
+        if User.objects.filter(email=normalized).exists():
+            raise serializers.ValidationError(
+                "Unable to register with the provided details."
+            )
+        return normalized
 
     def validate_username(self, value):
         value = value.strip()

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -605,7 +605,7 @@ class TmdbTokenView(APIView):
     def get(self, request, *args, **kwargs):
         try:
             cfg = SiteConfig.objects.get(key="tmdb_api_read_token")
-            plaintext = decrypt_value(cfg.value) if cfg.value else None
+            plaintext = cfg.get_value()
             configured = bool(plaintext)
             hint = plaintext[-4:] if configured else None
         except SiteConfig.DoesNotExist:
@@ -623,8 +623,7 @@ class TmdbTokenView(APIView):
         body = TmdbTokenBodySerializer(data=request.data)
         body.is_valid(raise_exception=True)
         plaintext = body.validated_data["value"]
-        SiteConfig.objects.update_or_create(
-            key="tmdb_api_read_token",
-            defaults={"value": encrypt_value(plaintext)},
-        )
+        cfg, _ = SiteConfig.objects.get_or_create(key="tmdb_api_read_token")
+        cfg.set_value(plaintext)
+        cfg.save()
         return Response({"configured": True, "hint": plaintext[-4:]})

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -22,7 +22,7 @@ from cryptography.fernet import InvalidToken
 
 from cineprime_api.encryption import decrypt_value, encrypt_value
 from cineprime_api.permissions import IsMasterUser
-from cineprime_api.throttling import LoginRateThrottle
+from cineprime_api.throttling import LoginRateThrottle, RegistrationRateThrottle
 from reservations.models import SessionSeat, SessionSeatStatus, Ticket
 from users.models import AdminPermissionLog, SiteConfig, User
 from users.serializers import (
@@ -109,6 +109,7 @@ class CurrentUserResponseSerializer(serializers.Serializer):
 class UserRegistrationView(CreateAPIView):
     serializer_class = UserRegistrationSerializer
     permission_classes = [AllowAny]
+    throttle_classes = [RegistrationRateThrottle]
 
 
 @extend_schema_view(
@@ -406,6 +407,11 @@ class AdminGrantView(APIView):
     def delete(self, request, user_id, *args, **kwargs):
         target = self._get_target(user_id)
         self._check_not_protected(target)
+
+        if target.is_superuser:
+            other_masters = User.objects.filter(is_superuser=True).exclude(pk=target.pk).count()
+            if other_masters == 0:
+                raise ValidationError("Cannot revoke the last master admin.")
 
         if target.is_staff or target.is_superuser:
             revoked_role = (


### PR DESCRIPTION
## What was done

Fixes for all items in **Section 2 — Security Vulnerabilities** of the backend audit.

| Severity | File | Fix |
|---|---|---|
| CRITICAL | `users/models.py`, `users/migrations/0007_encrypt_site_config_value.py` | `SiteConfig` values are now stored encrypted with Fernet (`SITE_CONFIG_ENCRYPTION_KEY`); data migration encrypts existing rows or clears them if the key is not set |
| HIGH | `cineprime_api/settings.py` | `SECRET_KEY` no longer has a hardcoded fallback — startup raises `ImproperlyConfigured` unless `ALLOW_UNSAFE_SECRET_KEY=true` is explicitly set |
| HIGH | `cineprime_api/middleware.py` | `X-Correlation-ID` header is validated against `^[a-zA-Z0-9\-_]{1,64}$` before use; invalid values are replaced with a generated UUID — prevents log injection and long-value reflection |
| HIGH | `cineprime_api/throttling.py`, `users/views.py`, `settings.py` | Added `RegistrationRateThrottle` (5/hour per IP) applied to `UserRegistrationView` — prevents account farming and welcome-email spam |
| HIGH | `cineprime_api/views.py`, `settings.py` | `/health/deep/` now requires `X-Internal-Key` header matching `HEALTH_DEEP_INTERNAL_KEY` when that env var is set — stops public reconnaissance of internal service availability |
| HIGH | `reservations/views.py` | `SessionSeatMapView` now applies `GlobalAnonRateThrottle` — prevents continuous seat-availability polling |
| MEDIUM | `users/views.py` | `AdminGrantView.delete()` checks that at least one other master admin exists before revoking — prevents privilege consolidation by a single master |
| MEDIUM | `users/serializers.py` | Registration endpoint returns a generic error regardless of whether the e-mail already exists — prevents user enumeration via registration |
| MEDIUM | `reservations/serializers.py` | `seat_ids` and `seats` fields capped at `max_length=20` — prevents heavy query attacks with hundreds of IDs in one request |