### PR TITLE
fix: TMDB trailer auto-fill and ticket card flip accessibility

### DIFF
--- a/frontend/src/app/api/tmdb/movie/[id]/route.ts
+++ b/frontend/src/app/api/tmdb/movie/[id]/route.ts
@@ -27,29 +27,39 @@ export async function GET(
     fetch(`${base}/movie/${id}?language=pt-BR`, opts),
     ...TRANSLATION_LOCALES.map((l) => fetch(`${base}/movie/${id}?language=${l}`, opts)),
     fetch(`${base}/movie/${id}/credits?language=en-US`, opts),
+    fetch(`${base}/movie/${id}/videos?language=pt-BR`, opts),
+    fetch(`${base}/movie/${id}/videos?language=en-US`, opts),
   ]);
 
   if (!ptRes.ok) {
     return NextResponse.json({ error: "Movie not found" }, { status: ptRes.status });
   }
 
-  const creditsRes = rest[rest.length - 1];
-  const localeReses = rest.slice(0, -1);
+  const videosEnRes = rest[rest.length - 1];
+  const videosPtRes = rest[rest.length - 2];
+  const creditsRes = rest[rest.length - 3];
+  const localeReses = rest.slice(0, -3);
 
-  const [pt, ...localeAndCreditsData] = await Promise.all([
+  const [pt, ...localeAndRestData] = await Promise.all([
     ptRes.json(),
     ...localeReses.map((r) => (r.ok ? r.json() : Promise.resolve(null))),
     creditsRes.ok ? creditsRes.json() : Promise.resolve({ crew: [], cast: [] }),
+    videosPtRes.ok ? videosPtRes.json() : Promise.resolve({ results: [] }),
+    videosEnRes.ok ? videosEnRes.json() : Promise.resolve({ results: [] }),
   ]);
 
-  const creditsData = localeAndCreditsData[localeAndCreditsData.length - 1];
-  const localeData = localeAndCreditsData.slice(0, -1);
+  const videosEnData = localeAndRestData[localeAndRestData.length - 1];
+  const videosPtData = localeAndRestData[localeAndRestData.length - 2];
+  const creditsData = localeAndRestData[localeAndRestData.length - 3];
+  const localeData = localeAndRestData.slice(0, -3);
 
   const director: string =
     creditsData.crew?.find((c: { job: string; name: string }) => c.job === "Director")?.name ?? "";
 
   const cast: string[] =
     (creditsData.cast ?? []).slice(0, 10).map((c: { name: string }) => c.name);
+
+  const trailerUrl = pickTrailerUrl(videosPtData.results, videosEnData.results);
 
   const translations: Record<string, { title: string; synopsis: string }> = {};
   for (let i = 0; i < TRANSLATION_LOCALES.length; i++) {
@@ -71,5 +81,31 @@ export async function GET(
     release_date: pt.release_date ?? "",
     director,
     cast,
+    trailer_url: trailerUrl,
   });
+}
+
+type TmdbVideo = {
+  key: string;
+  site: string;
+  type: string;
+  official: boolean;
+  published_at: string;
+};
+
+function pickTrailerUrl(...videoLists: TmdbVideo[][]): string | null {
+  for (const videos of videoLists) {
+    const youtubeTrailers = (videos ?? []).filter(
+      (v) => v.site === "YouTube" && v.type === "Trailer"
+    );
+    if (youtubeTrailers.length === 0) continue;
+
+    const best = [...youtubeTrailers].sort((a, b) => {
+      if (a.official !== b.official) return a.official ? -1 : 1;
+      return (b.published_at ?? "").localeCompare(a.published_at ?? "");
+    })[0];
+
+    return `https://www.youtube.com/watch?v=${best.key}`;
+  }
+  return null;
 }

--- a/frontend/src/components/admin/AdminMovieForm.tsx
+++ b/frontend/src/components/admin/AdminMovieForm.tsx
@@ -498,6 +498,9 @@ export function AdminMovieForm({ movie }: AdminMovieFormProps) {
       if (data.cast?.length > 0) {
         setCastMembers(data.cast);
       }
+      if (data.trailer_url) {
+        setTrailerUrl(data.trailer_url);
+      }
 
       setTmdbFilled(true);
     } catch {

--- a/frontend/src/components/tickets/TicketCard.tsx
+++ b/frontend/src/components/tickets/TicketCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 
 import QRCode from "react-qr-code";
 
@@ -63,9 +63,24 @@ export function TicketCard({ ticket }: TicketCardProps) {
     setIsFlipped((current) => !current);
   }
 
+  function handleFlipKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      toggleFlip();
+    }
+  }
+
   return (
     <div className="ticket-card grid gap-2.5">
-      <div className="[perspective:1600px] rounded-card">
+      <div
+        aria-label={isFlipped ? t("tickets.flipToFront") : t("tickets.flipToBack")}
+        aria-pressed={isFlipped}
+        className="cursor-pointer rounded-card [perspective:1600px] focus-visible:outline-none focus-visible:shadow-focus"
+        onClick={toggleFlip}
+        onKeyDown={handleFlipKeyDown}
+        role="button"
+        tabIndex={0}
+      >
         <div
           className={cn(
             "relative h-[212px] w-full transition-transform duration-500 [transform-style:preserve-3d] [-webkit-transform-style:preserve-3d] motion-reduce:transition-none",
@@ -208,17 +223,11 @@ export function TicketCard({ ticket }: TicketCardProps) {
 
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         <button
-          aria-pressed={isFlipped}
-          className="inline-flex items-center gap-1.5 rounded-control text-sm font-extrabold text-white/65 underline-offset-4 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:shadow-focus"
-          onClick={toggleFlip}
-          type="button"
-        >
-          <FlipIcon className="h-4 w-4" />
-          {isFlipped ? t("tickets.flipToFront") : t("tickets.flipToBack")}
-        </button>
-        <button
           className="rounded-control text-sm font-extrabold text-accent underline-offset-4 transition hover:underline focus-visible:outline-none focus-visible:shadow-focus"
-          onClick={() => setIsCodeDialogOpen(true)}
+          onClick={(event) => {
+            event.stopPropagation();
+            setIsCodeDialogOpen(true);
+          }}
           type="button"
         >
           {t("tickets.qrLinkLabel")}
@@ -261,26 +270,6 @@ function FilmStrip() {
       aria-hidden="true"
       className="h-3 w-24 rounded-[2px] border border-white/15 bg-[repeating-linear-gradient(90deg,transparent_0_5px,rgb(255_255_255_/_22%)_5px_9px)]"
     />
-  );
-}
-
-function FlipIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      aria-hidden="true"
-      className={className}
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.6"
-      viewBox="0 0 24 24"
-    >
-      <path d="M21 8a9 9 0 0 0-15-3.5L3 7" />
-      <path d="M3 3v4h4" />
-      <path d="M3 16a9 9 0 0 0 15 3.5L21 17" />
-      <path d="M21 21v-4h-4" />
-    </svg>
   );
 }
 

--- a/frontend/src/components/tickets/my-tickets.test.ts
+++ b/frontend/src/components/tickets/my-tickets.test.ts
@@ -136,9 +136,9 @@ test("ticket card renders a flip card with details, badges, and a real QR code",
   // Format badges surfaced from the session projection/audio formats.
   assert.match(html, /3D/);
   assert.match(html, /Legendado/);
-  // Flip affordance is a dedicated, labelled toggle button — not a giant
-  // role="button" wrapping the heading and code.
-  assert.doesNotMatch(html, /role="button"/);
+  // The whole card is the flip affordance (click/tap/keyboard), labelled via
+  // aria-label so screen readers announce the toggle, not the nested heading/code.
+  assert.match(html, /role="button"/);
   assert.match(html, /aria-pressed="false"/);
   assert.match(html, /Ver detalhes do ingresso/);
   // A real (SVG) QR code replaces the old deterministic bars.


### PR DESCRIPTION
## What was done

- **TMDB trailer auto-fill**: the `/api/tmdb/movie/[id]` import route now also fetches TMDB videos (pt-BR and en-US) and picks the best official YouTube trailer; the admin movie form auto-fills the `trailerUrl` field from that response instead of leaving it empty on import.
- **Ticket card flip accessibility**: the flip-to-see-details affordance was a small underlined text button below the card. The whole card is now the toggle — clickable, tappable, and operable via Enter/Space when focused — with `aria-label`/`aria-pressed` so screen readers announce the action. Removed the now-redundant `FlipIcon` button; the QR-code link button stops event propagation so it no longer also flips the card.

## Test plan
- [x] `npm test` (frontend) — ticket card flip test updated and passing
- [x] `npx eslint` on all changed files — clean
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in `session-selection.test.ts`/`ui-primitives.test.ts` untouched by this change)