### PR TITLE
fix: harden account bootstrap, JWT rollout, and profile edge cases

### DIFF
--- a/backend/cineprime_api/settings.py
+++ b/backend/cineprime_api/settings.py
@@ -394,6 +394,14 @@ EMAIL_VERIFICATION_TOKEN_MAX_AGE_SECONDS = _env_int(
     "EMAIL_VERIFICATION_TOKEN_MAX_AGE_SECONDS", 259200  # 3 days
 )
 
+# When real email delivery is unavailable (local development), mark new
+# accounts as verified at registration and skip the verification email.
+# Defaults to on outside production; forced off when DJANGO_ENV=production.
+AUTO_VERIFY_NEW_USERS = (
+    _env_bool("AUTO_VERIFY_NEW_USERS", default=not IS_PRODUCTION)
+    and not IS_PRODUCTION
+)
+
 # How long an email change confirmation link stays valid. Deliberately much
 # shorter than the verification link: applying an email change is an
 # account-takeover-grade operation.
@@ -482,6 +490,16 @@ SIMPLE_JWT = {
     # Rejects refresh tokens issued before the user's last password change.
     "TOKEN_REFRESH_SERIALIZER": "users.jwt.PasswordChangeAwareTokenRefreshSerializer",
 }
+
+# Two-phase rollout of the pwd_fp claim: tokens issued before the claim
+# existed carry no fingerprint, so requiring it immediately would force-log-out
+# every active session at deploy time. Keep this True for at least one full
+# JWT_REFRESH_TOKEN_LIFETIME_DAYS window after the first deploy that issues the
+# claim, then flip it to False so tokens without the claim are rejected.
+JWT_ACCEPT_TOKENS_WITHOUT_PASSWORD_FINGERPRINT = (
+    os.getenv("JWT_ACCEPT_TOKENS_WITHOUT_PASSWORD_FINGERPRINT", "true").lower()
+    == "true"
+)
 
 # -------------------------------------------------------------------
 # Logging

--- a/backend/tests/integration/test_email_verification.py
+++ b/backend/tests/integration/test_email_verification.py
@@ -59,6 +59,7 @@ def user():
 
 
 @pytest.mark.django_db
+@override_settings(AUTO_VERIFY_NEW_USERS=False)
 def test_registration_enqueues_verification_email():
     client = APIClient()
 
@@ -76,6 +77,26 @@ def test_registration_enqueues_verification_email():
     mock_apply_async.assert_called_once()
     call_args = mock_apply_async.call_args.kwargs["args"]
     assert call_args[0] == str(user_id)
+
+
+@pytest.mark.django_db
+@override_settings(AUTO_VERIFY_NEW_USERS=True)
+def test_registration_auto_verifies_without_email_when_enabled():
+    client = APIClient()
+
+    payload = {
+        "email": "autoverify@example.com",
+        "username": "autoverify",
+        "password": "StrongPassword123",
+    }
+
+    with patch("users.tasks.send_email_verification_email_task.apply_async") as mock_apply_async:
+        response = client.post("/api/v1/auth/register/", payload, format="json")
+
+    assert response.status_code == 201
+    mock_apply_async.assert_not_called()
+    user = User.objects.get(email=payload["email"])
+    assert user.is_verified is True
 
 
 @pytest.mark.django_db

--- a/backend/tests/integration/test_profile_update.py
+++ b/backend/tests/integration/test_profile_update.py
@@ -268,14 +268,19 @@ class TestEmailChangeConfirm:
         user.refresh_from_db()
         assert user.email == "profile@example.com"
 
-    def test_already_applied_token_cannot_be_reused(self, api_client, user):
+    def test_already_applied_token_confirms_idempotently(self, api_client, user):
+        # The confirmation POST can fire twice (StrictMode double-effect,
+        # link clicked twice, page reload); the retry must report success
+        # instead of showing an error for a change that was applied.
         token = generate_email_change_token(user, "confirmed@example.com")
 
         first = self._confirm(api_client, token)
         second = self._confirm(api_client, token)
 
         assert first.status_code == status.HTTP_200_OK
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert first.data["changed"] is True
+        assert second.status_code == status.HTTP_200_OK
+        assert second.data["changed"] is False
 
         user.refresh_from_db()
         assert user.email == "confirmed@example.com"

