### PR TITLE
fix: selected tab text was invisible against its own background

### DIFF
--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -70,10 +70,10 @@ export function Tabs({
               aria-controls={panelId}
               aria-selected={isSelected}
               className={cn(
-                "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold text-muted transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
+                "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
                 isSelected
                   ? "bg-surface text-black shadow-soft"
-                  : "hover:bg-surface hover:text-black"
+                  : "text-muted hover:bg-surface hover:text-black"
               )}
               disabled={item.disabled}
               id={tabId}

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -72,8 +72,8 @@ export function Tabs({
               className={cn(
                 "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold text-muted transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
                 isSelected
-                  ? "bg-surface text-text shadow-soft"
-                  : "hover:bg-surface hover:text-text"
+                  ? "bg-surface text-cinema-ink shadow-soft"
+                  : "hover:bg-surface hover:text-cinema-ink"
               )}
               disabled={item.disabled}
               id={tabId}

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -72,8 +72,8 @@ export function Tabs({
               className={cn(
                 "min-h-9 whitespace-nowrap rounded-control px-3 py-2 text-sm font-extrabold text-muted transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-[0.68]",
                 isSelected
-                  ? "bg-surface text-cinema-ink shadow-soft"
-                  : "hover:bg-surface hover:text-cinema-ink"
+                  ? "bg-surface text-black shadow-soft"
+                  : "hover:bg-surface hover:text-black"
               )}
               disabled={item.disabled}
               id={tabId}

--- a/frontend/src/components/ui/ui-primitives.test.ts
+++ b/frontend/src/components/ui/ui-primitives.test.ts
@@ -131,6 +131,26 @@ test("tabs fall back when default value is invalid or disabled", () => {
   assert.match(disabledDefaultHtml, /hidden=""[^>]*>Hoje/);
 });
 
+test("selected tab never carries both text-muted and its own text color class", () => {
+  // Regression: cn() does not dedupe conflicting Tailwind classes, so if the
+  // selected tab's button keeps the base "text-muted" class alongside its own
+  // color class, the two same-specificity rules fight over which one wins in
+  // the compiled stylesheet instead of the selected color reliably applying.
+  const html = renderToStaticMarkup(
+    createElement(Tabs, {
+      ariaLabel: "Periodos",
+      items: [
+        { content: "Hoje", label: "Hoje", value: "today" },
+        { content: "Amanha", label: "Amanha", value: "tomorrow" },
+      ],
+    })
+  );
+
+  const selectedButtonMatch = /<button[^>]*aria-selected="true"[^>]*>/.exec(html);
+  assert.ok(selectedButtonMatch);
+  assert.doesNotMatch(selectedButtonMatch[0], /\btext-muted\b/);
+});
+
 test("input renders a themed, accessible text field with label and error", () => {
   const html = renderToStaticMarkup(
     createElement(Input, {


### PR DESCRIPTION
## What was done
- `Tabs` paired `bg-surface` (white) with `text-text` (a near-white color meant for the dark theme) on the selected tab, making its label unreadable. Switched to `text-cinema-ink` (a dark color) for both the selected state and the unselected hover state, which had the same pairing.