### PR TITLE
fix: humanize chatbot replies and recover leaked pseudo tool-call syntax

### DIFF
--- a/backend/chatbot/service.py
+++ b/backend/chatbot/service.py
@@ -1,9 +1,105 @@
+import json
+import re
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from django.utils import timezone as django_timezone
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from chatbot.agent import SYSTEM_PROMPT, build_tools, get_llm
 from chatbot.models import ChatConversation
 
 MAX_HISTORY_MESSAGES = 20
+
+# Sessions are stored/queried in UTC (settings.TIME_ZONE) but shown to the user in the
+# cinema's local timezone, matching the frontend's own display convention (see
+# `sessionTimeZone` in frontend/src/components/movies/session-selection.ts).
+DISPLAY_TIMEZONE = ZoneInfo("America/Fortaleza")
+
+_SESSION_ID_SUFFIX_PATTERN = re.compile(r"\s*\(id: [0-9a-fA-F-]{36}\)")
+_ISO_DATETIME_PATTERN = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:\d{2}|Z)?"
+)
+_ISO_DATE_PATTERN = re.compile(r"(?<!\d)\d{4}-\d{2}-\d{2}(?!\d)")
+
+# Some Groq-hosted Llama models occasionally fall back to Llama 3.1's native
+# text-based tool-call syntax (``<function=name>{...}</function>``) instead of
+# using the structured ``tool_calls`` channel `bind_tools` expects — this
+# recovers the intended call so a model hiccup doesn't leak raw syntax to the
+# user or, worse, poison future turns once it's echoed back as conversation
+# history.
+_TEXTUAL_FUNCTION_CALL_PATTERN = re.compile(
+    r"<function=(?P<name>[a-zA-Z_][a-zA-Z0-9_]*)>(?P<args>\{.*?\})</function>",
+    re.DOTALL,
+)
+# Looser detector used only to recognize a *failed* attempt (e.g. truncated/invalid
+# JSON that the stricter pattern above won't match) so it still gets replaced with a
+# generic reply instead of leaking the opening tag verbatim.
+_TEXTUAL_FUNCTION_CALL_ATTEMPT_PATTERN = re.compile(r"<function=[a-zA-Z_][a-zA-Z0-9_]*>")
+_FALLBACK_ERROR_REPLY = "Desculpe, não consegui processar sua solicitação. Pode tentar novamente?"
+
+_MONTHS_PT = [
+    "janeiro",
+    "fevereiro",
+    "março",
+    "abril",
+    "maio",
+    "junho",
+    "julho",
+    "agosto",
+    "setembro",
+    "outubro",
+    "novembro",
+    "dezembro",
+]
+
+
+def _relative_day_label(local_date):
+    today = django_timezone.localtime(django_timezone.now(), DISPLAY_TIMEZONE).date()
+    if local_date == today:
+        return "hoje"
+    if local_date == today + timedelta(days=1):
+        return "amanhã"
+    return f"{local_date.day} de {_MONTHS_PT[local_date.month - 1]}"
+
+
+def _format_datetime_for_user(match):
+    parsed = datetime.fromisoformat(match.group())
+    if django_timezone.is_naive(parsed):
+        parsed = django_timezone.make_aware(parsed, ZoneInfo("UTC"))
+    local = parsed.astimezone(DISPLAY_TIMEZONE)
+    time_label = f"{local.hour}h" if local.minute == 0 else f"{local.hour}h{local.minute:02d}"
+    return f"{_relative_day_label(local.date())} às {time_label}"
+
+
+def _format_date_for_user(match):
+    return _relative_day_label(date.fromisoformat(match.group()))
+
+
+def _humanize_reply_for_user(text):
+    """Reformat a deterministic reply for display: natural pt-BR dates/times, no raw
+    technical identifiers.
+
+    The exact ID-bearing, ISO-dated text is still what's persisted to conversation
+    history in ``handle_message`` so the model can resolve a same-conversation
+    follow-up like "ainda tem assento?" against the right session — only what's shown
+    to the human is cleaned up here.
+    """
+    text = _SESSION_ID_SUFFIX_PATTERN.sub("", text)
+    text = _ISO_DATETIME_PATTERN.sub(_format_datetime_for_user, text)
+    text = _ISO_DATE_PATTERN.sub(_format_date_for_user, text)
+    return text
+
+
+def _parse_textual_function_call(content):
+    match = _TEXTUAL_FUNCTION_CALL_PATTERN.search(content or "")
+    if not match:
+        return None
+    try:
+        args = json.loads(match.group("args"))
+    except json.JSONDecodeError:
+        return None
+    return {"name": match.group("name"), "args": args}
 
 
 def _messages_from_history(history):
