### PR TITLE
fix: retry optional-auth requests anonymously and refetch preview on locale change

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -247,6 +247,110 @@ test("apiRequest clears auth through the controller when refresh fails", async (
   }
 });
 
+test("apiRequest refreshes and retries an optional-auth request once after 401", async () => {
+  const originalFetch = globalThis.fetch;
+  const seenAuthorizationHeaders: Array<string | null> = [];
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "old-access",
+      refreshAccessToken: async () => "new-access",
+    });
+
+    globalThis.fetch = async (_input, init) => {
+      const headers = new Headers(init?.headers);
+      seenAuthorizationHeaders.push(headers.get("Authorization"));
+
+      if (seenAuthorizationHeaders.length === 1) {
+        return Response.json(
+          {
+            error: {
+              code: "NOT_AUTHENTICATED",
+              details: {},
+              message: "Token is invalid or expired.",
+              status: 401,
+            },
+          },
+          { status: 401 }
+        );
+      }
+
+      return Response.json({ ok: true });
+    };
+
+    const response = await apiRequest<{ ok: boolean }>(
+      "/api/v1/reservation/sessions/abc/seats/",
+      {
+        auth: "optional",
+        baseUrl: "http://api.local:8000",
+      }
+    );
+
+    assert.deepEqual(response, { ok: true });
+    assert.deepEqual(seenAuthorizationHeaders, [
+      "Bearer old-access",
+      "Bearer new-access",
+    ]);
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("apiRequest retries an optional-auth request anonymously when refresh fails", async () => {
+  const originalFetch = globalThis.fetch;
+  const seenAuthorizationHeaders: Array<string | null> = [];
+  let handledRefreshFailureFor: string | null = null;
+
+  try {
+    setApiAuthController({
+      getAccessToken: () => "stale-access",
+      handleRefreshFailure: (path) => {
+        handledRefreshFailureFor = path;
+      },
+      refreshAccessToken: async () => {
+        throw new Error("refresh failed");
+      },
+    });
+
+    globalThis.fetch = async (_input, init) => {
+      const headers = new Headers(init?.headers);
+      seenAuthorizationHeaders.push(headers.get("Authorization"));
+
+      if (headers.get("Authorization")) {
+        return Response.json(
+          {
+            error: {
+              code: "NOT_AUTHENTICATED",
+              details: {},
+              message: "Token is invalid or expired.",
+              status: 401,
+            },
+          },
+          { status: 401 }
+        );
+      }
+
+      return Response.json({ ok: true });
+    };
+
+    const response = await apiRequest<{ ok: boolean }>(
+      "/api/v1/reservation/sessions/abc/seats/",
+      {
+        auth: "optional",
+        baseUrl: "http://api.local:8000",
+      }
+    );
+
+    assert.deepEqual(response, { ok: true });
+    assert.deepEqual(seenAuthorizationHeaders, ["Bearer stale-access", null]);
+    assert.equal(handledRefreshFailureFor, null);
+  } finally {
+    setApiAuthController(null);
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("getApiErrorUserMessage maps known backend codes without exposing raw backend messages", () => {
   for (const code of KNOWN_BACKEND_ERROR_CODES) {
     const error = new ApiError("Raw backend message.", 400, {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -141,7 +141,7 @@ export async function apiRequest<T>(
 
   if (
     response.status === 401 &&
-    auth === "required" &&
+    (auth === "required" || (auth === "optional" && accessToken)) &&
     retryOnUnauthorized &&
     apiAuthController
   ) {
@@ -157,6 +157,20 @@ export async function apiRequest<T>(
         json,
         retryOnUnauthorized: false,
         token: refreshedAccessToken,
+      });
+    }
+
+    if (auth === "optional") {
+      // A stale token must not break public endpoints: retry anonymously
+      // instead of surfacing the 401 (or logging the user out).
+      return apiRequest<T>(path, {
+        ...options,
+        auth: "none",
+        baseUrl,
+        body: options.body,
+        headers,
+        json,
+        retryOnUnauthorized: false,
       });
     }
 

--- a/frontend/src/components/reservations/SessionMoviePreview.tsx
+++ b/frontend/src/components/reservations/SessionMoviePreview.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { catalogApi } from "@/api/catalog";
+import { useI18n } from "@/i18n";
 import type { CatalogSession } from "@/types/catalog";
 
 import { MoviePreviewPanel } from "./MoviePreviewPanel";
@@ -20,6 +21,7 @@ export function SessionMoviePreview({
   summaryActionHref,
   summaryActionLabel,
 }: SessionMoviePreviewProps) {
+  const { locale } = useI18n();
   const [session, setSession] = useState<CatalogSession | null>(null);
   const [error, setError] = useState(false);
 
@@ -32,7 +34,7 @@ export function SessionMoviePreview({
         if (err.name !== "AbortError") setError(true);
       });
     return () => controller.abort();
-  }, [sessionId]);
+  }, [sessionId, locale]);
 
   if (error) return <p className="text-sm text-white/50">...</p>;
   if (!session) return <div className="animate-pulse rounded-card bg-white/5 h-64 w-full" />;


### PR DESCRIPTION
## What was done
- `apiRequest` now retries an optional-auth request (public endpoints that attach a token when available) anonymously on a 401 instead of surfacing the error or logging the user out over a stale token.
- `SessionMoviePreview` now refetches when the active locale changes, so switching languages updates the already-loaded session preview.