### PR TITLE
fix: auto-delete ended sessions and fix catalog pagination

### DIFF
--- a/backend/catalog/management/commands/schedule_session_cleanup.py
+++ b/backend/catalog/management/commands/schedule_session_cleanup.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+
+from catalog.models import Session
+from catalog.tasks import delete_ended_session
+
+
+class Command(BaseCommand):
+    help = (
+        "One-time backfill that arms auto-deletion for sessions created before "
+        "this feature existed. New sessions are scheduled automatically on save(); "
+        "run this once after deploying to cover existing rows."
+    )
+
+    def handle(self, *args, **options):
+        session_ids = list(Session.objects.values_list("id", flat=True))
+
+        for session_id in session_ids:
+            delete_ended_session.apply_async(args=[str(session_id)])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Scheduled auto-deletion check for {len(session_ids)} session(s)."
+            )
+        )

--- a/backend/catalog/models.py
+++ b/backend/catalog/models.py
@@ -1,5 +1,6 @@
 import uuid
 from decimal import Decimal
+from functools import partial
 
 from django.conf import settings
 from django.contrib.postgres.constraints import ExclusionConstraint
@@ -7,8 +8,14 @@ from django.contrib.postgres.fields import DateTimeRangeField, RangeOperators
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MinValueValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models import F, Func
+
+
+def _schedule_session_deletion(session_id, end_time):
+    from catalog.tasks import delete_ended_session
+
+    delete_ended_session.apply_async(args=[str(session_id)], eta=end_time)
 
 
 class MovieStatus(models.TextChoices):
@@ -333,7 +340,16 @@ class Session(models.Model):
 
     def save(self, *args, **kwargs):
         self.full_clean()
+        end_time_changed = self._state.adding or (
+            Session.objects.filter(pk=self.pk)
+            .exclude(end_time=self.end_time)
+            .exists()
+        )
         super().save(*args, **kwargs)
+        if end_time_changed:
+            transaction.on_commit(
+                partial(_schedule_session_deletion, self.pk, self.end_time)
+            )
 
 
 class CastMember(models.Model):

--- a/backend/catalog/tasks.py
+++ b/backend/catalog/tasks.py
@@ -1,0 +1,52 @@
+import logging
+
+from celery import shared_task
+from django.db import transaction
+from django.utils import timezone
+
+from catalog.models import Session
+from reservations.models import SessionSeat, Ticket
+from reservations.services import detach_tickets
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_jitter=True,
+    max_retries=5,
+    default_retry_delay=30,
+)
+def delete_ended_session(self, session_id: str) -> None:
+    from catalog.views import invalidate_session_list_cache
+
+    with transaction.atomic():
+        try:
+            session = Session.objects.select_for_update().get(id=session_id)
+        except Session.DoesNotExist:
+            return
+
+        if session.end_time > timezone.now():
+            # end_time was pushed back after this task was scheduled; re-arm
+            # for the new end_time instead of deleting a still-running session.
+            transaction.on_commit(
+                lambda: delete_ended_session.apply_async(
+                    args=[session_id], eta=session.end_time
+                )
+            )
+            return
+
+        list(
+            SessionSeat.objects.select_for_update(of=("self",))
+            .filter(session_id=session.id)
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+
+        detach_tickets(Ticket.objects.filter(session_seat__session=session))
+        session.delete()
+
+    invalidate_session_list_cache()
+    logger.info("Session auto-deleted after ending | session_id=%s", session_id)

--- a/backend/tests/integration/test_session_auto_deletion.py
+++ b/backend/tests/integration/test_session_auto_deletion.py
@@ -1,0 +1,152 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from catalog.models import Movie, Room, Session
+from catalog.tasks import delete_ended_session
+from reservations.models import Seat, SeatRow, SessionSeat, SessionSeatStatus, Ticket
+
+
+@pytest.fixture
+def room(db):
+    return Room.objects.create(name="Room Auto Deletion", capacity=100)
+
+
+@pytest.fixture
+def movie(db):
+    return Movie.objects.create(
+        title="Auto Deletion Movie",
+        synopsis="Synopsis",
+        duration_minutes=120,
+        release_date="2026-03-21",
+        poster_url="https://example.com/poster.jpg",
+    )
+
+
+@pytest.mark.django_db
+def test_creating_session_schedules_deletion_task_at_end_time(
+    room, movie, django_capture_on_commit_callbacks
+):
+    end_time = timezone.now() + timedelta(hours=3)
+
+    with patch("catalog.tasks.delete_ended_session.apply_async") as mocked_apply_async:
+        with django_capture_on_commit_callbacks(execute=True):
+            session = Session.objects.create(
+                movie=movie,
+                room=room,
+                start_time=timezone.now() + timedelta(hours=1),
+                end_time=end_time,
+                base_price="30.00",
+            )
+
+    mocked_apply_async.assert_called_once()
+    call_kwargs = mocked_apply_async.call_args.kwargs
+    assert call_kwargs["args"] == [str(session.id)]
+    assert call_kwargs["eta"] == end_time
+
+
+@pytest.mark.django_db
+def test_updating_session_end_time_reschedules_deletion_task(
+    room, movie, django_capture_on_commit_callbacks
+):
+    with django_capture_on_commit_callbacks(execute=True):
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=3),
+            base_price="30.00",
+        )
+
+    new_end_time = timezone.now() + timedelta(hours=5)
+
+    with patch("catalog.tasks.delete_ended_session.apply_async") as mocked_apply_async:
+        with django_capture_on_commit_callbacks(execute=True):
+            session.end_time = new_end_time
+            session.save()
+
+    mocked_apply_async.assert_called_once()
+    call_kwargs = mocked_apply_async.call_args.kwargs
+    assert call_kwargs["args"] == [str(session.id)]
+    assert call_kwargs["eta"] == new_end_time
+
+
+@pytest.mark.django_db
+def test_delete_ended_session_task_deletes_session_and_detaches_tickets(room, movie):
+    with patch("catalog.tasks.delete_ended_session.apply_async"):
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=timezone.now() - timedelta(hours=3),
+            end_time=timezone.now() - timedelta(hours=1),
+            base_price="30.00",
+        )
+
+    seat_row = SeatRow.objects.create(room=room, name="A")
+    seat = Seat.objects.create(row=seat_row, number=1)
+    session_seat = SessionSeat.objects.create(
+        session=session,
+        seat=seat,
+        status=SessionSeatStatus.PURCHASED,
+    )
+    user = get_user_model().objects.create_user(
+        email="auto-delete-ticket@example.com",
+        username="autodeleteticket",
+        password="StrongPass123!",
+    )
+    ticket = Ticket.objects.create(
+        user=user,
+        session_seat=session_seat,
+        ticket_type="inteira",
+        amount_paid="30.00",
+        payment_method="pix",
+    )
+
+    delete_ended_session(str(session.id))
+
+    assert not Session.objects.filter(id=session.id).exists()
+    ticket.refresh_from_db()
+    assert ticket.session_seat_id is None
+    assert ticket.session_snapshot["session"]["id"] == str(session.id)
+
+
+@pytest.mark.django_db
+def test_delete_ended_session_task_reschedules_when_session_still_running(
+    room, movie, django_capture_on_commit_callbacks
+):
+    end_time = timezone.now() + timedelta(hours=3)
+
+    with patch("catalog.tasks.delete_ended_session.apply_async"):
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=end_time,
+            base_price="30.00",
+        )
+
+    with patch("catalog.tasks.delete_ended_session.apply_async") as mocked_apply_async:
+        with django_capture_on_commit_callbacks(execute=True):
+            delete_ended_session(str(session.id))
+
+    assert Session.objects.filter(id=session.id).exists()
+    mocked_apply_async.assert_called_once_with(args=[str(session.id)], eta=end_time)
+
+
+@pytest.mark.django_db
+def test_delete_ended_session_task_is_noop_when_session_already_gone(room, movie):
+    with patch("catalog.tasks.delete_ended_session.apply_async"):
+        session = Session.objects.create(
+            movie=movie,
+            room=room,
+            start_time=timezone.now() - timedelta(hours=3),
+            end_time=timezone.now() - timedelta(hours=1),
+            base_price="30.00",
+        )
+    session_id = str(session.id)
+    session.delete()
+
+    delete_ended_session(session_id)