@@ -29,6 +125,8 @@ def _compose_reply(tool_name, result):
     Kept separate from the LLM so the user-facing wording for correctness-critical answers
     (availability, slot questions, ticket scoping) never depends on the model paraphrasing
     data correctly — the model only decides *which* tool to call and with *what* arguments.
+    The raw dates/ids this returns are still meant for machine/history consumption; display
+    formatting happens afterward in ``_humanize_reply_for_user``.
     """
     if not isinstance(result, dict):
         result = {"items": result}
@@ -55,20 +153,20 @@ def _compose_reply(tool_name, result):
         if not items:
             return "No momento não há filmes em cartaz ou em pré-venda.", None
         titles = "\n".join(f"- {movie['title']}" for movie in items)
-        return f"Filmes disponíveis:\n{titles}", None
+        return f"Claro! Aqui estão os filmes em cartaz agora:\n{titles}", None
 
     if tool_name == "list_sessions_for_movie":
         sessions = result.get("sessions", [])
         if not sessions:
             return (
-                f'Não encontrei sessões de "{result["movie_title"]}" em {result["date"]}.',
+                f'Não encontrei sessões de "{result["movie_title"]}" para {result["date"]}.',
                 None,
             )
         lines = "\n".join(
-            f"- {s['room']} às {s['start_time']} (id: {s['id']})" for s in sessions
+            f"- {s['room']}: {s['start_time']} (id: {s['id']})" for s in sessions
         )
         return (
-            f'Sessões de "{result["movie_title"]}" em {result["date"]}:\n{lines}',
+            f'Encontrei estas sessões de "{result["movie_title"]}" para {result["date"]}:\n{lines}',
             None,
         )
 
@@ -83,7 +181,7 @@ def _compose_reply(tool_name, result):
             }
             reply = (
                 f"Sim! Ainda há {result['available_seats']} assento(s) disponível(is) para essa "
-                "sessão. Quer ir para o mapa de assentos para continuar a compra?"
+                "sessão. Quer que eu te leve para o mapa de assentos para continuar a compra?"
             )
             return reply, action
         return "Infelizmente essa sessão está esgotada.", None
@@ -93,16 +191,16 @@ def _compose_reply(tool_name, result):
         if not items:
             return "Você ainda não possui ingressos.", None
         lines = "\n".join(
-            f"- {t['movie']['title']} em {t['session']['start_time']} (assento {t['seat']['identifier']})"
+            f"- {t['movie']['title']}, {t['session']['start_time']} (assento {t['seat']['identifier']})"
             for t in items
         )
-        return f"Seus ingressos:\n{lines}", None
+        return f"Aqui estão seus ingressos:\n{lines}", None
 
     if tool_name == "next_session_for_user":
         if result.get("has_upcoming") is False:
             return "Você não tem nenhuma sessão futura agendada.", None
         return (
-            f'Sua próxima sessão é "{result["movie"]["title"]}" em {result["session"]["start_time"]}.',
+            f'Sua próxima sessão é "{result["movie"]["title"]}", {result["session"]["start_time"]}.',
             None,
         )
 
@@ -131,12 +229,23 @@ def handle_message(*, user, conversation_id, message):
     action = None
 
     tool_calls = getattr(ai_message, "tool_calls", None) or []
+    if not tool_calls:
+        fallback_call = _parse_textual_function_call(reply_text)
+        if fallback_call is not None:
+            tool_calls = [fallback_call]
+        elif _TEXTUAL_FUNCTION_CALL_ATTEMPT_PATTERN.search(reply_text):
+            # The model attempted a call but we couldn't recover valid JSON args —
+            # never leak the raw pseudo-syntax to the user.
+            reply_text = _FALLBACK_ERROR_REPLY
+
     if tool_calls:
         call = tool_calls[0]
         selected_tool = _tool_by_name(tools, call["name"])
         if selected_tool is not None:
             result = selected_tool.invoke(call["args"])
             reply_text, action = _compose_reply(call["name"], result)
+        else:
+            reply_text = _FALLBACK_ERROR_REPLY
 
     conversation.messages = history + [
         {"role": "human", "content": message},
@@ -144,4 +253,4 @@ def handle_message(*, user, conversation_id, message):
     ]
     conversation.save(update_fields=["messages", "updated_at"])
 
-    return {"reply": reply_text, "action": action}
+    return {"reply": _humanize_reply_for_user(reply_text), "action": action}

--- a/backend/tests/integration/test_chatbot_conversation.py
+++ b/backend/tests/integration/test_chatbot_conversation.py
@@ -122,7 +122,14 @@ def test_multi_turn_slot_filling_resolves_pending_date(monkeypatch):
     )
 
     assert movie.title in second_result["reply"]
-    assert str(session.id) in second_result["reply"]
+    # The raw session id must not leak into what the human sees...
+    assert str(session.id) not in second_result["reply"]
+
+    # ...but it must still be in the persisted history, since that's what lets the model
+    # resolve a same-conversation follow-up like "ainda tem assento?" against the right
+    # session on a later turn.
+    conversation.refresh_from_db()
+    assert str(session.id) in conversation.messages[-1]["content"]
 
     # The second LLM call must have received the persisted history from the first turn —
     # this is what lets a bare date answer resolve the pending "which date?" question
@@ -192,3 +199,59 @@ def test_check_session_availability_includes_redirect_action_when_available(
         "target": "seatmap",
         "session_id": str(session.id),
     }
+
+
+@pytest.mark.django_db
+def test_textual_function_call_fallback_is_executed_like_a_real_tool_call(monkeypatch):
+    """Some Groq-hosted Llama models occasionally emit their native pseudo-XML
+    tool-call syntax as plain text instead of using the structured tool_calls
+    channel. The reply must still resolve to a real answer, not leak that raw
+    syntax to the user (see live report against issue #261/#263)."""
+    user = _make_user()
+    movie, room, session = _make_movie_with_session()
+
+    fake_llm = _FakeLLM(
+        [
+            AIMessage(
+                content=(
+                    "Vou verificar novamente.\n"
+                    '<function=list_sessions_for_movie>{"movie_title": "'
+                    + movie.title
+                    + '", "date": "'
+                    + session.start_time.date().isoformat()
+                    + '"}</function>'
+                ),
+                tool_calls=[],
+            )
+        ]
+    )
+    monkeypatch.setattr("chatbot.service.get_llm", lambda: fake_llm)
+
+    result = handle_message(
+        user=user, conversation_id="conv-fallback", message="Quais sessões tem?"
+    )
+
+    assert "<function=" not in result["reply"]
+    assert movie.title in result["reply"]
+
+
+@pytest.mark.django_db
+def test_unparseable_textual_function_call_falls_back_to_a_generic_reply(monkeypatch):
+    user = _make_user()
+
+    fake_llm = _FakeLLM(
+        [
+            AIMessage(
+                content="Vou verificar.\n<function=list_sessions_for_movie>{not valid json</function>",
+                tool_calls=[],
+            )
+        ]
+    )
+    monkeypatch.setattr("chatbot.service.get_llm", lambda: fake_llm)
+
+    result = handle_message(
+        user=user, conversation_id="conv-fallback-bad", message="Quais sessões tem?"
+    )
+
+    assert "<function=" not in result["reply"]
+    assert result["reply"] == "Desculpe, não consegui processar sua solicitação. Pode tentar novamente?"

--- a/backend/tests/integration/test_chatbot_reply_formatting.py
+++ b/backend/tests/integration/test_chatbot_reply_formatting.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+from django.utils import timezone
+
+from chatbot.service import DISPLAY_TIMEZONE, _humanize_reply_for_user
+
+
+def test_humanize_reply_strips_raw_session_id():
+    text = "- Sala 2: 2026-07-13T19:00:00+00:00 (id: d8300b56-bf81-4872-9268-2aca890ec098)"
+    result = _humanize_reply_for_user(text)
+
+    assert "d8300b56-bf81-4872-9268-2aca890ec098" not in result
+    assert "(id:" not in result
+
+
+def test_humanize_reply_labels_todays_session_as_hoje():
+    now_local = timezone.localtime(timezone.now(), DISPLAY_TIMEZONE)
+    today_at_seven_pm = now_local.replace(
+        hour=19, minute=0, second=0, microsecond=0
+    ).astimezone(ZoneInfo("UTC"))
+
+    text = f"- Sala 2: {today_at_seven_pm.isoformat()} (id: d8300b56-bf81-4872-9268-2aca890ec098)"
+    result = _humanize_reply_for_user(text)
+
+    assert "hoje às 19h" in result
+    assert "2026" not in result
+
+
+def test_humanize_reply_labels_tomorrows_session_as_amanha():
+    now_local = timezone.localtime(timezone.now(), DISPLAY_TIMEZONE)
+    tomorrow_at_nine_thirty = (now_local + timedelta(days=1)).replace(
+        hour=9, minute=30, second=0, microsecond=0
+    ).astimezone(ZoneInfo("UTC"))
+
+    text = f"Sua próxima sessão é \"Matrix\", {tomorrow_at_nine_thirty.isoformat()}."
+    result = _humanize_reply_for_user(text)
+
+    assert "amanhã às 9h30" in result
+
+
+def test_humanize_reply_spells_out_a_far_future_date():
+    now_local = timezone.localtime(timezone.now(), DISPLAY_TIMEZONE)
+    far_future = (now_local + timedelta(days=30)).date()
+
+    text = f'Encontrei estas sessões de "Matrix" para {far_future.isoformat()}:\n- Sala 1'
+    result = _humanize_reply_for_user(text)
+
+    assert far_future.isoformat() not in result
+    assert "de" in result
+
+
+def test_humanize_reply_leaves_plain_text_untouched():
+    text = "Você ainda não possui ingressos."
+    assert _humanize_reply_for_user(text) == text


### PR DESCRIPTION
## Objective

Fix chatbot reply quality issues found during live testing of the #263 frontend widget against #261's backend: raw ISO dates/datetimes and a technical session UUID leaking into the bot's prose, and — more seriously — the model occasionally emitting Llama's native `<function=name>{...}</function>` text syntax instead of a structured tool call, which then got echoed back into conversation history and caused the conversation to spiral into repeated garbled replies.

## What was done

### 1. Humanized reply formatting

`chatbot/service.py::_humanize_reply_for_user` reformats the deterministic reply text before it's returned to the client:

- ISO datetimes/dates are converted to natural pt-BR phrasing in the cinema's local timezone (`America/Fortaleza`, matching the frontend's own `sessionTimeZone`) — "hoje às 19h", "amanhã às 9h30", "13 de julho" — instead of raw `2026-07-13T19:00:00+00:00`.
- The raw session UUID is stripped from the text entirely.