--- a/backend/tests/integration/test_user_registration.py
+++ b/backend/tests/integration/test_user_registration.py
@@ -120,7 +120,32 @@ def test_user_registration_requires_email_username_and_password():
 
 
 @pytest.mark.django_db
-def test_public_registration_never_creates_admin():
+def test_first_registration_becomes_protected_master():
+    client = APIClient()
+
+    payload = {
+        "email": "founder@example.com",
+        "username": "founder",
+        "password": "StrongPassword123",
+    }
+
+    response = client.post("/api/v1/auth/register/", payload, format="json")
+
+    assert response.status_code == 201
+    user = User.objects.get(email=payload["email"])
+    assert user.is_staff is True
+    assert user.is_superuser is True
+    assert user.is_protected_master is True
+    assert user.is_verified is True
+
+
+@pytest.mark.django_db
+def test_public_registration_never_creates_admin_when_users_exist():
+    User.objects.create_user(
+        email="existing@example.com",
+        username="existing",
+        password="StrongPassword123",
+    )
     client = APIClient()
 
     payload = {
@@ -137,3 +162,4 @@ def test_public_registration_never_creates_admin():
     user = User.objects.get(email=payload["email"])
     assert user.is_staff is False
     assert user.is_superuser is False
+    assert user.is_protected_master is False

--- a/backend/users/exceptions.py
+++ b/backend/users/exceptions.py
@@ -1,0 +1,53 @@
+"""Custom API exceptions for the users app.
+
+Kept in a neutral module so serializers can raise them without importing
+views (which import serializers, creating a cycle).
+"""
+
+from rest_framework.exceptions import APIException
+
+
+class HasActiveTickets(APIException):
+    status_code = 409
+    default_code = "HAS_ACTIVE_TICKETS"
+    default_detail = "User has active tickets."
+
+    def __init__(self, ticket_count=0):
+        super().__init__()
+        self.ticket_count = ticket_count
+
+
+class OnlyMasterAdmin(APIException):
+    status_code = 400
+    default_code = "ONLY_MASTER_ADMIN"
+    default_detail = "You are the only master admin. Promote another user to master before deleting your account."
+
+
+class ProtectedTransferRequired(APIException):
+    status_code = 400
+    default_code = "PROTECTED_TRANSFER_REQUIRED"
+    default_detail = "You are the protected master. Designate a successor master before deleting your account."
+
+
+class WrongPassword(APIException):
+    status_code = 400
+    default_code = "WRONG_PASSWORD"
+    default_detail = "Incorrect password."
+
+
+class InvalidVerificationToken(APIException):
+    status_code = 400
+    default_code = "INVALID_VERIFICATION_TOKEN"
+    default_detail = "Invalid or expired verification link."
+
+
+class InvalidPasswordResetToken(APIException):
+    status_code = 400
+    default_code = "INVALID_RESET_TOKEN"
+    default_detail = "Invalid or expired password reset link."
+
+
+class InvalidEmailChangeToken(APIException):
+    status_code = 400
+    default_code = "INVALID_EMAIL_CHANGE_TOKEN"
+    default_detail = "Invalid or expired email change confirmation link."

--- a/backend/users/jwt.py
+++ b/backend/users/jwt.py
@@ -8,6 +8,7 @@ database-backed blacklist.
 
 import hashlib
 
+from django.conf import settings
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
@@ -27,7 +28,13 @@ def issue_tokens_for_user(user) -> RefreshToken:
 
 
 def _validate_password_fingerprint(token, user) -> None:
-    if token.get(PASSWORD_FINGERPRINT_CLAIM) != password_fingerprint(user):
+    claim = token.get(PASSWORD_FINGERPRINT_CLAIM)
+    if claim is None and settings.JWT_ACCEPT_TOKENS_WITHOUT_PASSWORD_FINGERPRINT:
+        # Legacy token issued before the claim existed; accepted during the
+        # rollout window (see the setting) instead of force-logging-out every
+        # session on deploy.
+        return
+    if claim != password_fingerprint(user):
         raise InvalidToken("Token is no longer valid because the password changed.")
 
 

--- a/backend/users/management/commands/bootstrap_admin.py
+++ b/backend/users/management/commands/bootstrap_admin.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
 
         user.is_staff = True
         user.is_superuser = True
+        user.is_protected_master = True
+        user.is_verified = True
 
         if created:
             user.set_password(password)

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,9 +1,11 @@
 from django.contrib.auth import authenticate
 from django.contrib.auth.password_validation import validate_password
+from django.db import connection, transaction
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 
+from users.exceptions import WrongPassword
 from users.models import AdminPermissionLog, User, WalletTransaction
 from reservations.models import Ticket
 
@@ -65,8 +67,6 @@ class ProfileUpdateSerializer(serializers.Serializer):
         if "email" in attrs:
             user = self.context["request"].user
             if not current_password or not user.check_password(current_password):
-                from users.views import WrongPassword
-
                 raise WrongPassword()
 
         return attrs
@@ -120,7 +120,40 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         return value
 
     def create(self, validated_data):
-        return User.objects.create_user(**validated_data)
+        # The very first account in an empty database becomes the protected
+        # master admin, so a fresh install always has an owner that cannot be
+        # locked out or demoted by later accounts.
+        with transaction.atomic():
+            is_first_user = False
+            if not User.objects.exists():
+                # Serialize only the bootstrap path: concurrent registrations
+                # against an empty database could otherwise both pass the
+                # exists() check (READ COMMITTED) and create two protected
+                # masters. The lock is only ever taken with an empty table,
+                # so normal registrations never wait on it.
+                if connection.vendor == "postgresql":
+                    with connection.cursor() as cursor:
+                        cursor.execute("SELECT pg_advisory_xact_lock(%s)", [713001])
+                is_first_user = not User.objects.exists()
+
+            user = User.objects.create_user(**validated_data)
+
+            if is_first_user:
+                user.is_staff = True
+                user.is_superuser = True
+                user.is_protected_master = True
+                user.is_verified = True
+                user.save(
+                    update_fields=[
+                        "is_staff",
+                        "is_superuser",
+                        "is_protected_master",
+                        "is_verified",
+                        "updated_at",
+                    ]
+                )
+
+        return user
 
 
 class UserLoginSerializer(serializers.Serializer):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -18,7 +19,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import status
 from rest_framework import serializers
-from rest_framework.exceptions import APIException, NotFound, PermissionDenied, ValidationError
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.generics import CreateAPIView, ListAPIView
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
@@ -41,6 +42,15 @@ from cineprime_api.throttling import (
     RegistrationRateThrottle,
 )
 from reservations.models import SessionSeat, SessionSeatStatus, Ticket
+from users.exceptions import (
+    HasActiveTickets,
+    InvalidEmailChangeToken,
+    InvalidPasswordResetToken,
+    InvalidVerificationToken,
+    OnlyMasterAdmin,
+    ProtectedTransferRequired,
+    WrongPassword,
+)
 from users.models import AdminPermissionLog, SiteConfig, User, WalletTransaction
 from users.serializers import (
     AdminPermissionLogSerializer,
@@ -64,34 +74,6 @@ from users.tokens import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class HasActiveTickets(APIException):
-    status_code = 409
-    default_code = "HAS_ACTIVE_TICKETS"
-    default_detail = "User has active tickets."
-
-    def __init__(self, ticket_count=0):
-        super().__init__()
-        self.ticket_count = ticket_count
-
-
-class OnlyMasterAdmin(APIException):
-    status_code = 400
-    default_code = "ONLY_MASTER_ADMIN"
-    default_detail = "You are the only master admin. Promote another user to master before deleting your account."
-
-
-class ProtectedTransferRequired(APIException):
-    status_code = 400
-    default_code = "PROTECTED_TRANSFER_REQUIRED"
-    default_detail = "You are the protected master. Designate a successor master before deleting your account."
-
-
-class WrongPassword(APIException):
-    status_code = 400
-    default_code = "WRONG_PASSWORD"
-    default_detail = "Incorrect password."
 
 
 def _delete_user_cascade(user):
@@ -137,24 +119,6 @@ class PasswordResetRequestResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
 
-class InvalidVerificationToken(APIException):
-    status_code = 400
-    default_code = "INVALID_VERIFICATION_TOKEN"
-    default_detail = "Invalid or expired verification link."
-
-
-class InvalidPasswordResetToken(APIException):
-    status_code = 400
-    default_code = "INVALID_RESET_TOKEN"
-    default_detail = "Invalid or expired password reset link."
-
-
-class InvalidEmailChangeToken(APIException):
-    status_code = 400
-    default_code = "INVALID_EMAIL_CHANGE_TOKEN"
-    default_detail = "Invalid or expired email change confirmation link."
-
-
 class ProfileUpdateResponseSerializer(CurrentUserResponseSerializer):
     email_change_requested = serializers.BooleanField()
 
@@ -194,6 +158,12 @@ class UserRegistrationView(CreateAPIView):
 
     def perform_create(self, serializer):
         user = serializer.save()
+
+        if settings.AUTO_VERIFY_NEW_USERS:
+            if not user.is_verified:
+                user.is_verified = True
+                user.save(update_fields=["is_verified", "updated_at"])
+            return
 
         from users.tasks import send_email_verification_email_task
 
@@ -450,13 +420,23 @@ class EmailChangeConfirmView(APIView):
         except (User.DoesNotExist, ValueError, DjangoValidationError):
             raise InvalidEmailChangeToken()
 
+        new_email = str(payload["new_email"]).strip().lower()
+
+        # Idempotent success: the confirmation POST can fire more than once
+        # (React StrictMode double-effect, link clicked twice, page reload).
+        # If this token was already applied to this account, report success
+        # instead of failing the from_email check below.
+        if user.email == new_email:
+            return Response(
+                {"email": user.email, "changed": False},
+                status=status.HTTP_200_OK,
+            )
+
         # Reject tokens issued against a previous address: applying any email
         # change (or reusing an already-applied token) invalidates every
         # other pending token for this account.
         if str(payload["from_email"]).strip().lower() != user.email:
             raise InvalidEmailChangeToken()
-
-        new_email = str(payload["new_email"]).strip().lower()
 
         if User.objects.filter(email=new_email).exclude(pk=user.pk).exists():
             raise InvalidEmailChangeToken()
@@ -552,20 +532,20 @@ class CurrentUserWalletView(APIView):
     def get(self, request, *args, **kwargs):
         queryset = WalletTransaction.objects.filter(user=request.user)
 
-        # Single transaction so the balance matches the listed entries even
-        # if a credit lands concurrently.
-        with transaction.atomic():
-            transactions = list(queryset[: self.MAX_TRANSACTIONS])
-            count = queryset.count()
-            balance = queryset.aggregate(total=Sum("amount"))["total"] or Decimal(
-                "0.00"
-            )
+        # Fetch one extra row so has_more is derived from the same query as
+        # the listed entries; balance/count may lag by a concurrent credit,
+        # which is acceptable for a display-only endpoint.
+        transactions = list(queryset[: self.MAX_TRANSACTIONS + 1])
+        has_more = len(transactions) > self.MAX_TRANSACTIONS
+        transactions = transactions[: self.MAX_TRANSACTIONS]
+        count = queryset.count()
+        balance = queryset.aggregate(total=Sum("amount"))["total"] or Decimal("0.00")
 
         return Response(
             {
                 "balance": str(balance.quantize(Decimal("0.01"))),
                 "count": count,
-                "has_more": count > len(transactions),
+                "has_more": has_more,
                 "transactions": WalletTransactionSerializer(
                     transactions, many=True
                 ).data,
@@ -652,7 +632,12 @@ class CurrentUserView(APIView):
         username = serializer.validated_data.get("username")
         if username and username != user.username:
             user.username = username
-            user.save(update_fields=["username", "updated_at"])
+            try:
+                user.save(update_fields=["username", "updated_at"])
+            except IntegrityError:
+                # Concurrent update grabbed the username between the
+                # serializer's uniqueness check and the save.
+                raise ValidationError({"username": ["This username is already taken."]})
 
         # Email changes are never applied directly: a confirmation link is
         # sent to the new address and the change only takes effect once that


### PR DESCRIPTION
## What was done
- First registration against an empty database becomes the protected master admin, guarded by a Postgres advisory lock against a concurrent bootstrap race; `bootstrap_admin` now sets the same flags.
- Add `AUTO_VERIFY_NEW_USERS` to skip sending the verification email when real delivery is unavailable (defaults on outside production).
- Add a `JWT_ACCEPT_TOKENS_WITHOUT_PASSWORD_FINGERPRINT` rollout flag so tokens issued before the `pwd_fp` claim existed aren't force-logged-out at deploy time.
- Email change confirmation is now idempotent: reconfirming an already-applied token reports success instead of failing.
- Fix the wallet `has_more` flag to derive from the same query as the listed transactions, and handle a concurrent username collision with a friendly validation error instead of a 500.
- Extract API exceptions into `users/exceptions.py` to break an import cycle between serializers and views.