--- a/frontend/src/api/catalog.ts
+++ b/frontend/src/api/catalog.ts
@@ -56,19 +56,19 @@ export const catalogApi = {
   },
 
   listFeaturedMovies() {
-    return listMovies({ is_featured: true });
+    return listAllMovies({ is_featured: true });
   },
 
   listNowShowingMovies() {
-    return listMovies({ status: "em_cartaz" });
+    return listAllMovies({ status: "em_cartaz" });
   },
 
   listPreSaleMovies() {
-    return listMovies({ status: "pre_venda" });
+    return listAllMovies({ status: "pre_venda" });
   },
 
   listUpcomingMovies() {
-    return listMovies({ status: "em_breve" });
+    return listAllMovies({ status: "em_breve" });
   },
 };
 
@@ -113,6 +113,25 @@ async function listMovies(params: ListMoviesParams) {
   }
 
   return response satisfies PaginatedResponse<CatalogMovie>;
+}
+
+// Home catalog sections need every movie matching a filter, not just one
+// page — the API paginates at PAGE_SIZE=10, which used to silently drop
+// movies past the first page (e.g. "em cartaz" with more than 10 titles).
+async function listAllMovies(
+  params: ListMoviesParams
+): Promise<PaginatedResponse<CatalogMovie>> {
+  let response = await listMovies(params);
+  const results = [...response.results];
+  let page = 2;
+
+  while (response.next) {
+    response = await listMovies({ ...params, page });
+    results.push(...response.results);
+    page += 1;
+  }
+
+  return { ...response, next: null, results };
 }
 
 async function getSessions(params: GetSessionsParams) {


### PR DESCRIPTION
## What was done

- **Auto-delete sessions after they end**: `Session.save()` now arms a self-rescheduling Celery task (no Beat needed) whenever `end_time` changes. When the task fires, it detaches tickets, deletes the session, and invalidates the session-list cache. Added a one-time `schedule_session_cleanup` management command to backfill auto-deletion for sessions created before this feature existed.
- **Fix catalog movie list dropping movies past page 1**: `listFeaturedMovies`, `listNowShowingMovies`, `listPreSaleMovies`, and `listUpcomingMovies` only fetched the first page of results (`PAGE_SIZE=10`), silently hiding movies beyond that on the home page. Added `listAllMovies()` in `frontend/src/api/catalog.ts`, which walks every page and merges the results before returning.

## Test plan

- [x] `backend/tests/integration/test_session_auto_deletion.py` covers scheduling/rescheduling/deletion behavior
- [x] Manually verify home catalog sections show more than 10 movies when more than one page exists