Critically, this only changes what the **human** sees. The exact ID-bearing, ISO-dated text is still what gets persisted to `ChatConversation.messages`, since that's what lets the model resolve a same-conversation follow-up ("ainda tem assento?") against the right session on a later turn — verified live end-to-end (see "How to test").

### 2. Recover leaked textual tool-call syntax

Some Groq-hosted Llama models occasionally fall back to Llama 3.1's native text-based tool-call format (`<function=name>{...}</function>`) instead of using the structured `tool_calls` channel `bind_tools` expects. When that happened, the raw syntax leaked straight into the user-visible reply, and — because it also got saved into conversation history — the model kept seeing its own garbled output on every subsequent turn and never recovered (reproduced live: the same broken pattern repeated three times in a row for one conversation).

`handle_message` now:
- recovers a well-formed textual call (parses `name` + JSON `args`) and executes it exactly like a normal tool call, so the reply is the same clean, deterministic text a proper `tool_calls` response would have produced;
- falls back to a generic "não consegui processar sua solicitação" reply for anything unrecoverable (truncated/invalid JSON, unknown tool name) — never leaks raw syntax to the user.

### 3. Minor tone pass

Touched up a few of the coldest deterministic templates (`_compose_reply`) to read a bit warmer — e.g. "Aqui estão os filmes em cartaz agora" instead of a bare "Filmes disponíveis:" — without weakening the existing design principle that correctness-critical wording is composed deterministically, never freely authored by the model.

