### PR TITLE
fix: hide and reject reviews for movies back in em_breve status

### DIFF
--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -222,11 +222,15 @@ def _sessions_with_valid_tickets(sessions_qs):
 
 
 def _movie_queryset_with_aggregates():
+    # Reviews attached to a movie that has moved back to "em_breve" are not
+    # surfaced anywhere (see MovieReviewListCreateView.get), so they must not
+    # count toward the rating either, or the two would disagree.
+    not_coming_soon = ~Q(status=MovieStatus.EM_BREVE)
     return (
         Movie.objects.prefetch_related("genres", "cast")
         .annotate(
-            average_rating=Avg("reviews__rating"),
-            review_count=Count("reviews"),
+            average_rating=Avg("reviews__rating", filter=not_coming_soon),
+            review_count=Count("reviews", filter=not_coming_soon),
         )
     )
 
@@ -758,7 +762,12 @@ class MovieReviewListCreateView(APIView):
         except (ValueError, TypeError):
             page = 1
 
-        qs = _review_queryset(movie, request)
+        # A movie that moved back to "em_breve" after being released keeps its
+        # historical reviews in the database, but they must stop being served
+        # (mirrors the average_rating/review_count filtering below).
+        movie_reviews_visible = movie.status != MovieStatus.EM_BREVE
+        base_qs = _review_queryset(movie, request) if movie_reviews_visible else _review_queryset(movie, request).none()
+        qs = base_qs
 
         rating_param = request.query_params.get("rating")
         if rating_param is not None:
@@ -790,7 +799,7 @@ class MovieReviewListCreateView(APIView):
         }
 
         if request.user.is_authenticated:
-            my_review_qs = _review_queryset(movie, request).filter(user=request.user).first()
+            my_review_qs = base_qs.filter(user=request.user).first()
             response_data["my_review"] = (
                 MovieReviewSerializer(my_review_qs).data if my_review_qs else None
             )
@@ -799,6 +808,20 @@ class MovieReviewListCreateView(APIView):
 
     def post(self, request, movie_pk):
         movie = get_object_or_404(Movie, pk=movie_pk)
+
+        if movie.status == MovieStatus.EM_BREVE:
+            return Response(
+                {
+                    "error": {
+                        "code": "MOVIE_NOT_RELEASED",
+                        "message": "Reviews can only be submitted for released movies.",
+                        "status": 400,
+                        "details": None,
+                    }
+                },
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
         serializer = MovieReviewSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/backend/tests/integration/test_movie_review_api.py
+++ b/backend/tests/integration/test_movie_review_api.py
@@ -1,0 +1,103 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from catalog.models import Movie, MovieReview
+from catalog.views import _movie_queryset_with_aggregates
+from users.models import User
+
+
+@pytest.mark.django_db
+class TestMovieReviewApi:
+    @pytest.fixture
+    def released_movie(self):
+        return Movie.objects.create(
+            title="Já Lançado",
+            synopsis="Um filme em cartaz.",
+            duration_minutes=100,
+            release_date="2025-01-01",
+            poster_url="https://example.com/poster.jpg",
+            status="em_cartaz",
+        )
+
+    @pytest.fixture
+    def upcoming_movie(self):
+        return Movie.objects.create(
+            title="Em Breve: O Filme",
+            synopsis="Um filme que está por vir.",
+            duration_minutes=110,
+            release_date="2027-01-01",
+            poster_url="https://example.com/poster.jpg",
+            status="em_breve",
+        )
+
+    @pytest.fixture
+    def presale_movie(self):
+        return Movie.objects.create(
+            title="Pré-venda: O Filme",
+            synopsis="Um filme em pré-venda.",
+            duration_minutes=105,
+            release_date="2027-01-01",
+            poster_url="https://example.com/poster.jpg",
+            status="pre_venda",
+        )
+
+    @pytest.fixture
+    def user(self):
+        return User.objects.create_user(
+            email="reviewer@example.com",
+            username="reviewer",
+            password="StrongPass123",
+        )
+
+    @pytest.fixture
+    def client(self, user):
+        api_client = APIClient()
+        api_client.force_authenticate(user=user)
+        return api_client
+
+    def _url(self, movie):
+        return f"/api/v1/catalog/movies/{movie.id}/reviews/"
+
+    def test_post_rejects_review_for_upcoming_movie(self, client, upcoming_movie):
+        response = client.post(
+            self._url(upcoming_movie), {"rating": 5, "comment": "Mal posso esperar!"}
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["error"]["code"] == "MOVIE_NOT_RELEASED"
+        assert not MovieReview.objects.filter(movie=upcoming_movie).exists()
+
+    def test_post_accepts_review_for_released_movie(self, client, released_movie):
+        response = client.post(
+            self._url(released_movie), {"rating": 4.5, "comment": "Muito bom."}
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert MovieReview.objects.filter(movie=released_movie).count() == 1
+
+    def test_post_accepts_review_for_presale_movie(self, client, presale_movie):
+        response = client.post(
+            self._url(presale_movie), {"rating": 4, "comment": "Já garanti meu ingresso."}
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert MovieReview.objects.filter(movie=presale_movie).count() == 1
+
+    def test_reviews_hidden_and_excluded_from_aggregates_once_movie_reverts_to_upcoming(
+        self, client, released_movie
+    ):
+        client.post(self._url(released_movie), {"rating": 5, "comment": "Excelente."})
+
+        released_movie.status = "em_breve"
+        released_movie.save(update_fields=["status"])
+
+        response = client.get(self._url(released_movie))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 0
+        assert response.data["results"] == []
+        assert response.data["my_review"] is None
+
+        movie_with_aggregates = _movie_queryset_with_aggregates().get(pk=released_movie.pk)
+        assert movie_with_aggregates.review_count == 0
+        assert movie_with_aggregates.average_rating is None

--- a/frontend/src/components/movies/MovieDetail.tsx
+++ b/frontend/src/components/movies/MovieDetail.tsx
@@ -286,12 +286,14 @@ function MovieDetailSuccess({
           )}
         </div>
 
-        <MovieReviewsPanel
-          currentUserId={currentUserId}
-          isAdmin={isAdmin}
-          isAuthenticated={isAuthenticated}
-          movie={movie}
-        />
+        {movie.status !== "em_breve" && (
+          <MovieReviewsPanel
+            currentUserId={currentUserId}
+            isAdmin={isAdmin}
+            isAuthenticated={isAuthenticated}
+            movie={movie}
+          />
+        )}
       </div>
 
       <article className="movie-detail__content">


### PR DESCRIPTION
## Summary
- A movie that was released and later reverts to `em_breve` (e.g. a delayed re-release) kept serving its historical reviews and counting them in `average_rating`/`review_count`, even though the movie detail page no longer shows anything else about the release.
- `POST` review is now rejected with `MOVIE_NOT_RELEASED` (400) while a movie is `em_breve`, `GET` reviews/`my_review` return empty for such movies, and the aggregate queryset excludes `em_breve` reviews from `average_rating`/`review_count`.
- The frontend no longer renders `MovieReviewsPanel` on the detail page while `movie.status === "em_breve"`.
