### PR TITLE
fix: center AdminConfirmDialog with Tailwind Preflight active

### DIFF
--- a/frontend/src/components/admin/AdminConfirmDialog.tsx
+++ b/frontend/src/components/admin/AdminConfirmDialog.tsx
@@ -53,8 +53,9 @@ export function AdminConfirmDialog({
   return (
     <dialog
       aria-labelledby="confirm-dialog-title"
+      // m-auto is required: Tailwind's Preflight resets margin, which the native <dialog> centering relies on.
       className={cn(
-        "w-full max-w-sm rounded-[10px] border border-white/[0.10]",
+        "fixed inset-0 m-auto w-full max-w-sm rounded-[10px] border border-white/[0.10]",
         "bg-[#1a2030] p-6 text-white shadow-xl backdrop:bg-black/60",
         "open:flex open:flex-col open:gap-4"
       )}


### PR DESCRIPTION
## Summary
- The native `<dialog>` element centers itself via UA-default margins, which Tailwind's Preflight resets to zero, leaving admin confirm dialogs pinned to the top-left of the viewport instead of centered.
- Restore centering explicitly with `fixed inset-0 m-auto`, independent of Preflight's margin reset.