## How to test

### Automated validation

```bash
docker compose exec backend pytest tests/integration/test_chatbot_conversation.py tests/integration/test_chatbot_api.py tests/integration/test_chatbot_tools.py tests/integration/test_chatbot_reply_formatting.py -q
docker compose exec backend pytest -q
```

### Manual validation

Reproduced the exact reported conversation against the real Groq-backed endpoint:

```bash
TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/auth/login/ -H "Content-Type: application/json" \
  -d '{"email":"<user>","password":"<pass>"}' | python3 -c "import sys,json;print(json.load(sys.stdin)['access'])")

curl -s -X POST http://localhost:8000/api/v1/chatbot/message/ \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d '{"conversation_id": "verify-1", "message": "existe sessoes disponiveis para a viagem de chihiro?"}'
# -> asks for a date, no raw syntax

curl -s -X POST http://localhost:8000/api/v1/chatbot/message/ \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d '{"conversation_id": "verify-1", "message": "2026-07-13"}'
# -> "Encontrei estas sessões de \"A Viagem de Chihiro\" para amanhã:\n- Sala 2: amanhã às 16h"

curl -s -X POST http://localhost:8000/api/v1/chatbot/message/ \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d '{"conversation_id": "verify-1", "message": "ainda tem assento disponivel?"}'
# -> "Sim! Ainda há 142 assento(s) disponível(is)..." + a redirect action with the correct session_id
```

Confirms: no raw dates/IDs/pseudo-syntax in any reply, and the multi-turn follow-up still resolves against the correct session from history.

## Expected Result

- Chatbot replies read as natural pt-BR text with no raw ISO dates or technical IDs.
- A model tool-calling hiccup degrades gracefully (recovered or replaced with a generic message) instead of corrupting the rest of the conversation.
- Same-conversation follow-ups (date slot-filling, availability checks) keep working exactly as before.
- Full backend test suite (456 tests) passes.

Related to #261 and the live-testing feedback from #263.